### PR TITLE
[Chore] change submodules to ssh access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "pytorch_blade/third_party/googletest"]
 	path = pytorch_blade/third_party/googletest
 	url = git@github.com:google/googletest.git
-[submodule "tao/third_party/json"]
-	path = tao/third_party/json
-	url = https://github.com/nlohmann/json.git
 [submodule "tf_community"]
 	path = tf_community
 	url = git@github.com:pai-disc/tensorflow.git
 [submodule "tao/third_party/abseil-cpp"]
 	path = tao/third_party/abseil-cpp
 	url = git@github.com:abseil/abseil-cpp.git
+[submodule "tao/third_party/json"]
+	path = tao/third_party/json
+	url = git@github.com:nlohmann/json.git


### PR DESCRIPTION
SSH access is perfered because:

- Using the key is more secure than using a password
- No repetitive authentication is required as with HTTPS
