### PR TITLE
[disc-cpu] [bugfix] fix a bug of cpu multi-thread task assigner

### DIFF
--- a/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_2d.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_2d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(%arg0: tensor<?x?xf32>) -> (tensor<?x?xf32>) attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Tanh"(%arg0) : (tensor<?x?xf32>) -> (tensor<?x?xf32>)
+      tf_executor.fetch %0 : tensor<?x?xf32>
+    }
+    return %graph : tensor<?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_3d.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_3d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(%arg0: tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>) attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Tanh"(%arg0) : (tensor<?x?x?xf32>) -> (tensor<?x?x?xf32>)
+      tf_executor.fetch %0 : tensor<?x?x?xf32>
+    }
+    return %graph : tensor<?x?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_4d.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/multi_threading_cpu_4d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(%arg0: tensor<?x?x?x?xf32>) -> (tensor<?x?x?x?xf32>) attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Tanh"(%arg0) : (tensor<?x?x?x?xf32>) -> (tensor<?x?x?x?xf32>)
+      tf_executor.fetch %0 : tensor<?x?x?x?xf32>
+    }
+    return %graph : tensor<?x?x?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/multi_threading_cpu.cc
+++ b/tao_compiler/mlir/disc/tests/regression/multi_threading_cpu.cc
@@ -1,0 +1,162 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/disc/tests/mlir_feature_test.h"
+#include "tensorflow/compiler/mlir/disc/tests/mlir_test.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace mlir_test {
+
+const std::string c_ft_path =
+    "tensorflow/compiler/mlir/disc/tests/regression/data/";
+
+static bool init_threads = []() {
+  setenv("OMP_NUM_THREADS", "3", 1);
+  return true;
+}();
+
+TEST(MultiThreadingTest, 2DTest0) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_2d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"50x1xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 2DTest1) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_2d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"20x300xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 2DTest2) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_2d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"60x100xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 3DTest1) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_3d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"5x1x1xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 3DTest2) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_3d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x1x2xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 3DTest3) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_3d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x1x50xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 3DTest4) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_3d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x3x50xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 4DTest1) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_4d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x2x2x2xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 4DTest2) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_4d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x1x1x1xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 4DTest3) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_4d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"2x1x1x100xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 4DTest4) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_4d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"5x2x1x100xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+TEST(MultiThreadingTest, 4DTest5) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "multi_threading_cpu_4d.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"1x2x1x100xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {}));
+}
+
+}  // namespace mlir_test


### PR DESCRIPTION
For a nested parallel for loop:
```
scf.parallel((iv1, iv2, ... ivn) in range(L1, L2, ... LN)) {
  ...
}
```
The task assigner partitions the loop as even as possible across M threads.

Original implementation fails to tackle the situations like following example.

Suppose we have parallel domain: (5, 1) and 3 threads.

Original partition plan:

thread 0:
  - task 0: (4:5, 0:1),

thread 1:
  - task 0: (3:4, 0:1)
  - task 1:  (4:5, 0:1)  # this is illegal

thread 2:
  - task 0: (2:3, 0:1)
  - task 1:  (4:5, 1:2) # this is illegal

This PR solve the above problem.