### PR TITLE
[disc-cpu] add a new schedule for concat op with many operands

### DIFF
--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -61,6 +61,7 @@ limitations under the License.
 #include "mlir/Transforms/Passes.h"
 #include "tensorflow/compiler/mlir/disc/disc_util.h"
 #include "tensorflow/compiler/mlir/disc/transforms/codegen_utils.h"
+#include "tensorflow/compiler/mlir/disc/transforms/fusion_utils.h"
 #include "tensorflow/compiler/mlir/disc/transforms/passes.h"
 #include "tensorflow/compiler/mlir/disc/transforms/placement_utils.h"
 #include "tensorflow/compiler/mlir/disc/transforms/rewriters.h"
@@ -273,6 +274,11 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   bool enable_stitch = !gpu_enabled;
   tensorflow::ReadBoolFromEnvVar("DISC_ENABLE_STITCH", !gpu_enabled,
                                  &enable_stitch);
+  if (!gpu_enabled) {
+    FusionOptions fusionOptions;
+    fusionOptions.max_num_arguments_per_kernel = 4096;
+    setGlobalFusionOptions(fusionOptions);
+  }
   pm.addNestedPass<FuncOp>(disc_ral::createDiscFusionPass(
       gpu_enabled, enable_stitch ? "stitch" : "base"));
   if (gpu_enabled) {

--- a/tao_compiler/mlir/disc/tests/regression/data/large_concat_cpu.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/large_concat_cpu.mlir
@@ -1,0 +1,61 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(
+	  %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>, %arg3: tensor<?x?xf32>,
+	  %arg4: tensor<?x?xf32>, %arg5: tensor<?x?xf32>, %arg6: tensor<?x?xf32>, %arg7: tensor<?x?xf32>,
+	  %arg8: tensor<?x?xf32>, %arg9: tensor<?x?xf32>, %arg10: tensor<?x?xf32>, %arg11: tensor<?x?xf32>,
+	  %arg12: tensor<?x?xf32>, %arg13: tensor<?x?xf32>, %arg14: tensor<?x?xf32>, %arg15: tensor<?x?xf32>,
+	  %arg16: tensor<?x?xf32>, %arg17: tensor<?x?xf32>, %arg18: tensor<?x?xf32>, %arg19: tensor<?x?xf32>,
+	  %arg20: tensor<?x?xf32>, %arg21: tensor<?x?xf32>, %arg22: tensor<?x?xf32>, %arg23: tensor<?x?xf32>,
+	  %arg24: tensor<?x?xf32>, %arg25: tensor<?x?xf32>, %arg26: tensor<?x?xf32>, %arg27: tensor<?x?xf32>,
+	  %arg28: tensor<?x?xf32>, %arg29: tensor<?x?xf32>, %arg30: tensor<?x?xf32>, %arg31: tensor<?x?xf32>,
+	  %arg32: tensor<?x?xf32>, %arg33: tensor<?x?xf32>, %arg34: tensor<?x?xf32>, %arg35: tensor<?x?xf32>,
+	  %arg36: tensor<?x?xf32>, %arg37: tensor<?x?xf32>, %arg38: tensor<?x?xf32>, %arg39: tensor<?x?xf32>,
+	  %arg40: tensor<?x?xf32>, %arg41: tensor<?x?xf32>, %arg42: tensor<?x?xf32>, %arg43: tensor<?x?xf32>,
+	  %arg44: tensor<?x?xf32>, %arg45: tensor<?x?xf32>, %arg46: tensor<?x?xf32>, %arg47: tensor<?x?xf32>,
+	  %arg48: tensor<?x?xf32>, %arg49: tensor<?x?xf32>, %arg50: tensor<?x?xf32>, %arg51: tensor<?x?xf32>,
+	  %arg52: tensor<?x?xf32>, %arg53: tensor<?x?xf32>, %arg54: tensor<?x?xf32>, %arg55: tensor<?x?xf32>,
+	  %arg56: tensor<?x?xf32>, %arg57: tensor<?x?xf32>, %arg58: tensor<?x?xf32>, %arg59: tensor<?x?xf32>,
+	  %arg60: tensor<?x?xf32>, %arg61: tensor<?x?xf32>, %arg62: tensor<?x?xf32>, %arg63: tensor<?x?xf32>
+	  ) -> tensor<?x?xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+      %2:2 = tf_executor.island wraps "tf.ConcatV2"(
+	      %arg0, %arg1, %arg2, %arg3,
+	      %arg4, %arg5, %arg6, %arg7,
+	      %arg8, %arg9, %arg10, %arg11,
+	      %arg12, %arg13, %arg14, %arg15,
+	      %arg16, %arg17, %arg18, %arg19,
+	      %arg20, %arg21, %arg22, %arg23,
+	      %arg24, %arg25, %arg26, %arg27,
+	      %arg28, %arg29, %arg30, %arg31,
+	      %arg32, %arg33, %arg34, %arg35,
+	      %arg36, %arg37, %arg38, %arg39,
+	      %arg40, %arg41, %arg42, %arg43,
+	      %arg44, %arg45, %arg46, %arg47,
+	      %arg48, %arg49, %arg50, %arg51,
+	      %arg52, %arg53, %arg54, %arg55,
+	      %arg56, %arg57, %arg58, %arg59,
+	      %arg60, %arg61, %arg62, %arg63,
+	      %0) : (
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<i32>) -> tensor<?x?xf32>
+      tf_executor.fetch %2 : tensor<?x?xf32>
+    }
+    return %graph : tensor<?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/data/large_concat_cpu_fused.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/large_concat_cpu_fused.mlir
@@ -1,0 +1,62 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(
+	  %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>, %arg3: tensor<?x?xf32>,
+	  %arg4: tensor<?x?xf32>, %arg5: tensor<?x?xf32>, %arg6: tensor<?x?xf32>, %arg7: tensor<?x?xf32>,
+	  %arg8: tensor<?x?xf32>, %arg9: tensor<?x?xf32>, %arg10: tensor<?x?xf32>, %arg11: tensor<?x?xf32>,
+	  %arg12: tensor<?x?xf32>, %arg13: tensor<?x?xf32>, %arg14: tensor<?x?xf32>, %arg15: tensor<?x?xf32>,
+	  %arg16: tensor<?x?xf32>, %arg17: tensor<?x?xf32>, %arg18: tensor<?x?xf32>, %arg19: tensor<?x?xf32>,
+	  %arg20: tensor<?x?xf32>, %arg21: tensor<?x?xf32>, %arg22: tensor<?x?xf32>, %arg23: tensor<?x?xf32>,
+	  %arg24: tensor<?x?xf32>, %arg25: tensor<?x?xf32>, %arg26: tensor<?x?xf32>, %arg27: tensor<?x?xf32>,
+	  %arg28: tensor<?x?xf32>, %arg29: tensor<?x?xf32>, %arg30: tensor<?x?xf32>, %arg31: tensor<?x?xf32>,
+	  %arg32: tensor<?x?xf32>, %arg33: tensor<?x?xf32>, %arg34: tensor<?x?xf32>, %arg35: tensor<?x?xf32>,
+	  %arg36: tensor<?x?xf32>, %arg37: tensor<?x?xf32>, %arg38: tensor<?x?xf32>, %arg39: tensor<?x?xf32>,
+	  %arg40: tensor<?x?xf32>, %arg41: tensor<?x?xf32>, %arg42: tensor<?x?xf32>, %arg43: tensor<?x?xf32>,
+	  %arg44: tensor<?x?xf32>, %arg45: tensor<?x?xf32>, %arg46: tensor<?x?xf32>, %arg47: tensor<?x?xf32>,
+	  %arg48: tensor<?x?xf32>, %arg49: tensor<?x?xf32>, %arg50: tensor<?x?xf32>, %arg51: tensor<?x?xf32>,
+	  %arg52: tensor<?x?xf32>, %arg53: tensor<?x?xf32>, %arg54: tensor<?x?xf32>, %arg55: tensor<?x?xf32>,
+	  %arg56: tensor<?x?xf32>, %arg57: tensor<?x?xf32>, %arg58: tensor<?x?xf32>, %arg59: tensor<?x?xf32>,
+	  %arg60: tensor<?x?xf32>, %arg61: tensor<?x?xf32>, %arg62: tensor<?x?xf32>, %arg63: tensor<?x?xf32>
+	  ) -> tensor<?x?xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+      %1:2 = tf_executor.island wraps "tf.Tanh"(%arg0) : (tensor<?x?xf32>) -> (tensor<?x?xf32>)
+      %2:2 = tf_executor.island wraps "tf.ConcatV2"(
+	      %1, %arg1, %arg2, %arg3,
+	      %arg4, %arg5, %arg6, %arg7,
+	      %arg8, %arg9, %arg10, %arg11,
+	      %arg12, %arg13, %arg14, %arg15,
+	      %arg16, %arg17, %arg18, %arg19,
+	      %arg20, %arg21, %arg22, %arg23,
+	      %arg24, %arg25, %arg26, %arg27,
+	      %arg28, %arg29, %arg30, %arg31,
+	      %arg32, %arg33, %arg34, %arg35,
+	      %arg36, %arg37, %arg38, %arg39,
+	      %arg40, %arg41, %arg42, %arg43,
+	      %arg44, %arg45, %arg46, %arg47,
+	      %arg48, %arg49, %arg50, %arg51,
+	      %arg52, %arg53, %arg54, %arg55,
+	      %arg56, %arg57, %arg58, %arg59,
+	      %arg60, %arg61, %arg62, %arg63,
+	      %0) : (
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>,
+		  tensor<i32>) -> tensor<?x?xf32>
+      tf_executor.fetch %2 : tensor<?x?xf32>
+    }
+    return %graph : tensor<?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/large_concat.cc
+++ b/tao_compiler/mlir/disc/tests/regression/large_concat.cc
@@ -33,4 +33,15 @@ TEST(LargeConcat, CPUTest) {
       /*output_descriptors*/ {"f32_X"}));
 }
 
+TEST(LargeConcat, FusedCPUTest) {
+  std::vector<std::string> input_descriptors(64, "30x4xf32_X");
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "large_concat_cpu_fused.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ input_descriptors.size(),
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ input_descriptors,
+      /*output_descriptors*/ {"f32_X"}));
+}
+
 }  // namespace mlir_test

--- a/tao_compiler/mlir/disc/tests/regression/large_concat.cc
+++ b/tao_compiler/mlir/disc/tests/regression/large_concat.cc
@@ -1,0 +1,39 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/disc/tests/mlir_feature_test.h"
+#include "tensorflow/compiler/mlir/disc/tests/mlir_test.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace mlir_test {
+
+const std::string c_ft_path =
+    "tensorflow/compiler/mlir/disc/tests/regression/data/";
+
+TEST(LargeConcat, CPUTest) {
+  std::vector<std::string> input_descriptors;
+  for (int i = 0; i < 64; ++i) {
+    input_descriptors.push_back("30x4xf32_X");
+  }
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "large_concat_cpu.mlir",
+      /*backend_types*/ {BackendType::kX86},
+      /*num_inputs*/ input_descriptors.size(),
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ input_descriptors,
+      /*output_descriptors*/ {"f32_X"}));
+}
+
+}  // namespace mlir_test

--- a/tao_compiler/mlir/disc/tests/regression/large_concat.cc
+++ b/tao_compiler/mlir/disc/tests/regression/large_concat.cc
@@ -23,10 +23,7 @@ const std::string c_ft_path =
     "tensorflow/compiler/mlir/disc/tests/regression/data/";
 
 TEST(LargeConcat, CPUTest) {
-  std::vector<std::string> input_descriptors;
-  for (int i = 0; i < 64; ++i) {
-    input_descriptors.push_back("30x4xf32_X");
-  }
+  std::vector<std::string> input_descriptors(64, "30x4xf32_X");
   EXPECT_TRUE(feature_test_main(
       /*mlir_file_path*/ c_ft_path + "large_concat_cpu.mlir",
       /*backend_types*/ {BackendType::kX86},

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -56,6 +56,8 @@ StringRef fusionTypeToString(FusionType ft) {
       return "kInput";
     case FusionType::kStitch:
       return "kStitch";
+    case FusionType::kLargeConcat:
+      return "kLargeConcat";
     default:
       assert(false && "unknown fusion type");
       return "";
@@ -76,6 +78,8 @@ FusionType fusionTypeFromString(StringRef ft) {
     return FusionType::kInput;
   } else if (ft == "kStitch") {
     return FusionType::kStitch;
+  } else if (ft == "kLargeConcat") {
+    return FusionType::kLargeConcat;
   }
   assert(false && "unknown fusion type");
   return FusionType::kNone;
@@ -796,6 +800,10 @@ bool BaseCpuFusionStrategy::initFusionPattern(
       inferredDominantOp = nullptr;
       break;
     }
+  }
+  auto& roots = fused_pattern.getRootOps();
+  if (roots.size() == 1 && isLargeConcatOp(roots[0])) {
+    inferredFusionType = FusionType::kLargeConcat;
   }
   fused_pattern.setDominantOp(inferredDominantOp);
   fused_pattern.setFusionType(inferredFusionType);

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -93,6 +93,8 @@ enum FusionType {
   kInput,
   // TAO v1/v2 Stitch Fusion
   kStitch,
+  // A schedule for concat op having many operands.
+  kLargeConcat,
 };
 
 // Convert a fusion type to its string representation.

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -336,6 +336,11 @@ struct FusionOptions {
   int max_num_arguments_per_kernel = 64;
 };
 
+void setGlobalFusionOptions(const FusionOptions& options);
+
+// Here 'large' refer to having many operands.
+bool isLargeConcatOp(Operation* op);
+
 // Represents a specific fusion strategy.
 // Examples are:
 //  - basic fusion strategy for CPU device

--- a/tao_compiler/mlir/disc/transforms/input_inline_fusion_pass.cc
+++ b/tao_compiler/mlir/disc/transforms/input_inline_fusion_pass.cc
@@ -65,7 +65,7 @@ std::unique_ptr<FunctionPass> createDiscInputInlineFusionPass() {
 
 namespace {
 
-constexpr unsigned c_MAX_ITERATION = 4096;
+constexpr unsigned c_MAX_ITERATION = 4096 * 1000;
 
 // This pass works after LhloLegalizeRootsToParallelLoops pass for the
 // XLA-style fusion codegen.

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -2032,7 +2032,25 @@ LogicalResult HandleGpuFusionOp(OpBuilder& b, Operation* fusion) {
 //     copy the last operand to output buffer
 //   }
 // }
-
+//
+// To reduce the average level of nested if statement, we further
+// reorder the structure of the if-else statement to form a binary
+// tree. Basic idea is:
+//
+// // Emits switch statement for range [from, to)
+// def emitSwitch(..., int idx, int from, int to) {
+//   if (to - from < 1) return;
+//   int mid = (from + to) / 2;
+//   if (idx == mid) {
+//     copy operand #mid to output
+//   } else {
+//     if (idx < mid) {
+//       emitSwitch(..., idx, from, mid);
+//     } else {
+//       emitSwitch(..., idx, mid+1, to);
+//     }
+//   }
+// }
 LogicalResult emitSwitchOperandIdx(OpBuilder& b, Location loc,
                                    lmhlo::ConcatenateOp op,
                                    SmallVector<Value>& concatOffsets,

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -2174,7 +2174,7 @@ LogicalResult lowerWithScheduleLoopCPU(
                                  parallel_loop, shape_constraint_analysis);
   }
 
-  if (root_ops.size() == 1 && isLargeConcatOp(root_ops[0])) {
+  if (non_fusion && isLargeConcatOp(dominant_op)) {
     return lowerWithScheduleLargeConcatCPU(
         root_ops, dominant_op, parent, non_fusion, shape_constraint_analysis);
   }
@@ -2365,6 +2365,12 @@ LogicalResult HandleCpuFusionOp(OpBuilder& b, Operation* fusion) {
                                           /*non_fusion*/ false,
                                           /*parallel_loop*/ true,
                                           /*multi_dim_loop*/ true))) {
+        return dominant_op->emitError() << "failed to lower to loops";
+      }
+      break;
+    case FusionType::kLargeConcat:
+      if (failed(lowerWithScheduleLargeConcatCPU(
+              root_ops, dominant_op, fused_block, /*non_fusion*/ false))) {
         return dominant_op->emitError() << "failed to lower to loops";
       }
       break;

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -2019,6 +2019,118 @@ LogicalResult HandleGpuFusionOp(OpBuilder& b, Operation* fusion) {
   return success();
 }
 
+// For concat op having many operands, we use following schedule:
+//
+// parallel.for %idx in range(num_operands_of_concat) {
+//   if (%idx == 0) {
+//     copy operand #0 to output buffer
+//   } else if (idx == 1) {
+//     copy operand #1 to output buffer
+//   } ...
+//   ... ...
+//   } else {
+//     copy the last operand to output buffer
+//   }
+// }
+
+LogicalResult emitSwitchOperandIdx(OpBuilder& b, Location loc,
+                                   lmhlo::ConcatenateOp op,
+                                   SmallVector<Value>& concatOffsets,
+                                   Value operandIdx, int from, int to) {
+  if (to - from < 1) return success();
+
+  int median = (from + to) / 2;
+  Value medianValue = b.create<ConstantIndexOp>(loc, median);
+  Value predEQ =
+      b.create<CmpIOp>(loc, CmpIPredicate::eq, operandIdx, medianValue);
+  auto ifOp = b.create<scf::IfOp>(loc, llvm::None, predEQ, true);
+  Block* thenBlock = &ifOp.thenRegion().getBlocks().front();
+  Block* elseBlock = &ifOp.elseRegion().getBlocks().front();
+
+  // if operandIdx == median
+  {
+    b.setInsertionPoint(thenBlock, thenBlock->begin());
+    Value operand = op->getOperand(median);
+    Value result = cast<lmhlo::LmhloOp>(op.getOperation()).getResultBuffer();
+    SmallVector<Value> operandShapeVec = getShapeValues(&b, operand);
+    Value zero = b.create<ConstantIndexOp>(loc, 0);
+    Value one = b.create<ConstantIndexOp>(loc, 1);
+    size_t rank = operandShapeVec.size();
+    SmallVector<Value> vars;
+    SmallVector<Value> starts(rank, zero);
+    SmallVector<Value> limits = operandShapeVec;
+    SmallVector<Value> steps(rank, one);
+    (void)createParallelAndSetInsPt(b, loc, vars, starts, limits, steps, {});
+    SmallVector<Value> resultVars = vars;
+    int64_t dimension = op.dimension();
+    resultVars[dimension] =
+        b.create<AddIOp>(loc, vars[dimension], concatOffsets[median]);
+    Value data = b.create<memref::LoadOp>(loc, operand, vars);
+    b.create<memref::StoreOp>(loc, data, result, resultVars);
+  }
+
+  b.setInsertionPoint(elseBlock, elseBlock->begin());
+  // else if operandIdx != median
+  {
+    Value predLT =
+        b.create<CmpIOp>(loc, CmpIPredicate::slt, operandIdx, medianValue);
+    auto ifOp = b.create<scf::IfOp>(loc, llvm::None, predLT, true);
+    Block* thenBlock = &ifOp.thenRegion().getBlocks().front();
+    Block* elseBlock = &ifOp.elseRegion().getBlocks().front();
+    b.setInsertionPoint(thenBlock, thenBlock->begin());
+    if (failed(emitSwitchOperandIdx(b, loc, op, concatOffsets, operandIdx, from,
+                                    median)))
+      return failure();
+    b.setInsertionPoint(elseBlock, elseBlock->begin());
+    if (failed(emitSwitchOperandIdx(b, loc, op, concatOffsets, operandIdx,
+                                    median + 1, to)))
+      return failure();
+  }
+  b.setInsertionPointAfter(ifOp);
+  return success();
+}
+
+LogicalResult lowerWithScheduleLargeConcatCPU(
+    ArrayRef<Operation*> root_ops, Operation* dominant_op,
+    Block* parent = nullptr, bool non_fusion = false,
+    const ShapeConstraintAnalysis* shape_constraint_analysis = nullptr) {
+  assert(root_ops.size() == 1 && isLargeConcatOp(root_ops[0]));
+
+  auto concat = cast<lmhlo::ConcatenateOp>(root_ops[0]);
+  int numOperands = concat->getNumOperands() - 1;
+  const auto loc = dominant_op->getLoc();
+  OpBuilder b(root_ops.back());
+  Value zero = b.create<ConstantIndexOp>(loc, 0);
+  Value one = b.create<ConstantIndexOp>(loc, 1);
+  Value numOperandsValue = b.create<ConstantIndexOp>(loc, numOperands);
+  SmallVector<Value> vars;
+  SmallVector<Value> starts{zero};
+  SmallVector<Value> limits{numOperandsValue};
+  SmallVector<Value> steps{one};
+
+  (void)createParallelAndSetInsPt(b, loc, vars, starts, limits, steps, {});
+  int64_t dimension = concat.dimension();
+  SmallVector<Value> concatOffsets{zero};
+  for (int i = 0; i < numOperands; ++i) {
+    concatOffsets.push_back(b.create<AddIOp>(
+        loc, concatOffsets.back(),
+        b.create<memref::DimOp>(loc, concat->getOperand(i), dimension)));
+  }
+  Value operandIdx = vars[0];
+  if (failed(emitSwitchOperandIdx(b, loc, concat, concatOffsets, operandIdx, 0,
+                                  numOperands)))
+    return failure();
+
+  // remove the root_op if it has no other users except the memref
+  if (non_fusion) {
+    for (Operation* root_op : root_ops) root_op->erase();
+  } else {
+    assert(parent != nullptr && "Parent must be provided for fusion lowering");
+    cleanUnusedLhloOps(parent);
+  }
+  return success();
+}
+
 // we don't do inbound check for kLoop Schedule
 // LoopSplit pass will do this.
 //
@@ -2042,6 +2154,11 @@ LogicalResult lowerWithScheduleLoopCPU(
   if (!multi_dim_loop || !rank || !parallel_loop) {
     return lowerWithScheduleLoop(root_ops, dominant_op, parent, non_fusion,
                                  parallel_loop, shape_constraint_analysis);
+  }
+
+  if (root_ops.size() == 1 && isLargeConcatOp(root_ops[0])) {
+    return lowerWithScheduleLargeConcatCPU(
+        root_ops, dominant_op, parent, non_fusion, shape_constraint_analysis);
   }
 
   const auto loc = dominant_op->getLoc();


### PR DESCRIPTION
For a concat op:
```
lmhlo.concatenate(%operand1, %operand2, ... %operandN, %output) { concat_axis = m}
```

Original schedule:
```
scf.for ((iv1, ..., iv{m-1}, iv{m+1},...iv{n}) in  range(non_concat_dims)) {
  scf.for (iv{m} in range(concat_dim)) {
    if ((iv1, iv2, ..., ivn) maps to operand1) {
      output[(iv1, iv2, ..., ivn)] = operand1[(iv1, ..., iv{m} - offset1, ...)];
    } else if ((iv1, iv2, ..., ivn) maps to operand2) {
      output[(iv1, iv2, ..., ivn)] = operand2[(iv1, ..., iv{m} - offset2, ...)];
    } ... {
      ...
    }
  }
}
```

New schedule:
```
parallel.for %idx in range(num_operands_of_concat) {
  if (%idx == 1) {
    copy operand1 to output buffer
  } else if (idx == 2) {
    copy operand2 to output buffer
  } ... {
    ...
  } else {
    copy the last operand to output buffer
  }
}
```