### PR TITLE
using https as submodule proto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "pytorch_blade/third_party/googletest"]
 	path = pytorch_blade/third_party/googletest
-	url = git@github.com:google/googletest.git
+        url = https://github.com/google/googletest.git 
 [submodule "tf_community"]
 	path = tf_community
-	url = git@github.com:pai-disc/tensorflow.git
+        url = https://github.com/pai-disc/tensorflow.git
 [submodule "tao/third_party/json"]
 	path = tao/third_party/json
-	url = git@github.com:nlohmann/json.git
+        url = https://github.com/nlohmann/json.git

--- a/tao/CMakeLists.txt
+++ b/tao/CMakeLists.txt
@@ -153,7 +153,6 @@ endif()
 if (${PLATFORM_ALIBABA})
   message("Build DISC in Alibaba platform")
   add_compile_options(-DPLATFORM_ALIBABA)
-  #set(PLATFORM_ALIBABA_PATH ../../platform_alibaba)
   get_filename_component(PLATFORM_ALIBABA_DIR ../../platform_alibaba ABSOLUTE)
 endif()
 

--- a/tao/CMakeLists.txt
+++ b/tao/CMakeLists.txt
@@ -153,7 +153,8 @@ endif()
 if (${PLATFORM_ALIBABA})
   message("Build DISC in Alibaba platform")
   add_compile_options(-DPLATFORM_ALIBABA)
-  set(PLATFORM_ALIBABA_PATH ../../platform_alibaba)
+  #set(PLATFORM_ALIBABA_PATH ../../platform_alibaba)
+  get_filename_component(PLATFORM_ALIBABA_DIR ../../platform_alibaba ABSOLUTE)
 endif()
 
 include_directories(${tao_ops_SOURCE_DIR})
@@ -234,15 +235,15 @@ target_link_options(tao_ops PUBLIC "-Wl,--exclude-libs,ALL,-ldl")
 
 # required by uploader in tao_bridge
 if(${TAO_ENABLE_UPLOAD_TOOL} AND ${PLATFORM_ALIBABA})
-    include_directories(${PLATFORM_ALIBABA_PATH}/third_party/aliyun-oss-cpp-sdk/sdk/include)
-    add_subdirectory(${PLATFORM_ALIBABA_PATH}/third_party/aliyun-oss-cpp-sdk aliyun-oss-cpp-sdk)
-    add_subdirectory(${PLATFORM_ALIBABA_PATH}/tools/tao/uploader uploader)
+    include_directories(${PLATFORM_ALIBABA_DIR}/third_party/aliyun-oss-cpp-sdk/sdk/include)
+    add_subdirectory(${PLATFORM_ALIBABA_DIR}/third_party/aliyun-oss-cpp-sdk aliyun-oss-cpp-sdk)
+    add_subdirectory(${PLATFORM_ALIBABA_DIR}/tools/tao/uploader uploader)
 endif()
 
 add_subdirectory(tao_bridge)
 
 if(${PLATFORM_ALIBABA})
-  add_subdirectory(${PLATFORM_ALIBABA_PATH}/third_party/PatineClient PatineClient)
+  add_subdirectory(${PLATFORM_ALIBABA_DIR}/third_party/PatineClient PatineClient)
 endif()
 # Unset these CACHE variables to not change the blade project structure
 unset(CMAKE_ARCHIVE_OUTPUT_DIRECTORY CACHE)


### PR DESCRIPTION
We use HTTP proxy in the internal cluster to fix random failed with `git clone, that the submodule should be HTTPS proto.

