### PR TITLE
download gtest with URL

### DIFF
--- a/tao/CMake/Googletest/CMakeLists.txt.in
+++ b/tao/CMake/Googletest/CMakeLists.txt.in
@@ -4,13 +4,12 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           main 
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
+  URL                   "https://pai-blade.oss-cn-zhangjiakou.aliyuncs.com/gtest/release-1.11.0.tar.gz"
+  DOWNLOAD_NO_PROGRESS  true
+  SOURCE_DIR            "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR            "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND     ""
+  BUILD_COMMAND         ""
+  INSTALL_COMMAND       ""
+  TEST_COMMAND          ""
 )
-


### PR DESCRIPTION
OSS URL achieves higher speed on the internal cluster.
