### PR TITLE
[torch converter][bugfix] Not convert transposed conv op

### DIFF
--- a/pytorch_blade/src/compiler/mlir/converters/impl/convolution.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/convolution.cpp
@@ -50,12 +50,16 @@ bool ConvertAtenConvolution(
   if (!CheckConstAttribute(jit_dilation, op_name, "dilation")) {
     return false;
   }
-  // other inputs is ignored currently
-  /*
   auto jit_trans = node.input(6);
   if (!CheckConstAttribute(jit_trans, op_name, "transposed")) {
     return false;
   }
+  // TODO(disc): support transposed convolution.
+  if (CastJitConstToBool(*jit_trans)) {
+    return false;
+  }
+  // TODO(disc): other inputs is ignored currently
+  /*
   auto jit_output_pad = node.input(7);
   if (!CheckConstAttribute(jit_output_pad, op_name, "output_padding")) {
     return false;
@@ -64,6 +68,10 @@ bool ConvertAtenConvolution(
   if (!CheckConstAttribute(jit_groups, op_name, "groups")) {
     return false;
   } */
+
+  if (ctx.IsSupportTesting()) {
+    return true;
+  }
 
   auto mlir_input = ctx.GetMlirValue(node.input(0));
   auto mlir_weight = ctx.GetMlirValue(jit_weight);


### PR DESCRIPTION
Original implementation puts a conv op into the supported list of DISC
no matter what the input values/attributes of the conv op are. However,
we actually do not support transposed conv op a.t.m. This CL fix the
problem.