### PR TITLE
[disc-cpu] support conv1d and conv3d

### DIFF
--- a/pytorch_blade/tests/mlir/test_disc_conv_ops.py
+++ b/pytorch_blade/tests/mlir/test_disc_conv_ops.py
@@ -13,6 +13,7 @@ import torch
 import torch_blade
 import unittest
 
+from torch_blade.version import cuda_available
 from tests.mlir.testing_utils import DiscTestCase
 
 class TestMlirConvolution(DiscTestCase):
@@ -25,7 +26,7 @@ class TestMlirConvolution(DiscTestCase):
             test_data = (test_data.to(self.device),)
         self._test_cvt_to_disc(conv_func, test_data)
 
-    @unittest.skip("RAL: please support conv1d first")
+    @unittest.skipIf(torch_blade.version.cuda_available, "disc-gpu not support 1d conv yet.")
     def test_conv1d(self):
         conv = torch.nn.Conv1d(16, 33, 3, stride=2, padding=2)
         self._test_conv(conv, torch.randn([20, 16, 60], device=self.device))
@@ -34,7 +35,7 @@ class TestMlirConvolution(DiscTestCase):
         conv = torch.nn.Conv2d(16, 33, (3, 4), stride=2, padding=[2, 1], dilation=2)
         self._test_conv(conv)
 
-    @unittest.skip("RAL: please support conv3d first")
+    @unittest.skipIf(torch_blade.version.cuda_available, "disc-gpu not support 3d conv yet.")
     def test_conv3d(self):
         conv = torch.nn.Conv3d(16, 33, (3, 4, 5), stride=[2, 1, 3], padding=2)
         self._test_conv(conv, torch.randn([20, 16, 60, 50, 100], device=self.device))


### PR DESCRIPTION
1, promote conv1d to conv2d by default.  This is the default behavior of TensorFlow. I also find that the promoted version is faster (+15%) than the original 1d version if the backend is oneDNN in some micro-benchmarks. 

2, add a 3d conv registration.

3, enable the conv1d & conv3d test of torch converter on cpu.