### PR TITLE
UT for corner case of PTXAS error before v11.1.

### DIFF
--- a/tao_compiler/mlir/disc/tests/regression/corner_case.cc
+++ b/tao_compiler/mlir/disc/tests/regression/corner_case.cc
@@ -1,0 +1,35 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorflow/compiler/mlir/disc/tests/mlir_feature_test.h"
+#include "tensorflow/compiler/mlir/disc/tests/mlir_test.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace mlir_test {
+
+const std::string c_ft_path =
+    "tensorflow/compiler/mlir/disc/tests/regression/data/";
+
+#if CUDA_VERSION >= 11100
+// This case fails with PTXAS of version 11.0. Log here to know this error
+// ahead in case a future version of ptxas fails for the same reason.
+TEST(KCornerCaseTest, CornerCaseErrorBeforePTXASX11100) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "corner_case_error_before_ptxas11100.mlir",
+      /*backend_types*/ {BackendType::kCuda},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"209x503xf32_X"},
+      /*output_descriptors*/ {"f32_X"}));
+}
+#endif
+
+}  // namespace mlir_test

--- a/tao_compiler/mlir/disc/tests/regression/data/corner_case_error_before_ptxas11100.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/corner_case_error_before_ptxas11100.mlir
@@ -1,0 +1,14 @@
+// This case will cause illegal address error with PTXAS version of 11.0.
+// PTXAS 11.1 works well. We have already check that it is not error codegen at
+// MLIR level. Changing dimension values does not help to avoid the error. 
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(%arg0: tensor<209x503xf32>) -> tensor<209xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %4:2 = tf_executor.island wraps "tf.Add"(%arg0, %arg0) : (tensor<209x503xf32>, tensor<209x503xf32>) -> tensor<209x503xf32>
+      %c2:2 = tf_executor.island wraps "tf.Const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+      %5:2 = tf_executor.island wraps "tf.Max"(%4, %c2) : (tensor<209x503xf32>, tensor<i32>) -> tensor<209xf32>
+      tf_executor.fetch %5: tensor<209xf32>
+    }
+    return %graph : tensor<209xf32>
+  }
+}


### PR DESCRIPTION
Add a UT about PTXAS compilation error before version of 11.1. Incase we encounter the same error in a future PTXAS release.