### PR TITLE
Save const values in metadata.proto in splat mode

### DIFF
--- a/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
@@ -44,17 +44,7 @@ constexpr static int kMd5DigestLength = 16;
 void ExtractConstValue(const DenseElementsAttr& valueAttr, MemRefType memref,
                        StrT& data) {
   ArrayRef<char> rawData = valueAttr.getRawData();
-  if (valueAttr.isSplat()) {
-    size_t num_elements = memref.getNumElements();
-    data.reserve(num_elements * memref.getElementTypeBitWidth());
-    std::string splatStr =
-        llvm::toHex(StringRef(rawData.data(), rawData.size()));
-    for (size_t i = 0; i < num_elements; ++i) {
-      data.append(splatStr);
-    }
-  } else {
-    data.append(llvm::toHex(StringRef(rawData.data(), rawData.size())));
-  }
+  data.append(llvm::toHex(StringRef(rawData.data(), rawData.size())));
 }
 
 // unique_name is in the format: {hash_of_literal}_2x3x4xf32

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <numeric>
 
 #include "absl/strings/str_split.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
@@ -238,7 +239,8 @@ int parseMetadataPb(const std::string& pb_file_path,
 }
 
 buffer_shape_t GetShapeFromConstUniqueName(ExecutionContext* ctx,
-                                           const std::string& unique_name) {
+                                           const std::string& unique_name,
+                                           int64_t* width_in_bytes) {
   std::vector<std::string> splitted = absl::StrSplit(unique_name, '_');
   if (splitted.size() != 3) {
     ctx->signalError(Context::FAILURE,
@@ -250,6 +252,10 @@ buffer_shape_t GetShapeFromConstUniqueName(ExecutionContext* ctx,
     for (auto& dim : dims_splitted) {
       shape.emplace_back(std::stoi(dim));
     }
+  }
+  *width_in_bytes = std::stoi(splitted[1].substr(1)) / 8;
+  if (*width_in_bytes < 1) {
+    *width_in_bytes = 1;
   }
   return shape;
 }
@@ -313,7 +319,9 @@ inline buffer_t ral_base_cuda_const_host_internal(ExecutionContext* ctx,
     std::string key(unique_name);
     auto it = state->host_constants.find(key);
     if (it == state->host_constants.end()) {
-      buffer_shape_t dim_sizes = GetShapeFromConstUniqueName(ctx, unique_name);
+      int64_t width_in_bytes = 0;
+      buffer_shape_t dim_sizes =
+          GetShapeFromConstUniqueName(ctx, unique_name, &width_in_bytes);
       // alloc, get value from metadata file
       const auto& constants = state->metadata_proto.host_global_constants();
       if (constants.find(key) == constants.end()) {
@@ -322,9 +330,19 @@ inline buffer_t ral_base_cuda_const_host_internal(ExecutionContext* ctx,
         ctx->signalError(Context::FAILURE, msg);
       }
       std::string hex_str = constants.at(key);
-      TAO_VLOG(2) << "fromHex start:";
       auto data = fromHex(hex_str);
       auto bytes = data.size();
+      int64_t num_elements = std::accumulate(dim_sizes.begin(), dim_sizes.end(),
+                                             1, std::multiplies<int64_t>());
+      if (bytes < num_elements * width_in_bytes) {
+        // isSplat
+        bytes = num_elements * width_in_bytes;
+        auto splat_data = data;
+        for (int64_t i = 0; i < num_elements - 1; ++i) {
+          std::copy(splat_data.begin(), splat_data.end(),
+                    std::back_inserter(data));
+        }
+      }
       auto cpu_driver = ctx->getDriver<cpu::CPUDriver>(cpu::CPUDriver::name());
       buffer_t data_ptr = use_process_store
                               ? cpu_driver->raw_alloc(ctx->getContext(), bytes)

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl.h
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl.h
@@ -104,7 +104,8 @@ static inline void* aligned_malloc(int64_t size) {
 }
 
 buffer_shape_t GetShapeFromConstUniqueName(ExecutionContext* ctx,
-                                           const std::string& unique_name);
+                                           const std::string& unique_name,
+                                           int64_t* width_in_bytes);
 
 std::vector<uint8_t> fromHex(const std::string& Input);
 


### PR DESCRIPTION
This change is to fix the problem that huge splat constant may exceed the limit of protobuf.