### PR TITLE
[TorchDISC] setup torch-disc building environment and CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,172 +6,199 @@ name: DISC
 # or API.
 on:
   push:
-    branches: [ main ]
+    branches: [ main, features/torch_disc_devel ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, features/torch_disc_devel ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "greet"
-  CUDA10-TF115:
+#  CUDA10-TF115:
+#    if: github.repository == 'alibaba/BladeDISC'
+#    # The type of runner that the job will run on
+#    runs-on: [self-hosted, gpu-t4]
+#
+#    # Steps represent a sequence of tasks that will be executed as part of the job
+#    steps:
+#    # Runs a single command using the runners shell
+#    - name: Checkout
+#      uses: actions/checkout@v2.4.0
+#    - name: pre-commit
+#      shell: bash
+#      run: |
+#        export PATH=$HOME/.local/bin:$PATH
+#        pre-commit run -a --show-diff-on-failure
+#    - name: Build Dev Docker
+#      shell: bash
+#      run: |
+#        set -e
+#        git submodule sync
+#        git submodule update --depth=1 --init --recursive
+#        docker build -t disc-dev-cuda10.0 \
+#          --build-arg BASEIMAGE=nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 \
+#          --build-arg DISC_HOST_TF_VERSION="tensorflow-gpu==1.15" \
+#          -f docker/dev/Dockerfile .
+#    - name: Build And Test DISC
+#      run: |
+#        set -e
+#        nvidia-docker run --rm -t --user $(id -u) \
+#          -v $HOME/.cache:$HOME/.cache \
+#          -v /etc/passwd:/etc/passwd:ro \
+#          -v /etc/group:/etc/group:ro \
+#          -v $PWD:/disc \
+#          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
+#          -w /disc \
+#          disc-dev-cuda10.0 bash ./scripts/ci/build_and_test.sh
+#    - name: Deploy Docker
+#      if: github.event.ref == 'refs/heads/main'
+#      env:
+#        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+#        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+#        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#        GITHUB_PULL_REQUEST: ${{ github.event.number }}
+#        LOCAL_DEV_DOCKER: disc-dev-cuda10.0
+#        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda10.0
+#        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-tensorflow1.15
+#        RUNTIME_BASEIMAGE: tensorflow/tensorflow:1.15.5-gpu
+#      run: |
+#        set -e
+#        bash ./scripts/ci/deploy_tf_wrapper.sh
+#  CUDA11-TF24:
+#    if: github.repository == 'alibaba/BladeDISC'
+#    # The type of runner that the job will run on
+#    runs-on: [self-hosted, gpu-t4]
+#    # Steps represent a sequence of tasks that will be executed as part of the job
+#    steps:
+#    # Runs a single command using the runners shell
+#    - name: Checkout
+#      uses: actions/checkout@v2.4.0
+#    - name: Build Dev Docker
+#      run: |
+#        set -e
+#        git submodule sync
+#        git submodule update --depth=1 --init --recursive
+#        docker build -t disc-dev-cuda11.0 \
+#          --build-arg BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 \
+#          --build-arg DISC_HOST_TF_VERSION="tensorflow-gpu==2.4" \
+#          -f docker/dev/Dockerfile .
+#    - name: Build And Test DISC
+#      run: |
+#        set -e
+#        nvidia-docker run --rm -t --user $(id -u) \
+#          -v $HOME/.cache:$HOME/.cache \
+#          -v /etc/passwd:/etc/passwd:ro \
+#          -v /etc/group:/etc/group:ro \
+#          -v $PWD:/disc \
+#          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
+#          -w /disc \
+#          disc-dev-cuda11.0 bash ./scripts/ci/build_and_test.sh
+#    - name: Deploy Docker
+#      if: github.event.ref == 'refs/heads/main'
+#      env:
+#        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+#        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+#        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#        GITHUB_PULL_REQUEST: ${{ github.event.number }}
+#        LOCAL_DEV_DOCKER: disc-dev-cuda11.0
+#        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda11.0
+#        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-tensorflow2.4
+#        RUNTIME_BASEIMAGE: tensorflow/tensorflow:2.4.0-gpu
+#      run: |
+#        set -e
+#        bash ./scripts/ci/deploy_tf_wrapper.sh
+  CUDA11-TORCH-DISC:
     if: github.repository == 'alibaba/BladeDISC'
-    # The type of runner that the job will run on
     runs-on: [self-hosted, gpu-t4]
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Runs a single command using the runners shell
     - name: Checkout
       uses: actions/checkout@v2.4.0
-    - name: pre-commit
-      shell: bash
-      run: |
-        export PATH=$HOME/.local/bin:$PATH
-        pre-commit run -a --show-diff-on-failure
+      with:
+        path: ./torch_disc_devel
     - name: Build Dev Docker
-      shell: bash
+      working-directory: ./torch_disc_devel
       run: |
         set -e
         git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker build -t disc-dev-cuda10.0 \
-          --build-arg BASEIMAGE=nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 \
-          --build-arg DISC_HOST_TF_VERSION="tensorflow-gpu==1.15" \
-          -f docker/dev/Dockerfile .
-    - name: Build And Test DISC
+        git submodule update --init --depth=1
+        docker build -t torch-disc-devel-cuda11.0 \
+          --build-arg PYTORCH_COMMIT=$(git submodule status torch_disc/pytorch | awk '{print $1}') \
+          -f docker/dev/Dockerfile.torch-disc ./docker/
+    - name: Build and Test
+      working-directory: ./torch_disc_devel
       run: |
         set -e
         nvidia-docker run --rm -t --user $(id -u) \
+          -v $PWD:/workspace \
           -v $HOME/.cache:$HOME/.cache \
           -v /etc/passwd:/etc/passwd:ro \
           -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -w /disc \
-          disc-dev-cuda10.0 bash ./scripts/ci/build_and_test.sh
-    - name: Deploy Docker
-      if: github.event.ref == 'refs/heads/main'
-      env:
-        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GITHUB_PULL_REQUEST: ${{ github.event.number }}
-        LOCAL_DEV_DOCKER: disc-dev-cuda10.0
-        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda10.0
-        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-tensorflow1.15
-        RUNTIME_BASEIMAGE: tensorflow/tensorflow:1.15.5-gpu
-      run: |
-        set -e
-        bash ./scripts/ci/deploy_tf_wrapper.sh
-  CUDA11-TF24:
-    if: github.repository == 'alibaba/BladeDISC'
-    # The type of runner that the job will run on
-    runs-on: [self-hosted, gpu-t4]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Runs a single command using the runners shell
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Build Dev Docker
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker build -t disc-dev-cuda11.0 \
-          --build-arg BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 \
-          --build-arg DISC_HOST_TF_VERSION="tensorflow-gpu==2.4" \
-          -f docker/dev/Dockerfile .
-    - name: Build And Test DISC
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u) \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -w /disc \
-          disc-dev-cuda11.0 bash ./scripts/ci/build_and_test.sh
-    - name: Deploy Docker
-      if: github.event.ref == 'refs/heads/main'
-      env:
-        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GITHUB_PULL_REQUEST: ${{ github.event.number }}
-        LOCAL_DEV_DOCKER: disc-dev-cuda11.0
-        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda11.0
-        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-tensorflow2.4
-        RUNTIME_BASEIMAGE: tensorflow/tensorflow:2.4.0-gpu
-      run: |
-        set -e
-        bash ./scripts/ci/deploy_tf_wrapper.sh
-  CUDA11-TORCH171:
-    if: github.repository == 'alibaba/BladeDISC'
-    # The type of runner that the job will run on
-    runs-on: [self-hosted, gpu-t4]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Runs a single command using the runners shell
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Build Dev Docker
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker build -t disc-dev-cuda11.0 \
-          --build-arg BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 -f docker/dev/Dockerfile .
-    - name: Build and Test DISC
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u) \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -w /disc \
-          disc-dev-cuda11.0 bash ./scripts/ci/test_pytorch_blade.sh
-    - name: Deploy PyTorch Blade
-      if: github.event.ref == 'refs/heads/main'
-      env:
-        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GITHUB_PULL_REQUEST: ${{ github.event.number }}
-        LOCAL_DEV_DOCKER: disc-dev-cuda11.0
-        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda11.0
-        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-torch1.7.1
-        RUNTIME_BASEIMAGE: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
-      run: |
-        set -e
-        bash ./scripts/ci/deploy_pytorch_blade.sh
-  CPU-TF115:
-    uses: ./.github/workflows/cpu_reusable.yml
-    with:
-      remote_runtime_docker: bladedisc:latest-runtime-tensorflow1.15-cpu
-      runtime_base_image: tensorflow/tensorflow:1.15.5
-      exec_command: bash ./scripts/ci/build_and_test.sh --cpu-only
-      deploy_command: bash ./scripts/ci/deploy_tf_wrapper.sh
-    secrets:
-      ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-      ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  CPU-TORCH181:
-    uses: ./.github/workflows/cpu_reusable.yml
-    with:
-      extra_envs: -e TORCH_BLADE_BUILD_WITH_CUDA_SUPPORT=OFF
-        -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cpu
-      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
-  CPU-CMAKE-TORCH181:
-    uses: ./.github/workflows/cpu_reusable.yml
-    with:
-      extra_envs: -e TORCH_BLADE_BUILD_WITH_CUDA_SUPPORT=OFF
-        -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cpu
-        -e TORCH_BLADE_USE_CMAKE_BUILD=ON
-      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+          -w /workspace torch-disc-devel-cuda11.0 bash ./scripts/ci/test_torch_disc.sh
+#  CUDA11-TORCH171:
+#    if: github.repository == 'alibaba/BladeDISC'
+#    # The type of runner that the job will run on
+#    runs-on: [self-hosted, gpu-t4]
+#    # Steps represent a sequence of tasks that will be executed as part of the job
+#    steps:
+#    # Runs a single command using the runners shell
+#    - name: Checkout
+#      uses: actions/checkout@v2.4.0
+#    - name: Build Dev Docker
+#      run: |
+#        set -e
+#        git submodule sync
+#        git submodule update --depth=1 --init --recursive
+#        docker build -t disc-dev-cuda11.0 \
+#          --build-arg BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 -f docker/dev/Dockerfile .
+#    - name: Build and Test DISC
+#      run: |
+#        set -e
+#        nvidia-docker run --rm -t --user $(id -u) \
+#          -v $HOME/.cache:$HOME/.cache \
+#          -v /etc/passwd:/etc/passwd:ro \
+#          -v /etc/group:/etc/group:ro \
+#          -v $PWD:/disc \
+#          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
+#          -w /disc \
+#          disc-dev-cuda11.0 bash ./scripts/ci/test_pytorch_blade.sh
+#    - name: Deploy PyTorch Blade
+#      if: github.event.ref == 'refs/heads/main'
+#      env:
+#        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+#        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+#        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#        GITHUB_PULL_REQUEST: ${{ github.event.number }}
+#        LOCAL_DEV_DOCKER: disc-dev-cuda11.0
+#        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda11.0
+#        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-torch1.7.1
+#        RUNTIME_BASEIMAGE: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+#      run: |
+#        set -e
+#        bash ./scripts/ci/deploy_pytorch_blade.sh
+#  CPU-TF115:
+#    uses: ./.github/workflows/cpu_reusable.yml
+#    with:
+#      remote_runtime_docker: bladedisc:latest-runtime-tensorflow1.15-cpu
+#      runtime_base_image: tensorflow/tensorflow:1.15.5
+#      exec_command: bash ./scripts/ci/build_and_test.sh --cpu-only
+#      deploy_command: bash ./scripts/ci/deploy_tf_wrapper.sh
+#    secrets:
+#      ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+#      ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+#      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#  CPU-TORCH181:
+#    uses: ./.github/workflows/cpu_reusable.yml
+#    with:
+#      extra_envs: -e TORCH_BLADE_BUILD_WITH_CUDA_SUPPORT=OFF
+#        -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cpu
+#      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+#  CPU-CMAKE-TORCH181:
+#    uses: ./.github/workflows/cpu_reusable.yml
+#    with:
+#      extra_envs: -e TORCH_BLADE_BUILD_WITH_CUDA_SUPPORT=OFF
+#        -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cpu
+#        -e TORCH_BLADE_USE_CMAKE_BUILD=ON
+#      exec_command: bash ./scripts/ci/test_pytorch_blade.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,33 +108,6 @@ jobs:
 #      run: |
 #        set -e
 #        bash ./scripts/ci/deploy_tf_wrapper.sh
-  CUDA11-TORCH-DISC:
-    if: github.repository == 'alibaba/BladeDISC'
-    runs-on: [self-hosted, gpu-t4]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-      with:
-        path: ./torch_disc_devel
-    - name: Build Dev Docker
-      working-directory: ./torch_disc_devel
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --init --depth=1
-        docker build -t torch-disc-devel-cuda11.0 \
-          --build-arg PYTORCH_COMMIT=$(git submodule status torch_disc/pytorch | awk '{print $1}') \
-          -f docker/dev/Dockerfile.torch-disc ./docker/
-    - name: Build and Test
-      working-directory: ./torch_disc_devel
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u) \
-          -v $PWD:/workspace \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -w /workspace torch-disc-devel-cuda11.0 bash ./scripts/ci/test_torch_disc.sh
 #  CUDA11-TORCH171:
 #    if: github.repository == 'alibaba/BladeDISC'
 #    # The type of runner that the job will run on
@@ -202,3 +175,30 @@ jobs:
 #        -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cpu
 #        -e TORCH_BLADE_USE_CMAKE_BUILD=ON
 #      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+  CUDA11-TORCH-DISC:
+    if: github.repository == 'alibaba/BladeDISC'
+    runs-on: [self-hosted, gpu-t4]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.4.0
+      with:
+        path: ./torch_disc_devel
+    - name: Build Dev Docker
+      working-directory: ./torch_disc_devel
+      run: |
+        set -e
+        git submodule sync
+        git submodule update --init --depth=1
+        docker build -t torch-disc-devel-cuda11.0 \
+          --build-arg PYTORCH_COMMIT=$(git submodule status torch_disc/pytorch | awk '{print $1}') \
+          -f docker/dev/Dockerfile.torch-disc ./docker/
+    - name: Build and Test
+      working-directory: ./torch_disc_devel
+      run: |
+        set -e
+        nvidia-docker run --rm -t --user $(id -u) \
+          -v $PWD:/workspace \
+          -v $HOME/.cache:$HOME/.cache \
+          -v /etc/passwd:/etc/passwd:ro \
+          -v /etc/group:/etc/group:ro \
+          -w /workspace torch-disc-devel-cuda11.0 bash ./scripts/ci/test_torch_disc.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,8 @@ jobs:
         set -e
         git submodule sync
         git submodule update --init --depth=1
-        docker build -t torch-disc-devel-cuda11.0 \
+        docker pull bladedisc/torch-disc:devel-cuda11.0
+        docker build --from-cache bladedisc/torch-disc:devel-cuda11.0 -t torch-disc-devel-cuda11.0 \
           --build-arg PYTORCH_COMMIT=$(git submodule status torch_disc/pytorch | awk '{print $1}') \
           -f docker/dev/Dockerfile.torch-disc ./docker/
     - name: Build and Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
         git submodule sync
         git submodule update --init --depth=1
         docker pull bladedisc/torch-disc:devel-cuda11.0
-        docker build --from-cache bladedisc/torch-disc:devel-cuda11.0 -t torch-disc-devel-cuda11.0 \
+        docker build --cache-from bladedisc/torch-disc:devel-cuda11.0 -t torch-disc-devel-cuda11.0 \
           --build-arg PYTORCH_COMMIT=$(git submodule status torch_disc/pytorch | awk '{print $1}') \
           -f docker/dev/Dockerfile.torch-disc ./docker/
     - name: Build and Test

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tao/third_party/mkldnn/oneDNN"]
 	path = tao/third_party/mkldnn/oneDNN
 	url = https://github.com/oneapi-src/oneDNN.git
+[submodule "torch_disc/pytorch"]
+	path = torch_disc/pytorch
+	url = https://github.com/pytorch/pytorch.git

--- a/docker/dev/Dockerfile.torch-disc
+++ b/docker/dev/Dockerfile.torch-disc
@@ -1,0 +1,11 @@
+FROM bladedisc/bladedisc:latest-devel-cuda11.0
+ARG PYTORCH_COMMIT=""
+ENV PYTORCH_COMMIT=${PYTORCH_COMMIT}
+
+COPY ./scripts /opt/scripts
+RUN apt-get update -y && \
+    apt-get install -y clang-8 clang++-8 python3.8 python3.8-dev && \
+    rm /usr/bin/python && \
+    ln -s /usr/bin/python3.8 /usr/bin/python && \
+    python -m pip install pyyaml typing_extensions virtualenv numpy
+RUN bash /opt/scripts/install-pytorch-ltc.sh

--- a/docker/dev/Dockerfile.torch-disc
+++ b/docker/dev/Dockerfile.torch-disc
@@ -7,6 +7,6 @@ RUN apt-get update -y && \
     apt-get install -y clang-8 clang++-8 python3.8 python3.8-dev && \
     rm /usr/bin/python && \
     ln -s /usr/bin/python3.8 /usr/bin/python && \
-    python -m pip --upgrade pip && \
+    python -m pip install --upgrade pip && \
     python -m pip install cpython pyyaml typing_extensions virtualenv numpy
 RUN bash /opt/scripts/install-pytorch-ltc.sh

--- a/docker/dev/Dockerfile.torch-disc
+++ b/docker/dev/Dockerfile.torch-disc
@@ -7,5 +7,6 @@ RUN apt-get update -y && \
     apt-get install -y clang-8 clang++-8 python3.8 python3.8-dev && \
     rm /usr/bin/python && \
     ln -s /usr/bin/python3.8 /usr/bin/python && \
-    python -m pip install pyyaml typing_extensions virtualenv numpy
+    python -m pip --upgrade pip && \
+    python -m pip install cpython pyyaml typing_extensions virtualenv numpy
 RUN bash /opt/scripts/install-pytorch-ltc.sh

--- a/docker/scripts/install-pytorch-ltc.sh
+++ b/docker/scripts/install-pytorch-ltc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+echo "PYTORCH_COMMIT: "$PYTORCH_COMMIT
+
+cd /opt && \
+git clone https://github.com/pytorch/pytorch.git && \
+cd pytorch && \
+git checkout $PYTORCH_COMMIT && \
+git submodule update --init --recursive --depth=1 && \
+python setup.py install && rm -rf /opt/pytorch

--- a/pytorch_blade/src/BUILD
+++ b/pytorch_blade/src/BUILD
@@ -14,6 +14,7 @@ cc_library(
     ] + if_cuda_is_configured([
         "@local_config_cuda//cuda:cudart",
     ]),
+    visibility=["//visibility:public"],
 )
 
 # Pybind11 bindings for TorchBlade

--- a/pytorch_blade/src/compiler/jit/BUILD
+++ b/pytorch_blade/src/compiler/jit/BUILD
@@ -10,6 +10,7 @@ filegroup(
             "**/torch/onnx.cpp",
             "**/*test.cpp",
             "**/pybind*.cpp",
+            "**/freeze_module.cpp" # TODO(yancey.yx): fix this pass to pass building with PyTorch LTC branch
         ],
     ),
 )

--- a/pytorch_blade/src/compiler/mlir/runtime/ral_context.cpp
+++ b/pytorch_blade/src/compiler/mlir/runtime/ral_context.cpp
@@ -14,6 +14,9 @@
 #include <dlfcn.h>
 
 #include <c10/core/CPUAllocator.h>
+#if PYTORCH_MAJOR_VERSION == 1 && PYTORCH_MIN_VERSION >= 12
+#include <c10/core/impl/alloc_cpu.h>
+#endif
 
 #ifdef TORCH_BLADE_BUILD_WITH_CUDA
 #ifdef TORCH_BLADE_USE_ROCM

--- a/scripts/ci/test_torch_disc.sh
+++ b/scripts/ci/test_torch_disc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+python -m virtualenv --system-site-packages myenv && source myenv/bin/activate
+(cd torch_disc && python setup.py develop)
+
+# check _torch_disc.so
+(cd bazel-bin/torch_disc && python -c "import _torch_disc")
+
+deactive

--- a/scripts/ci/test_torch_disc.sh
+++ b/scripts/ci/test_torch_disc.sh
@@ -11,10 +11,11 @@
 # limitations under the License.
 set -e
 
+python scripts/python/tao_build.py /opt/venv_disc -s configure --bridge-gcc default --compiler-gcc default
+
 python -m virtualenv --system-site-packages myenv && source myenv/bin/activate
+# build _torch_disc.so
 (cd torch_disc && python setup.py develop)
-
-# check _torch_disc.so
+# check pybind library
 (cd torch_disc/bazel-bin/torch_disc && python -c "import _torch_disc")
-
 deactive

--- a/scripts/ci/test_torch_disc.sh
+++ b/scripts/ci/test_torch_disc.sh
@@ -21,5 +21,5 @@ bash pytorch/lazy_tensor_core/scripts/generate_code.sh
 # 4. build "_torch_disc.so"
 python setup.py develop
 # 5. a easy way to test torch_disc, just try to import the pybind library
-(cd bazel-bin/torch_disc && python -c "import _torch_disc")
+(cd bazel-bin/torch_disc && python -c "import torch; import _torch_disc")
 deactivate

--- a/scripts/ci/test_torch_disc.sh
+++ b/scripts/ci/test_torch_disc.sh
@@ -11,11 +11,15 @@
 # limitations under the License.
 set -e
 
+# 1. configure tensorflow
 python scripts/python/tao_build.py /opt/venv_disc -s configure --bridge-gcc default --compiler-gcc default
-
+# 2. using a virtualenv to avoid permission issue
 python -m virtualenv --system-site-packages myenv && source myenv/bin/activate
-# build _torch_disc.so
-(cd torch_disc && python setup.py develop)
-# check pybind library
-(cd torch_disc/bazel-bin/torch_disc && python -c "import _torch_disc")
-deactive
+# 3. call LTC code generator, that's used in ts lowering
+cd torch_disc
+bash pytorch/lazy_tensor_core/scripts/generate_code.sh
+# 4. build "_torch_disc.so"
+python setup.py develop
+# 5. a easy way to test torch_disc, just try to import the pybind library
+(cd bazel-bin/torch_disc && python -c "import _torch_disc")
+deactivate

--- a/scripts/ci/test_torch_disc.sh
+++ b/scripts/ci/test_torch_disc.sh
@@ -15,6 +15,6 @@ python -m virtualenv --system-site-packages myenv && source myenv/bin/activate
 (cd torch_disc && python setup.py develop)
 
 # check _torch_disc.so
-(cd bazel-bin/torch_disc && python -c "import _torch_disc")
+(cd torch_disc/bazel-bin/torch_disc && python -c "import _torch_disc")
 
 deactive

--- a/torch_disc/.bazelrc
+++ b/torch_disc/.bazelrc
@@ -1,0 +1,3 @@
+try-import ../tf_community/.bazelrc
+try-import ../tf_community/.bazelrc.user
+build --verbose_failures --remote_cache=http://172.17.101.135:9090

--- a/torch_disc/BUILD.bazel
+++ b/torch_disc/BUILD.bazel
@@ -1,0 +1,5 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)

--- a/torch_disc/README.md
+++ b/torch_disc/README.md
@@ -1,0 +1,30 @@
+# Torch-DISC
+
+## How to build
+
+1. Development Docker image
+
+    ```bash
+    nvidia-docker run --rm -it -v $PWD:/work pytorch/pytorch:1.10.0-cuda11.3-cudnn8-devel bash
+    ```
+
+1. install requirements
+
+    ``` bash
+    conda install -y cmake git ninja
+    apt-get update -y && apt-get install -y clang-8 clang++-8
+    ```
+
+1. build pytorch and torch-ltc
+
+    ``` bash
+    (cd torch_disc/pytorch && python setup.py install)
+    (cd torch_disc && setup.py develop)
+    ```
+
+1. Try to load `torch_disc` module
+
+    ``` bash
+    cd torch_disc/bazel-bin/torch_disc
+    python -c "import _torch_disc"
+    ```

--- a/torch_disc/WORKSPACE
+++ b/torch_disc/WORKSPACE
@@ -1,0 +1,126 @@
+workspace(name = "org_torch_disc")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.17.2")
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "ae34c344514e08c23e90da0e2d6cb700fcd28e80c02e23e4d5715dddcb42f7b3",
+    strip_prefix = "buildtools-4.2.2",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "rules_python",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
+        "https://github.com/bazelbuild/rules_python/releases/download/0.4.2/rules_python-0.4.0.tar.gz",
+    ],
+)
+
+#`pybind11_bazel`
+# See https://github.com/pybind/pybind11_bazel
+http_archive(
+    name = "pybind11_bazel",
+    sha256 = "a5666d950c3344a8b0d3892a88dc6b55c8e0c78764f9294e806d69213c03f19d",
+    strip_prefix = "pybind11_bazel-26973c0ff320cb4b39e45bc3e4297b82bc3a6c09",
+    urls = [
+        "http://pai-blade.oss-cn-zhangjiakou.aliyuncs.com/build_deps/pybind11_bazel/26973c0ff320cb4b39e45bc3e4297b82bc3a6c09.zip",
+        "https://github.com/pybind/pybind11_bazel/archive/26973c0ff320cb4b39e45bc3e4297b82bc3a6c09.zip",
+    ],
+)
+
+http_archive(
+  name = "pybind11",
+  build_file = "@pybind11_bazel//:pybind11.BUILD",
+  strip_prefix = "pybind11-2.9.1",
+  urls = ["https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"],
+)
+
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+python_configure(name = "local_config_python")
+
+http_archive(
+    name = "googltest",
+    sha256 = "bc1cc26d1120f5a7e9eb450751c0b24160734e46a02823a573f3c6b6c0a574a7",
+    strip_prefix = "googletest-e2c06aa2497e330bab1c1a03d02f7c5096eb5b0b",
+    urls = [
+        "http://pai-blade.oss-cn-zhangjiakou.aliyuncs.com/build_deps/googletest/e2c06aa2497e330bab1c1a03d02f7c5096eb5b0b.zip",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/googletest/archive/e2c06aa2497e330bab1c1a03d02f7c5096eb5b0b.zip",
+        "https://github.com/google/googletest/archive/e2c06aa2497e330bab1c1a03d02f7c5096eb5b0b.zip",
+    ],
+)
+
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "33a5690733c5cc2ede39cb62ebf89e751f2448e27f20c8b2fbbc7d136b166804",
+    strip_prefix = "rules_foreign_cc-0.5.1",
+    urls = [
+        "http://pai-blade.oss-cn-zhangjiakou.aliyuncs.com/build_deps/rules_foreign_cc/0.5.1.tar.gz",
+        "https://github.com/bazelbuild/rules_foreign_cc/archive/0.5.1.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "85ffff62a4c22a74dbd98d05da6cf40f497344b3dbf1e1ab0a37ab2a1a6ca014",
+    strip_prefix = "rules_docker-0.23.0",
+    urls = [
+        "https://pai-blade.oss-cn-zhangjiakou.aliyuncs.com/build_deps/rules_docker/rules_docker-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/rules_docker/releases/download/v0.23.0/rules_docker-v0.23.0.tar.gz",
+    ],
+)
+
+load("//bazel/torch:repo.bzl", "torch_configure", "torch_pybind11_configure")
+
+torch_configure(name = "local_org_torch")
+
+local_repository(
+    name = "org_torch_blade",
+    path = "../pytorch_blade"
+)
+local_repository(
+    name = "org_mhlo_builder",
+    path = "../mhlo_builder",
+)
+
+local_repository(
+    name = "org_tensorflow",
+    path = "../tf_community",
+)
+
+# Initialize TensorFlow's external dependencies.
+load("@org_tensorflow//tensorflow:workspace3.bzl", "tf_workspace3")
+
+tf_workspace3()
+
+load("@org_tensorflow//tensorflow:workspace2.bzl", "tf_workspace2")
+
+tf_workspace2()
+
+load("@org_tensorflow//tensorflow:workspace1.bzl", "tf_workspace1")
+
+tf_workspace1()
+
+load("@org_tensorflow//tensorflow:workspace0.bzl", "tf_workspace0")
+
+tf_workspace0()

--- a/torch_disc/bazel/torch/repo.bzl
+++ b/torch_disc/bazel/torch/repo.bzl
@@ -11,7 +11,9 @@ def _impl(repo_ctx):
     repo_ctx.symlink(torch_path + "/lib", "lib")
     repo_ctx.symlink(_TORCH_SUBMODULE, "pytorch")
     repo_ctx.symlink(_TORCH_SUBMODULE + "/lazy_tensor_core", "lazy_tensor_core")
-    repo_ctx.symlink(_TORCH_SUBMODULE + "/torch/csrc/lazy", "lazy")
+    repo_ctx.symlink(_TORCH_SUBMODULE + "/torch/csrc/lazy", "ts_include/torch/csrc/lazy")
+    repo_ctx.symlink(_TORCH_SUBMODULE + "/torch/csrc/generic", "ts_include/torch/csrc/generic")
+    repo_ctx.symlink(_TORCH_SUBMODULE + "/lazy_tensor_core/third_party/computation_client", "ts_include/lazy_tensors/computation_client")
 
 torch_configure = repository_rule(
     implementation = _impl,

--- a/torch_disc/bazel/torch/repo.bzl
+++ b/torch_disc/bazel/torch/repo.bzl
@@ -1,0 +1,42 @@
+_TORCH_INSTALL_PATH = "TORCH_BLADE_TORCH_INSTALL_PATH"
+_TORCH_SUBMODULE = "/workspace/torch_disc/pytorch"
+
+def _impl(repo_ctx):
+    torch_path = repo_ctx.os.environ.get(_TORCH_INSTALL_PATH, None)
+    if torch_path == None:
+        fail("Please set the torch library path via env var: {}".format(_TORCH_INSTALL_PATH))
+
+    repo_ctx.symlink(Label("//bazel/torch:torch.BUILD.tpl"), "BUILD")
+    repo_ctx.symlink(torch_path + "/include", "include")
+    repo_ctx.symlink(torch_path + "/lib", "lib")
+    repo_ctx.symlink(_TORCH_SUBMODULE, "pytorch")
+    repo_ctx.symlink(_TORCH_SUBMODULE + "/lazy_tensor_core", "lazy_tensor_core")
+    repo_ctx.symlink(_TORCH_SUBMODULE + "/torch/csrc/lazy", "lazy")
+
+torch_configure = repository_rule(
+    implementation = _impl,
+    local = True,
+    environ = [_TORCH_INSTALL_PATH],
+)
+
+def _symlink_files(repo_ctx, fpaths):
+    for f in fpaths:
+        fpath = repo_ctx.path(f)
+        fname = fpath.basename
+        repo_ctx.symlink(fpath, fname)
+
+def _impl_pybind11(repo_ctx):
+    torch_path = repo_ctx.os.environ.get(_TORCH_INSTALL_PATH, None)
+    if torch_path == None:
+        fail("Please set the torch library path via env var: {}".format(_TORCH_INSTALL_PATH))
+
+    pybind11_files = repo_ctx.path(torch_path + "/include/pybind11").readdir()
+    _symlink_files(repo_ctx, pybind11_files)
+    repo_ctx.symlink(repo_ctx.attr.build_file, "BUILD")
+
+torch_pybind11_configure = repository_rule(
+    implementation = _impl_pybind11,
+    local = True,
+    attrs = {"build_file": attr.label(allow_single_file = True)},
+    environ = [_TORCH_INSTALL_PATH],
+)

--- a/torch_disc/bazel/torch/torch.BUILD.tpl
+++ b/torch_disc/bazel/torch/torch.BUILD.tpl
@@ -1,0 +1,113 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@local_config_cuda//cuda:build_defs.bzl",
+    "if_cuda_is_configured",
+)
+
+cc_library(
+    name = "libtorch",
+    srcs = [
+            "lib/libtorch.so",
+            "lib/libtorch_cpu.so",
+            "lib/libtorch_global_deps.so",
+        ] + glob(
+            ["lib/libtorch_cuda.so","lib/libtensorpipe.so",]),
+    hdrs = glob(
+        [
+            "include/torch/**/*.h",
+            "include/torch/csrc/api/include/**/*.h",
+        ],
+    ),
+    includes = [
+        "include",
+        "include/torch/csrc/api/include/",
+    ],
+    deps = [
+        ":ATen",
+        ":c10_cuda",
+    ],
+)
+
+cc_library(
+    name = "c10_cuda",
+    srcs = glob(["lib/libc10_cuda.so"]),
+    hdrs = glob([
+        "include/c10/**/*.h",
+    ]),
+    strip_include_prefix = "include",
+    deps = [
+        ":c10",
+    ] + if_cuda_is_configured(
+      ["@local_config_cuda//cuda:cuda_headers",
+      "@local_config_cuda//cuda:cudart"]
+    ),
+)
+
+
+cc_library(
+    name = "c10",
+    srcs = ["lib/libc10.so"],
+    hdrs = glob([
+        "include/c10/**/*.h",
+    ]),
+    strip_include_prefix = "include",
+)
+
+cc_library(
+    name = "ATen",
+    hdrs = glob([
+        "include/ATen/**/*.h",
+    ]),
+    strip_include_prefix = "include",
+)
+
+cc_library(
+    name = "torch_python",
+    srcs = [
+            "lib/libtorch_python.so",
+        ],
+    hdrs = glob([
+        "include/pybind11/**/*.h",
+    ]),
+    deps = [
+        ":libtorch",
+    ],
+    strip_include_prefix = "include",
+)
+
+cc_library(
+    name = "ltc_ts_backend",
+    srcs = glob(
+        [
+            "lazy_tensor_core/lazy_tensor_core/**/*.cpp",
+            "lazy/python/*.cpp",
+            "lazy_tensor_core/third_party/computation_client/*.cc",
+        ],
+        exclude=[
+            "lazy_tensor_core/test/**/*",
+            "lazy_tensor_core/**/init_python_bindings.cpp",
+            "lazy/**/test_*.cpp"
+        ],
+        allow_empty=False
+    ),
+    hdrs = glob(
+        [
+            "lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/*.h",
+            "lazy_tensor_core/third_party/computation_client/*.h",
+            "lazy/**/*.h",
+        ],
+        allow_empty=False
+    ),
+    includes =[
+        "pytorch/torch/include",
+        "pytorch/torch/csrc",
+        "lazy_tensor_core",
+        "include",
+        "include/torch/csrc/api/include/",
+    ],
+    deps = [
+         "@local_config_python//:python_headers",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/torch_disc/bazel/torch/torch.BUILD.tpl
+++ b/torch_disc/bazel/torch/torch.BUILD.tpl
@@ -81,13 +81,13 @@ cc_library(
     srcs = glob(
         [
             "lazy_tensor_core/lazy_tensor_core/**/*.cpp",
-            "lazy/python/*.cpp",
+            "ts_include/torch/csrc/lazy/python/*.cpp",
             "lazy_tensor_core/third_party/computation_client/*.cc",
         ],
         exclude=[
             "lazy_tensor_core/test/**/*",
             "lazy_tensor_core/**/init_python_bindings.cpp",
-            "lazy/**/test_*.cpp"
+            "ts_include/torch/csrc/lazy/**/test_*.cpp"
         ],
         allow_empty=False
     ),
@@ -95,7 +95,7 @@ cc_library(
         [
             "lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/*.h",
             "lazy_tensor_core/third_party/computation_client/*.h",
-            "lazy/**/*.h",
+            "ts_include/torch/csrc/lazy/**/*.h",
         ],
         allow_empty=False
     ),

--- a/torch_disc/bazel/torch/torch.BUILD.tpl
+++ b/torch_disc/bazel/torch/torch.BUILD.tpl
@@ -105,6 +105,7 @@ cc_library(
         "lazy_tensor_core",
         "include",
         "include/torch/csrc/api/include/",
+        "ts_include"
     ],
     deps = [
          "@local_config_python//:python_headers",

--- a/torch_disc/bazel_build.py
+++ b/torch_disc/bazel_build.py
@@ -1,0 +1,115 @@
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import errno
+import subprocess
+import sys
+
+cwd = os.path.dirname(os.path.abspath(__file__))
+
+def get_fullpath_or_create(dir_path):
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    return os.path.abspath(dir_path)
+
+def _make_executable(path):
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    os.chmod(path, mode)
+
+def _symlink_force(target, link_name):
+    try:
+        os.symlink(target, link_name)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            os.remove(link_name)
+            os.symlink(target, link_name)
+        else:
+            raise e
+
+class BazelBuild():
+    def __init__(self, torch_version, torch_dir):
+        self.torch_version = torch_version
+        self.targets = [
+            "//torch_disc:_torch_disc.so",
+        ]
+        torch_major_version, torch_minor_version = self.torch_version.split(".")[:2]
+        self.extra_opts = [
+            "--copt=-DPYTORCH_MAJOR_VERSION={}".format(torch_major_version),
+            "--copt=-DPYTORCH_MINOR_VERSION={}".format(torch_minor_version),
+            "--action_env TORCH_BLADE_TORCH_INSTALL_PATH={}".format(torch_dir),
+            # Workaroud issue: https://github.com/bazelbuild/bazel/issues/10327
+            "--action_env BAZEL_LINKLIBS=-lstdc++"
+        ]
+
+        self.shell_setting = "set -e; set -o pipefail; "
+        self.build_cmd = "bazel build"
+
+    def fix_generated_code(self):
+        cmd = [os.path.join("scripts", "pytorch_patch.sh")]
+        if subprocess.call(cmd) != 0:
+            print(
+                'Failed to correct ATEN bindins head files: {}'.format(cmd),
+                file=sys.stderr)
+            sys.exit(1)
+
+    def run(self, extdir=None, srcdir=None, build_temp=None):
+        self.fix_generated_code()
+        srcdir = get_fullpath_or_create(
+            srcdir or os.path.dirname(os.path.abspath(__file__))
+        )
+        extdir = get_fullpath_or_create(extdir or "build/temp")
+
+        env = os.environ.copy()
+        ld_library_path = ":".join([env.get("LD_LIBRARY_PATH", "")])
+        env["LD_LIBRARY_PATH"] = ld_library_path
+
+        bazel_cmd = " ".join(
+            [self.shell_setting, self.build_cmd]
+            + self.extra_opts
+        )
+        with open("debug_bazel.sh", "w") as f:
+            f.write("#!/bin/bash\n")
+            f.write("export LD_LIBRARY_PATH={}\n".format(ld_library_path))
+            f.write("export GCC_HOST_COMPILER_PATH={}\n".format(env.get("GCC_HOST_COMPILER_PATH", "")))
+            f.write(bazel_cmd + " $@")
+        _make_executable("debug_bazel.sh")
+
+        bazel_cmd = " ".join([bazel_cmd] + self.targets)
+
+        subprocess.check_call(
+            bazel_cmd, shell=True, env=env, executable="/bin/bash"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Bazel build TorchBlade")
+    parser.add_argument(
+        "--torch_version", type=str, required=True, help="The version of torch"
+    )
+    parser.add_argument(
+        "--torch_dir", type=str, required=True, help="The directory where torch located"
+    )
+    parser.add_argument(
+        "--cuda_version", type=str, default=None, help="The version of cuda toolkit"
+    )
+    parser.add_argument("--cxx11", action="store_true", help="Use c++ cxx11 abi")
+
+    args = parser.parse_args()
+
+    build = BazelBuild(
+        args.torch_dir, args.torch_version, args.cuda_version, cxx11_abi=args.cxx11
+    )
+    build.write_version_file(os.path.join(cwd, "version.txt"))
+    srcdir = os.path.dirname(os.path.abspath(__file__))
+    build.run(extdir=os.path.join(srcdir, "torch_blade"))

--- a/torch_disc/disc_demo.py
+++ b/torch_disc/disc_demo.py
@@ -1,0 +1,59 @@
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision import datasets, transforms
+import torch.optim as optim
+from torch.optim.lr_scheduler import StepLR
+import _torch_disc as disc
+disc._ltc_init_disc_backend()
+
+class SimpleNet(nn.Module):
+    def __init__(self):
+        super(SimpleNet, self).__init__()
+        self.fc = nn.Linear(784, 10)
+
+    def forward(self, x):
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+device = 'lazy'
+model = SimpleNet().to(device)
+
+transform=transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+        ])
+
+ds = datasets.MNIST('../data', train=True, download=True,
+                    transform=transform)
+
+train_loader = torch.utils.data.DataLoader(ds, batch_size=32, num_workers=1, pin_memory=True, shuffle=True)
+
+optimizer = optim.Adadelta(model.parameters(), lr=1.0)
+
+scheduler = StepLR(optimizer, step_size=1, gamma=0.7)
+
+model.train().to(device)
+
+data, target = next(iter(train_loader))
+data, target = data.to(device), target.to(device)
+
+optimizer.zero_grad()
+output = model(data)
+loss = F.nll_loss(output, target)
+loss.backward()
+optimizer.step()
+#disc.mark_step()

--- a/torch_disc/scripts/pytorch_patch.sh
+++ b/torch_disc/scripts/pytorch_patch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+TS_BACKEND_DIR=pytorch/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend
+grep -rnw ${TS_BACKEND_DIR} -e "LazyNativeFunctions.h" | awk -F':' '{print $1}' | xargs sed -i 's/.*LazyNativeFunctions.h.*/#include <lazy_tensor_core\/csrc\/ts_backend\/LazyNativeFunctions.h>/g'
+grep -rnw ${TS_BACKEND_DIR} -e "LazyLazyIr.h" | awk -F':' '{print $1}' | xargs sed -i 's/.*LazyLazyIr.h.*/#include <lazy_tensor_core\/csrc\/ts_backend\/LazyLazyIr.h>/g'
+grep -rnw ${TS_BACKEND_DIR} -e "ts_node.h" | awk -F':' '{print $1}' | xargs sed -i 's/.*ts_node.h.*/#include <lazy\/ts_backend\/ts_node.h>/g'
+grep -rnw ${TS_BACKEND_DIR} -e "shape_inference.h" | awk -F':' '{print $1}' | xargs sed -i 's/.*shape_inference.h.*/#include <lazy\/core\/shape_inference.h>/g'

--- a/torch_disc/setup.py
+++ b/torch_disc/setup.py
@@ -1,0 +1,55 @@
+# Copyright 2022 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import print_function
+import os
+import bazel_build
+import torch
+
+from setuptools import setup, find_packages
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+
+builder = bazel_build.BazelBuild(
+    torch.version.__version__,
+    os.path.dirname(torch.__file__))
+class TorchBladeExtension(Extension):
+    def __init__(self, name, sourcedir=""):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+class TorchBladeBuild(build_ext):
+    def run(self):
+        # version.txt Would be package into C++ SDK by CPACK
+        for ext in self.extensions:
+            extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+            builder.run(extdir=extdir, srcdir=ext.sourcedir, build_temp="build/temp")
+
+
+setup(
+    name='torch_disc',
+    version='0.1',
+    description='DISC backend implementation for Lazy tensors Core',
+    url='https://github.com/alibaba/BladeDISC',
+    author='DISC Dev Team',
+    author_email='disc-dev@alibaba-inc.com',
+    # Exclude the build files.
+    packages=find_packages(exclude=['build']),
+    ext_modules=[TorchBladeExtension("torch_disc._torch_disc")],
+    cmdclass=dict(build_ext=TorchBladeBuild),
+    package_data = {
+        'torch_disc': [
+            'lib/*.so*',
+    ]},
+    data_files=[]
+)

--- a/torch_disc/torch_disc/BUILD
+++ b/torch_disc/torch_disc/BUILD
@@ -1,0 +1,21 @@
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
+
+pybind_library (
+  name = "torch_disc_pybind11",
+  srcs = ["csrc/init_python_bindings.cpp"],
+  deps = [
+    "@local_org_torch//:ltc_ts_backend",
+    # TODO(yancey1989): depends on one module
+    "@org_torch_blade//src/compiler/mlir/converters:torch_blade_mhlo_converter",
+    "@org_torch_blade//src/compiler/mlir/converters/impl:torch_blade_mhlo_converter_impl",
+    "@org_torch_blade//src/compiler/jit:torch_blade_jit",
+  ]
+)
+
+pybind_extension(
+    name = "_torch_disc",
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    deps = [
+        ":torch_disc_pybind11",
+    ],
+)

--- a/torch_disc/torch_disc/csrc/init_python_bindings.cpp
+++ b/torch_disc/torch_disc/csrc/init_python_bindings.cpp
@@ -1,0 +1,87 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <c10/core/Device.h>
+#include <c10/util/Optional.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/python/pybind.h>
+#include <torch/csrc/lazy/backend/backend_device.h>
+#include <torch/csrc/lazy/backend/backend_interface.h>
+#include <torch/csrc/lazy/core/helpers.h>
+#include <torch/csrc/lazy/core/ir_dump_util.h>
+#include <torch/csrc/lazy/core/ir_util.h>
+#include <torch/csrc/lazy/core/lazy_graph_executor.h>
+#include <torch/csrc/lazy/core/metrics.h>
+#include <torch/csrc/lazy/core/multi_wait.h>
+#include <torch/csrc/lazy/core/tensor_impl.h>
+#include <torch/csrc/lazy/core/tensor_util.h>
+#include <torch/csrc/lazy/core/thread_pool.h>
+#include <torch/csrc/lazy/core/util.h>
+#include <torch/csrc/lazy/python/python_util.h>
+#include <torch/csrc/utils/cuda_lazy_init.h>
+
+#include <vector>
+
+// mhlo conversion
+#include <torch/csrc/lazy/ts_backend/ts_lowering_context.h>
+
+#include "compiler/mlir/converters/mhlo_conversion.h"
+#include "lazy_tensor_core/csrc/ts_backend/backend_impl.h"
+
+namespace torch_disc {
+namespace {
+
+torch::lazy::BackendDevice GetDeviceOrCurrent(const std::string& device_str) {
+  if (device_str.empty()) {
+    return torch::lazy::BackendDevice();
+  }
+  return torch::lazy::atenDeviceToBackendDevice(c10::Device(device_str));
+}
+
+std::string GetLazyTensorsDump(
+    const std::vector<torch::lazy::LazyTensor>& tensors,
+    const std::function<std::string(c10::ArrayRef<torch::lazy::Node*>)>&
+        coverter) {
+  std::vector<torch::lazy::Node*> nodes;
+  std::vector<torch::lazy::Value> values;
+  for (auto& tensor : tensors) {
+    values.push_back(tensor.GetIrValue());
+    nodes.push_back(values.back().node.get());
+  }
+  return coverter(nodes);
+}
+
+std::string GetBackendGraph() {
+  auto device = GetDeviceOrCurrent("");
+  auto tensors = torch::lazy::LazyGraphExecutor::Get()->GetLiveTensors(&device);
+  return torch::lazy::LazyGraphExecutor::Get()->DumpBackendComputation(tensors);
+}
+
+void InitLtcModuleBindings(py::module m) {
+  m.def("_ltc_init_disc_backend",
+        []() { torch_lazy_tensors::compiler::InitTorchScriptBackend(); });
+  m.def("_disc_backend_graph", &GetBackendGraph);
+  m.def("_ltc_dump_graph", []() {
+    auto device = GetDeviceOrCurrent("");
+    auto tensors =
+        torch::lazy::LazyGraphExecutor::Get()->GetLiveTensors(&device);
+    auto coverter = [](c10::ArrayRef<torch::lazy::Node*> nodes) {
+      return torch::lazy::DumpUtil::ToDot(nodes);
+    };
+    return GetLazyTensorsDump(tensors, coverter);
+  });
+}
+void InitLtcBindings(py::module m) { InitLtcModuleBindings(m); }
+}  // namespace
+
+}  //  namespace torch_disc
+
+PYBIND11_MODULE(_torch_disc, m) { torch_disc::InitLtcBindings(m); }


### PR DESCRIPTION
This PR builds the TorchDISC pybind library  `_torch_disc.so` with Torch LTC, Torch Blade, and official PyTorch source code.
And also add a CI job to test it with a rough way: `import _torch_disc`.

The CI job includes two parts to reduce the CI time:
1. building devel docker: install PyTorch with `lazy_tensor_staging` branch from source code.
2. build and test torch-disc with the devel image from step1.

Develops can build from zero with the guide https://github.com/alibaba/BladeDISC/blob/de3a386114dfcd6038c16c9fbe0737c0a6c5f6ef/torch_disc/README.md