### PR TITLE
[Torch] improve TensorRT fallback & dynamic

### DIFF
--- a/pytorch_blade/src/compiler/backends/backend_input_outputs.h
+++ b/pytorch_blade/src/compiler/backends/backend_input_outputs.h
@@ -43,6 +43,7 @@ struct DynamicRanges {
   SerialType Serialize() const;
   static DynamicRanges Deserialize(const SerialType& serialized);
   bool Validate(int);
+  bool InRange(const ShapesType& shapes);
   std::string GetShapeString() const;
 };
 

--- a/pytorch_blade/src/compiler/backends/engine_class.cpp
+++ b/pytorch_blade/src/compiler/backends/engine_class.cpp
@@ -65,9 +65,11 @@ torch::List<torch::Tensor> EngineClass::Execute(
     } catch (const std::runtime_error& error) {
       const auto& enable_fallback =
           std::getenv("TORCH_BLADE_ENABLE_RUNTIME_FALLBACK");
-      if (enable_fallback == nullptr ||
+
+      bool should_fallback = enable_fallback == nullptr ||
           std::strcmp(enable_fallback, "true") == 0 ||
-          std::strcmp(enable_fallback, "on") == 0) {
+          std::strcmp(enable_fallback, "on") == 0;
+      if (should_fallback) {
         outputs = Fallback(inputs);
       } else {
         throw error;

--- a/pytorch_blade/src/compiler/backends/engine_interface.h
+++ b/pytorch_blade/src/compiler/backends/engine_interface.h
@@ -56,6 +56,11 @@ class EngineInterface {
 
   virtual torch::List<torch::Tensor> Execute(
       const torch::List<torch::Tensor>& inputs) = 0;
+
+  virtual bool ShouldFallback(const torch::List<torch::Tensor>& inputs) {
+    return false;
+  }
+
   static std::shared_ptr<EngineInterface> CreateEngine(const State&);
 };
 

--- a/pytorch_blade/src/compiler/tensorrt/bridge/tensorrt_logger.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/bridge/tensorrt_logger.cpp
@@ -17,15 +17,23 @@
 namespace torch {
 namespace blade {
 TensorrtLogger::TensorrtLogger() : log_level_(Severity::kERROR) {
-  const auto trt_log_lvl_cstr = std::getenv("TORCH_BLADE_TRT_LOG_LEVEL");
+  const char* torch_blade_debug = std::getenv("TORCH_BLADE_DEBUG_LOG");
+  const char* trt_log_lvl_cstr = std::getenv("TORCH_BLADE_TRT_LOG_LEVEL");
+
   if (trt_log_lvl_cstr == nullptr) {
-    return;
+    if (torch_blade_debug != nullptr) {
+      trt_log_lvl_cstr = "ERROR";
+    } else {
+      return;
+    }
   }
+
   log_enable_ = true;
   std::string trt_log_lvl_str = std::string(trt_log_lvl_cstr);
   std::for_each(trt_log_lvl_str.begin(), trt_log_lvl_str.end(), [](char& c) {
     c = ::toupper(c);
   });
+
   if (trt_log_lvl_str == "FATAL") {
     log_level_ = Severity::kINTERNAL_ERROR;
   } else if (trt_log_lvl_str == "ERROR") {

--- a/pytorch_blade/src/compiler/tensorrt/bridge/tensorrt_onnx_parser.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/bridge/tensorrt_onnx_parser.cpp
@@ -96,6 +96,7 @@ TrtUniquePtr<nvinfer1::ICudaEngine> TensorrtOnnxParser::BuildEngine(
         if (!each_dynamic_range.Validate(n_trt_input)) {
           LOG(ERROR) << "Get a invalid dynamic setting, skip this:";
           LOG(ERROR) << each_dynamic_range.GetShapeString();
+          return nullptr;
         }
         nvinfer1::IOptimizationProfile* profile =
             context.builder->createOptimizationProfile();
@@ -116,6 +117,7 @@ TrtUniquePtr<nvinfer1::ICudaEngine> TensorrtOnnxParser::BuildEngine(
                 inp_name, nvinfer1::OptProfileSelector::kOPT, inp_dims_opt);
           }
         }
+        TORCH_CHECK(profile->isValid());
         config->addOptimizationProfile(profile);
       }
     }

--- a/pytorch_blade/src/compiler/tensorrt/pybind_functions.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/pybind_functions.cpp
@@ -41,9 +41,10 @@ std::shared_ptr<backends::EngineState> cvt_onnx_to_tensorrt(
       state->backend_name = GetBackendName();
       out->destroy();
     }
+    return state;
+  } else {
+    return nullptr;
   }
-
-  return state;
 }
 
 void initTensorRTBindings(py::module& m) {

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
@@ -32,6 +32,7 @@ class TRTContext {
   TRTContext(std::shared_ptr<State> state);
   std::string SerializeAsString() const;
   torch::List<torch::Tensor> Execute(const torch::List<torch::Tensor>&);
+  bool IsInRange(const torch::List<torch::Tensor>& inputs);
 
  private:
   // Setup binding buffers to the input/output blobs on the GPU.
@@ -58,7 +59,6 @@ class TRTContext {
       const torch::List<torch::Tensor>& inputs);
   void UpdateProfileIfNeed(const torch::List<torch::Tensor>& inputs);
   bool IsInRange(const torch::List<torch::Tensor>&, int64_t);
-
   int64_t tensorrt_device_;
   mutable std::mutex lock_;
   TrtUniquePtr<nvinfer1::ICudaEngine> engine_;

--- a/pytorch_blade/src/pybind.cpp
+++ b/pytorch_blade/src/pybind.cpp
@@ -69,7 +69,8 @@ void initModules<COMMUNITY_VERSION_ID>(py::module& m) {
       .def_readwrite("min_shape", &DynamicRanges::min_shape)
       .def_readwrite("max_shape", &DynamicRanges::max_shape)
       .def_readwrite("dynamic_setting", &DynamicRanges::dynamic_setting)
-      .def_readwrite("opt_shapes", &DynamicRanges::opt_shapes);
+      .def_readwrite("opt_shapes", &DynamicRanges::opt_shapes)
+      .def("validate", &DynamicRanges::Validate);
 
   py::class_<TensorInfo>(backends, "TensorInfo")
       .def(py::init<>())

--- a/pytorch_blade/tests/mlir/test_disc_reduction.py
+++ b/pytorch_blade/tests/mlir/test_disc_reduction.py
@@ -15,6 +15,7 @@ import unittest
 from tests.mlir.testing_utils import DiscTestCase
 from torch_blade import utils
 
+
 class TestDiscReduction(DiscTestCase):
     def _test_reduction(self, reduce_func, dtype=None):
         if dtype in {torch.int32, torch.int64}:
@@ -88,8 +89,10 @@ class TestDiscReduction(DiscTestCase):
 
         self._test_reduction(sum_func)
 
-    @skipIf(utils.torch_version_number() >= utils.parse_version("1.11.0"),
-            "mean(): input dtype should be either floating point or complex dtypes.")
+    @unittest.skipIf(
+        utils.torch_version_number() >= utils.parse_version("1.11.0"),
+        "mean(): input dtype should be either floating point or complex dtypes.",
+    )
     def test_cvt_to_disc_mean_dtype_i32(self):
         @torch.jit.script
         def sum_func(x):

--- a/pytorch_blade/tests/mlir/test_disc_reduction.py
+++ b/pytorch_blade/tests/mlir/test_disc_reduction.py
@@ -13,7 +13,7 @@ import torch
 import unittest
 
 from tests.mlir.testing_utils import DiscTestCase
-
+from torch_blade import utils
 
 class TestDiscReduction(DiscTestCase):
     def _test_reduction(self, reduce_func, dtype=None):
@@ -88,6 +88,8 @@ class TestDiscReduction(DiscTestCase):
 
         self._test_reduction(sum_func)
 
+    @skipIf(utils.torch_version_number() >= utils.parse_version("1.11.0"),
+            "mean(): input dtype should be either floating point or complex dtypes.")
     def test_cvt_to_disc_mean_dtype_i32(self):
         @torch.jit.script
         def sum_func(x):

--- a/pytorch_blade/torch_blade/config.py
+++ b/pytorch_blade/torch_blade/config.py
@@ -57,8 +57,8 @@ def _check_dynamic_ranges(val):
 def _validate_dynamic_ranges(val):
     if isinstance(val, dict):
         val = [val]
-    # for v in val:
-    #     _check_dynamic_ranges(v)
+    for v in val:
+        _check_dynamic_ranges(v)
     return val
 
 

--- a/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
+++ b/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
@@ -61,11 +61,11 @@ def _build_onnx_engine(subgraph, engine_build_func, q_info=None, dynamic_setting
         max_shape = dynamic_shapes[0].max_shape
         opt_shapes = dynamic_shapes[0].opt_shapes
         logger.info(
-            "Dynamic shape settings: \n"
-            "min_shape: {str(min_shape)},\n"
-            "max_shape: {str(max_shape)},\n"
-            "opt_shapes: {str(opt_shapes)},\n"
-            "dynamic_axes: {str(dynamic_axes)}"
+            "Dynamic shape settings, "
+            f"min_shape: {str(min_shape)}, "
+            f"max_shape: {str(max_shape)}, "
+            f"opt_shapes: {str(opt_shapes)}, "
+            f"dynamic_axes: {str(dynamic_axes)}."
         )
 
     dyn_proto = pass_manager._export_onnx(graph, dynamic_axes)

--- a/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
+++ b/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
@@ -57,6 +57,16 @@ def _build_onnx_engine(subgraph, engine_build_func, q_info=None, dynamic_setting
     if dynamic_settings is not None:
         dynamic_shapes = dynamic_settings
         dynamic_axes = dynamic_shapes[0].dynamic_setting
+        min_shape = dynamic_shapes[0].min_shape
+        max_shape = dynamic_shapes[0].max_shape
+        opt_shapes = dynamic_shapes[0].opt_shapes
+        logger.info(
+            "Dynamic shape settings: \n"
+            "min_shape: {str(min_shape)},\n"
+            "max_shape: {str(max_shape)},\n"
+            "opt_shapes: {str(opt_shapes)},\n"
+            "dynamic_axes: {str(dynamic_axes)}"
+        )
 
     dyn_proto = pass_manager._export_onnx(graph, dynamic_axes)
     onnx_model = onnx.load_from_string(dyn_proto)
@@ -68,6 +78,7 @@ def _build_onnx_engine(subgraph, engine_build_func, q_info=None, dynamic_setting
     state.model_proto = dyn_proto
     return engine_build_func(dyn_proto, state, dynamic_shapes, q_val)
 
+
 def _subgraph_to_bytes(subgraph, group_name):
     fallback_module = utils.subgraph_to_module(subgraph, group_name)
     m_bytes = BytesIO()
@@ -75,9 +86,7 @@ def _subgraph_to_bytes(subgraph, group_name):
     return m_bytes.getvalue()
 
 
-def _register_onnx_engine(
-    module, subgraph, state, group_name, disable_fallback=False
-):
+def _register_onnx_engine(module, subgraph, state, group_name, disable_fallback=False):
     if disable_fallback:
         state.model_proto = ""
 

--- a/pytorch_blade/torch_blade/onnx_backends/backend_testbed.py
+++ b/pytorch_blade/torch_blade/onnx_backends/backend_testbed.py
@@ -47,6 +47,7 @@ class OnnxBackendChecker:
             graph, _ = pass_manager._jit_pass_lower_to_onnx(graph)
             if not self._check_concrete_shape(graph):
                 return False
+
             proto = pass_manager._export_onnx(graph, {})
             onnx_model = onnx.load_from_string(proto)
             # pylint: disable=maybe-no-member

--- a/pytorch_blade/torch_blade/utils.py
+++ b/pytorch_blade/torch_blade/utils.py
@@ -251,3 +251,9 @@ def dump_graph_and_code(module, fpath):
 
     with open(fpath + ".code.py", "w") as out:
         out.write(str(module.forward.code))
+
+def disable_pytorch_jit():
+    torch._C._jit_set_profiling_executor(False)
+    torch._C._jit_set_profiling_mode(False)
+    torch._C._jit_set_texpr_fuser_enabled(False)
+    torch._C._jit_set_nvfuser_enabled(False)


### PR DESCRIPTION
This pull request mainly improves dynamic shape optimization and fallback of TensorRT.

Previously, we only support user configuration of dynamic shapes by setting min/max/opts shapes, which are lists of ints.
And TorchBlade will automatically generate test data according to the input shapes. With the test data, TorchBlade can trace the intermediate tensors' shapes and data types which is valuable to the optimization.

1. In this PR we would like to support inferencing dynamic shape setting with user input test data. Because some network's computations could be different according to different inputs, such as detection and decoder networks. And a randomly generated test data might output empty results.

2. In this PR we improve the fallback performance of TensorRT as well.
3. In this PR we added some debug utilities.