### PR TITLE
[bugfix] remove `_output_shapes` attr to avoid crash when loading graphdef to mlir

### DIFF
--- a/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
+++ b/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
@@ -792,14 +792,14 @@ Status Encapsulator::Subgraph::RecordArg(
     DataType dtype = edge->dst()->input_type(edge->dst_input());
     builder.Attr("T", dtype);
     builder.Attr("index", arg_index);
-    if (src_node->attrs().Find("_output_shapes") != nullptr) {
-      const auto& output_shape =
-          src_node->attrs().Find("_output_shapes")->shape();
-      builder.Attr("_output_shapes", PartialTensorShape(output_shape));
-      VLOG(2) << "Adding _output_shapes info to node: "
-              << absl::StrCat(src_node->name(), "_", src_slot, "_arg");
-      VLOG(2) << "Shape info: " << output_shape.DebugString();
-    }
+    // if (src_node->attrs().Find("_output_shapes") != nullptr) {
+    //   const auto& output_shape =
+    //       src_node->attrs().Find("_output_shapes")->shape();
+    //   builder.Attr("_output_shapes", PartialTensorShape(output_shape));
+    //   VLOG(2) << "Adding _output_shapes info to node: "
+    //           << absl::StrCat(src_node->name(), "_", src_slot, "_arg");
+    //   VLOG(2) << "Shape info: " << output_shape.DebugString();
+    // }
     Status s = builder.Finalize(&arg_def);
     if (!s.ok()) return s;
 
@@ -1482,6 +1482,7 @@ Status Encapsulator::CopySubgraphNodes(
     image->ClearAttr(group_attribute_);
     image->ClearAttr("_grappler:ArithmeticOptimizer:MinimizeBroadcasts");
     image->ClearAttr("_grappler:ArithmeticOptimizer:AddOpsRewriteStage");
+    image->ClearAttr("_output_shapes");
     (*node_images)[node] = image;
   }
   return Status::OK();

--- a/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
+++ b/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
@@ -792,6 +792,10 @@ Status Encapsulator::Subgraph::RecordArg(
     DataType dtype = edge->dst()->input_type(edge->dst_input());
     builder.Attr("T", dtype);
     builder.Attr("index", arg_index);
+    // `tao_compiler_main` failed to load graphdef with ops having
+    // `_output_shapes`. Just remote such attribute here as a workaround to fix
+    // such problem.
+    //
     // if (src_node->attrs().Find("_output_shapes") != nullptr) {
     //   const auto& output_shape =
     //       src_node->attrs().Find("_output_shapes")->shape();
@@ -1482,6 +1486,9 @@ Status Encapsulator::CopySubgraphNodes(
     image->ClearAttr(group_attribute_);
     image->ClearAttr("_grappler:ArithmeticOptimizer:MinimizeBroadcasts");
     image->ClearAttr("_grappler:ArithmeticOptimizer:AddOpsRewriteStage");
+    // `tao_compiler_main` failed to load graphdef with ops having
+    // `_output_shapes`. Just remote such attribute here as a workaround to fix
+    // such problem.
     image->ClearAttr("_output_shapes");
     (*node_images)[node] = image;
   }

--- a/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
+++ b/tao/tao_bridge/passes/tao_encapsulate_subgraphs_pass.cc
@@ -793,7 +793,7 @@ Status Encapsulator::Subgraph::RecordArg(
     builder.Attr("T", dtype);
     builder.Attr("index", arg_index);
     // `tao_compiler_main` failed to load graphdef with ops having
-    // `_output_shapes`. Just remote such attribute here as a workaround to fix
+    // `_output_shapes`. Just remove such attribute here as a workaround to fix
     // such problem.
     //
     // if (src_node->attrs().Find("_output_shapes") != nullptr) {
@@ -1487,7 +1487,7 @@ Status Encapsulator::CopySubgraphNodes(
     image->ClearAttr("_grappler:ArithmeticOptimizer:MinimizeBroadcasts");
     image->ClearAttr("_grappler:ArithmeticOptimizer:AddOpsRewriteStage");
     // `tao_compiler_main` failed to load graphdef with ops having
-    // `_output_shapes`. Just remote such attribute here as a workaround to fix
+    // `_output_shapes`. Just remove such attribute here as a workaround to fix
     // such problem.
     image->ClearAttr("_output_shapes");
     (*node_images)[node] = image;


### PR DESCRIPTION
`tao_compiler_main` failed to load graphdef with ops having `_output_shapes`. Just remote such attribute here as a workaround to fix such problem.
