### PR TITLE
Fix cpu demo crash on aarch64 platform

### DIFF
--- a/docker/dev/Dockerfile.aarch64
+++ b/docker/dev/Dockerfile.aarch64
@@ -98,8 +98,8 @@ RUN mkdir -p ~/.pip && \
 
 RUN pip3 install --upgrade pip
 
-COPY docker/scripts/install-python.sh /install/scripts/install-python.sh
-RUN bash /install/scripts/install-python.sh
+COPY docker/scripts/install-python-aarch64.sh /install/scripts/install-python-aarch64.sh
+RUN bash /install/scripts/install-python-aarch64.sh
 
 RUN chmod a+x /usr/local/bin/bazel
 

--- a/docker/runtime/Dockerfile.pytorch.aarch64
+++ b/docker/runtime/Dockerfile.pytorch.aarch64
@@ -5,4 +5,5 @@ ARG WHEEL_FILE=torch_blade*.whl
 
 ADD ./build/${WHEEL_FILE}  /install/python/
 
-RUN pip install /install/python/${WHEEL_FILE}
+RUN source /opt/venv_disc/bin/activate && \
+    pip install /install/python/${WHEEL_FILE}

--- a/docker/runtime/Dockerfile.tf.aarch64
+++ b/docker/runtime/Dockerfile.tf.aarch64
@@ -6,4 +6,5 @@ ARG WHEEL_FILE=blade_disc*.whl
 ADD ./build/${WHEEL_FILE}  /install/python/
 ADD ./build/disc-replay-main /usr/bin/disc-replay-main
 
-RUN pip install /install/python/${WHEEL_FILE}
+RUN source /opt/venv_disc/bin/activate && \
+    pip install /install/python/${WHEEL_FILE}

--- a/docker/scripts/install-python-aarch64.sh
+++ b/docker/scripts/install-python-aarch64.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2021 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -ex
+python3 -m pip install virtualenv numpy
+DISC_VENV=/opt/venv_disc
+
+function install_venv() {
+  python3 -m virtualenv ${DISC_VENV}
+  source ${DISC_VENV}/bin/activate
+  # TODO(disc): tensorflow-aarch64 wheel is not compatible with `libtao_ops.so`.
+  # Thus we use the wheel package provided by the ARM:
+  #   https://github.com/ARM-software/Tool-Solutions/tree/master/docker/tensorflow-aarch64
+  # See #244 for more details.
+  # if [[ ! -z "${DISC_HOST_TF_VERSION}" ]]; then
+  #   echo "install TensorFlow: "${DISC_HOST_TF_VERSION} "..."
+  #   pip install -q ${DISC_HOST_TF_VERSION}
+  # fi
+  pip install https://hlomodule.oss-cn-zhangjiakou.aliyuncs.com/bladedisc/aarch64/tensorflow-2.8.0-cp38-cp38-linux_aarch64.whl
+
+  pip install pytest pytest-forked
+  deactivate
+}
+
+install_venv

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -52,8 +52,4 @@ cp tao/dist/blade_disc*.whl ./build
 cp tf_community/bazel-bin/tensorflow/compiler/mlir/disc/tools/disc-replay/disc-replay-main ./build/
 
 # test example models
-arch=`uname -p`
-if [[ $arch == "x86_64" ]]; then
-  # TODO(disc): figure out the root cause of failure on aarch64
-  source ${SCRIPT_DIR}/test_cpu_examples.sh
-fi
+source ${SCRIPT_DIR}/test_cpu_examples.sh

--- a/scripts/ci/test_cpu_examples.sh
+++ b/scripts/ci/test_cpu_examples.sh
@@ -12,7 +12,7 @@
 set -ex
 if [ ! -z "$CPU_ONLY" ]; then
   # install disc python wheel
-  python -m virtualenv venv && source venv/bin/activate
+  source /opt/venv_disc/bin/activate
   python -m pip install ./build/blade_disc*.whl
 
   pushd examples/TensorFlow/Inference/X86/BERT
@@ -21,5 +21,5 @@ if [ ! -z "$CPU_ONLY" ]; then
   # clean up download files
   rm -rf model
   popd
-  rm -rf venv
+  python -m pip uninstall blade-disc-* -y
 fi

--- a/scripts/ci/test_cpu_examples.sh
+++ b/scripts/ci/test_cpu_examples.sh
@@ -12,7 +12,12 @@
 set -ex
 if [ ! -z "$CPU_ONLY" ]; then
   # install disc python wheel
-  source /opt/venv_disc/bin/activate
+  python -m virtualenv venv && source venv/bin/activate
+  arch=`uname -p`
+  if [[ $arch == "aarch64" ]]; then
+    # TODO(disc): a workaround for issue #224
+    pip install https://hlomodule.oss-cn-zhangjiakou.aliyuncs.com/bladedisc/aarch64/tensorflow-2.8.0-cp38-cp38-linux_aarch64.whl
+  fi
   python -m pip install ./build/blade_disc*.whl
 
   pushd examples/TensorFlow/Inference/X86/BERT
@@ -21,5 +26,5 @@ if [ ! -z "$CPU_ONLY" ]; then
   # clean up download files
   rm -rf model
   popd
-  python -m pip uninstall blade-disc-* -y
+  rm -rf venv
 fi

--- a/tao_compiler/mlir/xla/ral/context/mkldnn/ideep/ideep/operators/matmul.hpp
+++ b/tao_compiler/mlir/xla/ral/context/mkldnn/ideep/ideep/operators/matmul.hpp
@@ -53,10 +53,10 @@ struct matmul_forward : public dnnl::matmul,
       data_type x_dtype = data_type::f32,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
-    auto x_dims = weights_dims;
+    dims x_dims = weights_dims;
     x_dims[ndims - 2] = 1;
     x_dims[ndims - 1] = weights_dims[ndims - 2];
-    auto y_dims = {x_dims[0], weights_dims[1]};
+    dims y_dims = {x_dims[0], weights_dims[1]};
     if (ndims == 3) y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 


### PR DESCRIPTION
We try to fix #244 in this PR. The root cause of the crash is still not clear. After doing some experiments, we think that it isn't likely to be the bug of BladeDISC itself.
- The crash could be re-produced on a graph with a single GEMM op using BladeDISC TF bridge.
- Same GEMM op test is ok if we do the test in UT environments (not using TF bridge) or use BladeDISC torch bridge.
-  Codegen kernel runs successfully using BladeDISC TF bridge.
-  if we use the wheel file from ARM community instead of `pip install tensorflow-aarch64`, GEMM op test is ok using BladeDISC TF bridge.

Thus, we provide a workaround to fix #244 by replacing the wheel package. 