### PR TITLE
[Torch] fixup onnx2trt int64 inputs

### DIFF
--- a/pytorch_blade/src/compiler/jit/pybind_functions.cpp
+++ b/pytorch_blade/src/compiler/jit/pybind_functions.cpp
@@ -114,6 +114,7 @@ void initToolsBindings(py::module& m) {
   tools.def("set_value_type", set_value_type);
   tools.def("node_schema_str", node_schema_str);
   tools.def("cast_to_tensor_type", cast_to_tensor_type);
+  tools.def("cast_to_i32_tensor_type", cast_to_i32_tensor_type);
 
   tools.def(
       "set_trust_tracing_shape",

--- a/pytorch_blade/src/compiler/jit/tool_funcs.cpp
+++ b/pytorch_blade/src/compiler/jit/tool_funcs.cpp
@@ -138,6 +138,16 @@ torch::TypePtr fromNumberType(torch::TypePtr typ) {
   return nullptr;
 }
 
+bool cast_to_i32_tensor_type(torch::jit::Value& value) {
+  const auto& tensor_type = value.type()->cast<torch::TensorType>();
+  if (tensor_type) {
+    return value.setType(tensor_type->withScalarType(at::kInt));
+  } else {
+    return value.setType(
+        torch::TensorType::createContiguous(at::kInt, at::kCPU, {}));
+  }
+}
+
 bool cast_to_tensor_type(torch::jit::Value& value) {
   auto tensor_type = fromNumberType(value.type());
   if (tensor_type != nullptr) {

--- a/pytorch_blade/src/compiler/jit/tool_funcs.h
+++ b/pytorch_blade/src/compiler/jit/tool_funcs.h
@@ -50,6 +50,7 @@ void set_value_type(
     bool is_contiguous);
 
 std::string node_schema_str(const torch::jit::Node& node);
+bool cast_to_i32_tensor_type(torch::jit::Value& value);
 bool cast_to_tensor_type(torch::jit::Value& value);
 } // namespace blade
 } // namespace torch

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
@@ -323,7 +323,7 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
   // TODO: we currently only support inputs on the same device as tensorrt
   TORCH_CHECK(tensorrt_device_ == c10::cuda::current_device());
   TORCH_CHECK(CheckCurrentDevice(inputs));
-  TORCH_CHECK(ChangingShape(cuda_ctu_inputs, context));
+  TORCH_CHECK(ChangingShape(inputs, context));
 
   const auto& graph_inputs = engine_state_->inputs;
   // pre-process the input bindings

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
@@ -300,7 +300,6 @@ bool TRTContext::ChangingShape(
   const auto& graph_inputs = engine_state_->inputs;
   for (size_t k = 0; k < inputs.size(); ++k) {
     torch::Tensor inp_tensor = inputs[k];
-    TORCH_CHECK(inp_tensor.scalar_type() == graph_inputs[k].scalar_type);
     int bind_index = input_bind_indices_[optimization_profile_][k];
     // The subgraph input should have been eliminated in TensorRT engine
     if (bind_index < 0) {
@@ -323,6 +322,8 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
     std::shared_ptr<nvinfer1::IExecutionContext>& context) {
   // TODO: we currently only support inputs on the same device as tensorrt
   TORCH_CHECK(tensorrt_device_ == c10::cuda::current_device());
+  TORCH_CHECK(CheckCurrentDevice(inputs));
+  TORCH_CHECK(ChangingShape(cuda_ctu_inputs, context));
 
   const auto& graph_inputs = engine_state_->inputs;
   // pre-process the input bindings
@@ -342,8 +343,6 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
     cuda_ctu_inputs.push_back(ctu_tensor);
   }
 
-  TORCH_CHECK(CheckCurrentDevice(ctu_inputs));
-  TORCH_CHECK(ChangingShape(ctu_inputs, context));
   return cuda_ctu_inputs;
 }
 

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
@@ -323,8 +323,6 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
     std::shared_ptr<nvinfer1::IExecutionContext>& context) {
   // TODO: we currently only support inputs on the same device as tensorrt
   TORCH_CHECK(tensorrt_device_ == c10::cuda::current_device());
-  TORCH_CHECK(CheckCurrentDevice(inputs));
-  TORCH_CHECK(ChangingShape(inputs, context));
 
   const auto& graph_inputs = engine_state_->inputs;
   // pre-process the input bindings
@@ -343,6 +341,9 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
     // add to cuda_ctu_inputs, make the ctu_tensor has lifetime out of the loop
     cuda_ctu_inputs.push_back(ctu_tensor);
   }
+
+  TORCH_CHECK(CheckCurrentDevice(ctu_inputs));
+  TORCH_CHECK(ChangingShape(ctu_inputs, context));
   return cuda_ctu_inputs;
 }
 

--- a/pytorch_blade/tests/tensorrt/test_tensorrt.py
+++ b/pytorch_blade/tests/tensorrt/test_tensorrt.py
@@ -69,7 +69,7 @@ class TestTensorRTEngine(TestCase):
         input = torch.Tensor([3]).to(type).cuda()
         model = self._load_model(type)
         cfg = Config.get_current_context_or_new()
-        cfg.optimization_pipeline = "TensorRT"
+        cfg.optimization_pipeline = torch_blade.tensorrt.backend_name() 
         with cfg:
             opt_model = optimize(model, allow_tracing=True, model_inputs=input)
         self._test_tensorrt_type_normal(model, opt_model, type)

--- a/pytorch_blade/tests/tensorrt/test_tensorrt.py
+++ b/pytorch_blade/tests/tensorrt/test_tensorrt.py
@@ -69,7 +69,7 @@ class TestTensorRTEngine(TestCase):
         input = torch.Tensor([3]).to(type).cuda()
         model = self._load_model(type)
         cfg = Config.get_current_context_or_new()
-        cfg.optimization_pipeline = torch_blade.tensorrt.backend_name() 
+        cfg.optimization_pipeline = tensorrt.backend_name()
         with cfg:
             opt_model = optimize(model, allow_tracing=True, model_inputs=input)
         self._test_tensorrt_type_normal(model, opt_model, type)
@@ -85,7 +85,7 @@ class TestTensorRTEngine(TestCase):
 
         x = torch.randn(1)
         cfg = Config.get_current_context_or_new()
-        cfg.optimization_pipeline = "TensorRT"
+        cfg.optimization_pipeline = tensorrt.backend_name()
         with cfg:
             triple = optimize(Triple().eval(), allow_tracing=True, model_inputs=x)
 
@@ -117,7 +117,7 @@ class TestTensorRTEngine(TestCase):
         model = Model().cuda().eval()
         out = model(one)
         cfg = Config.get_current_context_or_new()
-        cfg.optimization_pipeline = "TensorRT"
+        cfg.optimization_pipeline = tensorrt.backend_name()
         with cfg:
             opt = optimize(model, allow_tracing=True, model_inputs=one)
         self.assertEqual(tensorrt.num_engines(opt), 1)
@@ -129,7 +129,7 @@ class TestTensorRTEngine(TestCase):
         input = torch.Tensor([3]).to(type).cuda()
         model = self._load_model(type)
         cfg = Config.get_current_context_or_new()
-        cfg.optimization_pipeline = "TensorRT"
+        cfg.optimization_pipeline = tensorrt.backend_name()
         with cfg:
             opt_model = optimize(model, allow_tracing=True, model_inputs=input)
         trt_engines = tensorrt.collect_engines(opt_model)

--- a/pytorch_blade/torch_blade/__init__.py
+++ b/pytorch_blade/torch_blade/__init__.py
@@ -35,6 +35,12 @@ try:
 except ImportError as e:
     pass
 
+try:
+    import torch_blade.tensorrt
+except ImportError as e:
+    pass
+
+
 warnings.filterwarnings("ignore")
 
 utils.add_method(torch._C.ScriptModule)(tools.create_method_from_graph)

--- a/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
+++ b/pytorch_blade/torch_blade/onnx_backends/backend_conversion.py
@@ -18,7 +18,6 @@ import torch_blade._torch_blade._backends as _backends
 from torch_blade import pass_manager
 from torch_blade import utils
 from torch_blade import tools
-from torch_blade.config import Config
 from torch_blade.clustering.support_group_conversion import group_to_engine_conversion
 from torch_blade.logging import logger
 
@@ -45,7 +44,7 @@ def _try_cast_graph_integer_inputs_to_i32(graph):
     # Convert INT64 to INT32.
     for val in graph.inputs():
         if val.type().scalarType() == "Long":
-            tools.cast_int_to_i32_tensor_type(val)
+            tools.cast_to_i32_tensor_type(val)
 
 
 def _build_onnx_engine(subgraph, engine_build_func, q_info=None,

--- a/pytorch_blade/torch_blade/pass_manager.py
+++ b/pytorch_blade/torch_blade/pass_manager.py
@@ -121,7 +121,7 @@ def _jit_pass_lower_to_onnx(graph):
     #
     # But something weird happened:
     # call to ConstantValueMap::ClearMaps() in C++ will segfault
-    if utils.torch_version_number() >= utils.parse_version("1.11.0"):
+    if utils.torch_version_number() >= utils.parse_version("1.9.0"):
         onnx_graph = torch._C._jit_pass_onnx(graph, OperatorExportTypes.ONNX)
         # fix(tanyo): call to torch_blade.tools._jit_pass_onnx would segfault
         value_map = dict()
@@ -143,7 +143,7 @@ def _jit_pass_lower_to_onnx(graph):
     torch._C._jit_pass_lint(onnx_graph)
 
     from torch.onnx.symbolic_helper import _export_onnx_opset_version
-    if utils.torch_version_number() >= utils.parse_version("1.11.0"):
+    if utils.torch_version_number() >= utils.parse_version("1.9.0"):
         torch._C._jit_pass_onnx_scalar_type_analysis(onnx_graph, True, _export_onnx_opset_version)
     else:
         torch._C._jit_pass_onnx_scalar_type_analysis(onnx_graph)

--- a/pytorch_blade/torch_blade/tensorrt/tensorrt_optimization.py
+++ b/pytorch_blade/torch_blade/tensorrt/tensorrt_optimization.py
@@ -53,6 +53,7 @@ def trt_engine_conversion(
         q_info,
         disable_fallback,
         dynamic_settings,
+        cast_int_to_i32=True
     )
 
 


### PR DESCRIPTION
+ `torch._C._jit_pass_lower_to_onnx` and `torch._C._jit_pass_onnx_scalar_type_analysis` APIs has changed in torch 1.9.0 https://github.com/alibaba/BladeDISC/issues/253
+ Cast subgraph's inputs to `torch.int32` where it's `torch.int64` https://github.com/alibaba/BladeDISC/issues/254

TorchBlade returns a model with accuracy error, after optimizing the hugging face a pre-trained Albert model with TensorRT.
The script is listed as follow:
```python
import torch_blade
import torch_blade.tensorrt
from torch_blade.testing.common_utils import assert_almost_equal
from transformers import AlbertConfig, AlbertModel, AutoTokenizer

def load_albert_and_inputs():
    model_name = "albert-base-v2"
    model = AlbertModel.from_pretrained(model_name, torchscript=True).cuda()

    tokenizer = AutoTokenizer.from_pretrained(model_name)
    def plain_tokenizer(inputs_str, return_tensors="pt"):
        inputs = tokenizer(inputs_str, return_tensors=return_tensors, padding=True)
        inputs = dict(map(lambda x: (x[0], x[1].cuda()), inputs.items()))

    input_strs = [
     "We are very happy to show you the story.",
     "We hope you don't hate it."]
    inputs = plain_tokenizer(input_strs)
    inputs = (inputs['input_ids'].cuda(), inputs['attention_mask'].cuda(), inputs['token_type_ids'].cuda(),)

    return model.eval(), inputs

def do_optimization(model, inputs):
    torch_config = torch_blade.Config()
    torch_config.optimization_pipeline = torch_blade.tensorrt.backend_name()
    with torch_config:
           opt_model = torch_blade.optimize(model, True, inputs)

    return opt_model

model, inputs = load_albert_and_inputs()
opt_model = do_optimization(model, inputs)

outputs0 = model(*inputs)
outputs1 = opt_model(*inputs)
assert_almost_equal(outputs0, outputs1)
```

After debugging, we found the accuracy error occurred because we use inputs with `torch.int64` data types. But TensorRT has only limited support on INT64. We fix up the issue by casting all `torch.LongTensor` to `torch.IntTensor` on the inputs of the subgraph given to ONNX2TensorRT. Refer to https://github.com/onnx/onnx-tensorrt/blob/main/docs/operators.md.

This pull request only fixes the accuracy error since TensorRT 8.2.3.0. TensorRT with a lower version has other accuracy error problems, but we won't fix them now.