### PR TITLE
[Torch] slim header files inclusion

### DIFF
--- a/pytorch_blade/src/compiler/backends/backend_input_outputs.cpp
+++ b/pytorch_blade/src/compiler/backends/backend_input_outputs.cpp
@@ -148,7 +148,7 @@ TensorInfo::TensorInfo(const torch::jit::Value& val) {
   // default to device cpu
   name = val.debugName();
   device = is_gpu_tensor_type(val) ? "cuda" : "cpu";
-  auto tensor_type = val.type()->cast<torch::TensorType>();
+  auto tensor_type = val.type()->cast<at::TensorType>();
   TORCH_CHECK(tensor_type != nullptr);
   auto concrete_sizes = tensor_type->sizes().concrete_sizes();
   if (concrete_sizes) {

--- a/pytorch_blade/src/compiler/backends/backend_input_outputs.h
+++ b/pytorch_blade/src/compiler/backends/backend_input_outputs.h
@@ -11,8 +11,13 @@
 
 #pragma once
 
-#include <torch/script.h>
+#include <ATen/core/ScalarType.h>
 #include <vector>
+namespace torch {
+namespace jit {
+class Value;
+}
+} // namespace torch
 
 namespace torch {
 namespace blade {

--- a/pytorch_blade/src/compiler/backends/engine_class.cpp
+++ b/pytorch_blade/src/compiler/backends/engine_class.cpp
@@ -258,7 +258,7 @@ torch::TypePtr register_engine(
     const std::string& fallback_module_bytes,
     const std::string& original_subgraph) {
   auto custom_class_obj = create_engine(
-      engine_stae, attr_debug_name, fallback_module_bytes, original_subgraph);
+      engine_state, attr_debug_name, fallback_module_bytes, original_subgraph);
   module.register_attribute(
       attr_debug_name, custom_class_obj.type(), custom_class_obj);
   return custom_class_obj.type();

--- a/pytorch_blade/src/compiler/backends/engine_class.cpp
+++ b/pytorch_blade/src/compiler/backends/engine_class.cpp
@@ -14,6 +14,8 @@
 #include "common_utils/logging.h"
 #include "common_utils/utils.h"
 
+#include <torch/script.h>
+
 namespace torch {
 namespace blade {
 namespace backends {
@@ -32,8 +34,7 @@ EngineClass::EngineClass(SerialType serialized) {
   attr_debug_name_ = std::move(GetAttrString(kDebugName));
 }
 
-torch::List<torch::Tensor> EngineClass::Fallback(
-    const torch::List<torch::Tensor>& inputs) {
+at::List<at::Tensor> EngineClass::Fallback(const at::List<at::Tensor>& inputs) {
   auto fallback = GetFallback();
   std::vector<IValue> f_inputs(inputs.begin(), inputs.end());
 
@@ -44,8 +45,7 @@ torch::List<torch::Tensor> EngineClass::Fallback(
   return ret.toTensorList();
 }
 
-torch::List<torch::Tensor> EngineClass::Execute(
-    const torch::List<torch::Tensor>& inputs) {
+at::List<at::Tensor> EngineClass::Execute(const at::List<at::Tensor>& inputs) {
   if (GetRecordClusterIOFlag()) {
     // Note:
     // This is for accuracy debug & testing purpose, not recommend
@@ -55,7 +55,7 @@ torch::List<torch::Tensor> EngineClass::Execute(
   auto record_inputs = std::vector<torch::IValue>{inputs.begin(), inputs.end()};
   TORCH_BLADE_RECORD_FUNCTION(attr_debug_name_, record_inputs);
 
-  torch::List<torch::Tensor> outputs;
+  at::List<at::Tensor> outputs;
   // do inference
   if (engine_->ShouldFallback(inputs)) {
     outputs = Fallback(inputs);
@@ -88,7 +88,7 @@ torch::jit::Module EngineClass::GetFallback() {
     TORCH_CHECK(
         !fallback_module_bytes.empty(), "Fallback haven't been implemented");
     std::stringstream istream(fallback_module_bytes);
-    fallback_module_ = ::torch::jit::load(istream);
+    fallback_module_ = ::torch::jit::load(istream)._ivalue();
   });
   return fallback_module_;
 }
@@ -126,12 +126,12 @@ std::vector<std::string> EngineClass::GetAttrKeys() const {
   return keys;
 }
 
-torch::List<torch::Tensor> EngineClass::last_inputs() {
+at::List<at::Tensor> EngineClass::last_inputs() {
   TORCH_CHECK(
       GetRecordClusterIOFlag(), "Only avaliable with RecordClusterIOFlag set");
   return last_inputs_;
 }
-torch::List<torch::Tensor> EngineClass::last_outputs() {
+at::List<at::Tensor> EngineClass::last_outputs() {
   TORCH_CHECK(
       GetRecordClusterIOFlag(), "Only avaliable with RecordClusterIOFlag set");
   return last_outputs_;
@@ -159,84 +159,86 @@ c10::intrusive_ptr<EngineClass> EngineClass::Deserialize(
   return c10::make_intrusive<EngineClass>(std::move(serialized));
 }
 
-// Notice a few things:
-// - We pass the class to be registered as a template parameter to
-//   `torch::class_`. In this instance, we've passed the
-//   specialization of the MyStackClass class ``MyStackClass<std::string>``.
-//   In general, you cannot register a non-specialized template
-//   class. For non-templated classes, you can just pass the
-//   class name directly as the template parameter.
-// - The arguments passed to the constructor make up the "qualified name"
-//   of the class. In this case, the registered class will appear in
-//   Python and C++ as `torch.classes.my_classes.MyStackClass`. We call
-//   the first argument the "namespace" and the second argument the
-//   actual class name.
-static auto torch_blade_engine_class =
-    // TODO(GTY): Use inheritance or template to do version control
-    torch::class_<EngineClass>("torch_blade", "Engine")
-        // The following line registers the contructor of our MyStackClass
-        // class that takes a single `std::vector<std::string>` argument,
-        // i.e. it exposes the C++ method `MyStackClass(std::vector<T> init)`.
-        // Currently, we do not support registering overloaded
-        // constructors, so for now you can only `def()` one instance of
-        // `torch::init`.
-        .def(torch::init<EngineClass::SerialType>())
-        // The next line registers a stateless (i.e. no captures) C++ lambda
-        // function as a method. Note that a lambda function must take a
-        // `c10::intrusive_ptr<YourClass>` (or some const/ref version of that)
-        // as the first argument. Other arguments can be whatever you want.
-        .def(
-            "execute",
-            [](const c10::intrusive_ptr<EngineClass>& self,
-               at::List<at::Tensor> inputs) { return self->Execute(inputs); })
-        // The following four lines expose methods of the
-        // MyStackClass<std::string> class as-is. `torch::class_` will
-        // automatically examine the argument and return types of the passed-in
-        // method pointers and expose these to Python and TorchScript
-        // accordingly. Finally, notice that we must take the *address* of the
-        // fully-qualified method name, i.e. use the unary `&` operator, due to
-        // C++ typing rules.
-        .def("dump_attr_to_file", &EngineClass::DumpAttrToFile)
-        .def("dump_model_proto", &EngineClass::DumpModelProto)
-        .def("get_attr_string", &EngineClass::GetAttrString)
-        .def("get_attr_keys", &EngineClass::GetAttrKeys)
-        .def("last_inputs", &EngineClass::last_inputs)
-        .def("last_outputs", &EngineClass::last_outputs)
-        // class_<>::def_pickle allows you to define the serialization
-        // and deserialization methods for your C++ class.
-        // Currently, we only support passing stateless lambda functions
-        // as arguments to def_pickle
-        .def_pickle(
-            // __getstate__
-            // This function defines what data structure should be produced
-            // when we serialize an instance of this class. The function
-            // must take a single `self` argument, which is an intrusive_ptr
-            // to the instance of the object. The function can return
-            // any type that is supported as a return value of the TorchScript
-            // custom operator API. In this instance, we've chosen to return
-            // a std::vector<std::string> as the salient data to preserve
-            // from the class.
-            [](const c10::intrusive_ptr<EngineClass>& self)
-                -> EngineClass::SerialType { return self->Serialize(); },
-            // __setstate__
-            // This function defines how to create a new instance of the C++
-            // class when we are deserializing. The function must take a
-            // single argument of the same type as the return value of
-            // `__getstate__`. The function must return an intrusive_ptr
-            // to a new instance of the C++ class, initialized however
-            // you would like given the serialized state.
-            [](EngineClass::SerialType serialized)
-                -> c10::intrusive_ptr<EngineClass> {
-              // A convenient way to instantiate an object and get an
-              // intrusive_ptr to it is via `make_intrusive`. We use
-              // that here to allocate an instance of MyStackClass<std::string>
-              // and call the single-argument std::vector<std::string>
-              // constructor with the serialized state.
-              return EngineClass::Deserialize(std::move(serialized));
-            });
+void InitTorchBladeEngine() {
+  // Notice a few things:
+  // - We pass the class to be registered as a template parameter to
+  //   `torch::class_`. In this instance, we've passed the
+  //   specialization of the MyStackClass class ``MyStackClass<std::string>``.
+  //   In general, you cannot register a non-specialized template
+  //   class. For non-templated classes, you can just pass the
+  //   class name directly as the template parameter.
+  // - The arguments passed to the constructor make up the "qualified name"
+  //   of the class. In this case, the registered class will appear in
+  //   Python and C++ as `torch.classes.my_classes.MyStackClass`. We call
+  //   the first argument the "namespace" and the second argument the
+  //   actual class name.
+  static auto torch_blade_engine_class =
+      // TODO(GTY): Use inheritance or template to do version control
+      torch::class_<EngineClass>("torch_blade", "Engine")
+          // The following line registers the contructor of our MyStackClass
+          // class that takes a single `std::vector<std::string>` argument,
+          // i.e. it exposes the C++ method `MyStackClass(std::vector<T> init)`.
+          // Currently, we do not support registering overloaded
+          // constructors, so for now you can only `def()` one instance of
+          // `torch::init`.
+          .def(torch::init<EngineClass::SerialType>())
+          // The next line registers a stateless (i.e. no captures) C++ lambda
+          // function as a method. Note that a lambda function must take a
+          // `c10::intrusive_ptr<YourClass>` (or some const/ref version of that)
+          // as the first argument. Other arguments can be whatever you want.
+          .def(
+              "execute",
+              [](const c10::intrusive_ptr<EngineClass>& self,
+                 at::List<at::Tensor> inputs) { return self->Execute(inputs); })
+          // The following four lines expose methods of the
+          // MyStackClass<std::string> class as-is. `torch::class_` will
+          // automatically examine the argument and return types of the
+          // passed-in method pointers and expose these to Python and
+          // TorchScript accordingly. Finally, notice that we must take the
+          // *address* of the fully-qualified method name, i.e. use the unary
+          // `&` operator, due to C++ typing rules.
+          .def("dump_attr_to_file", &EngineClass::DumpAttrToFile)
+          .def("dump_model_proto", &EngineClass::DumpModelProto)
+          .def("get_attr_string", &EngineClass::GetAttrString)
+          .def("get_attr_keys", &EngineClass::GetAttrKeys)
+          .def("last_inputs", &EngineClass::last_inputs)
+          .def("last_outputs", &EngineClass::last_outputs)
+          // class_<>::def_pickle allows you to define the serialization
+          // and deserialization methods for your C++ class.
+          // Currently, we only support passing stateless lambda functions
+          // as arguments to def_pickle
+          .def_pickle(
+              // __getstate__
+              // This function defines what data structure should be produced
+              // when we serialize an instance of this class. The function
+              // must take a single `self` argument, which is an intrusive_ptr
+              // to the instance of the object. The function can return
+              // any type that is supported as a return value of the TorchScript
+              // custom operator API. In this instance, we've chosen to return
+              // a std::vector<std::string> as the salient data to preserve
+              // from the class.
+              [](const c10::intrusive_ptr<EngineClass>& self)
+                  -> EngineClass::SerialType { return self->Serialize(); },
+              // __setstate__
+              // This function defines how to create a new instance of the C++
+              // class when we are deserializing. The function must take a
+              // single argument of the same type as the return value of
+              // `__getstate__`. The function must return an intrusive_ptr
+              // to a new instance of the C++ class, initialized however
+              // you would like given the serialized state.
+              [](EngineClass::SerialType serialized)
+                  -> c10::intrusive_ptr<EngineClass> {
+                // A convenient way to instantiate an object and get an
+                // intrusive_ptr to it is via `make_intrusive`. We use
+                // that here to allocate an instance of
+                // MyStackClass<std::string> and call the single-argument
+                // std::vector<std::string> constructor with the serialized
+                // state.
+                return EngineClass::Deserialize(std::move(serialized));
+              });
+}
 
-torch::TypePtr register_engine(
-    torch::jit::Module& module,
+torch::IValue create_engine(
     const EngineState& engine_state,
     const std::string& attr_debug_name,
     const std::string& fallback_module_bytes,
@@ -246,6 +248,17 @@ torch::TypePtr register_engine(
 
   auto custom_class_obj =
       torch::make_custom_class<EngineClass>(std::move(serialized));
+  return custom_class_obj;
+}
+
+torch::TypePtr register_engine(
+    torch::jit::Module& module,
+    const EngineState& engine_state,
+    const std::string& attr_debug_name,
+    const std::string& fallback_module_bytes,
+    const std::string& original_subgraph) {
+  auto custom_class_obj = create_engine(
+      engine_stae, attr_debug_name, fallback_module_bytes, original_subgraph);
   module.register_attribute(
       attr_debug_name, custom_class_obj.type(), custom_class_obj);
   return custom_class_obj.type();

--- a/pytorch_blade/src/compiler/backends/engine_class.h
+++ b/pytorch_blade/src/compiler/backends/engine_class.h
@@ -22,12 +22,12 @@
 #include <ATen/core/List.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/ivalue.h>
-#include <ATen/core/type_ptr.h>
+#include <ATen/core/jit_type_base.h>
 
 namespace torch {
 namespace jit {
 class Module;
-}
+} // namespace jit
 } // namespace torch
 
 namespace torch {

--- a/pytorch_blade/src/compiler/backends/engine_class.h
+++ b/pytorch_blade/src/compiler/backends/engine_class.h
@@ -22,7 +22,7 @@
 #include <ATen/core/List.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/ivalue.h>
-#include <ATen/core/jit_type_base.h>
+#include <ATen/core/jit_type.h>
 
 namespace torch {
 namespace jit {

--- a/pytorch_blade/src/compiler/backends/engine_interface.cpp
+++ b/pytorch_blade/src/compiler/backends/engine_interface.cpp
@@ -37,6 +37,7 @@ struct EngineCreatorRegistry {
   std::shared_ptr<EngineInterface> CreateEngine(const EngineState& state) {
     auto creator = lut.find(state.backend_name);
     if (creator == lut.end()) {
+      LOG(WARNING) << "Can not found backend " << state.backend_name;
       return nullptr;
     }
     TORCH_CHECK(

--- a/pytorch_blade/src/compiler/backends/engine_interface.h
+++ b/pytorch_blade/src/compiler/backends/engine_interface.h
@@ -11,7 +11,8 @@
 
 #pragma once
 
-#include <torch/script.h>
+#include <ATen/core/List.h>
+#include <ATen/core/Tensor.h>
 #include "compiler/backends/backend_input_outputs.h"
 
 namespace torch {
@@ -54,10 +55,9 @@ class EngineInterface {
     return "Engine";
   }
 
-  virtual torch::List<torch::Tensor> Execute(
-      const torch::List<torch::Tensor>& inputs) = 0;
+  virtual at::List<at::Tensor> Execute(const at::List<at::Tensor>& inputs) = 0;
 
-  virtual bool ShouldFallback(const torch::List<torch::Tensor>& inputs) {
+  virtual bool ShouldFallback(const at::List<at::Tensor>& inputs) {
     return false;
   }
 

--- a/pytorch_blade/src/compiler/jit/fusion.cpp
+++ b/pytorch_blade/src/compiler/jit/fusion.cpp
@@ -120,8 +120,8 @@ Node* MergeNodeIntoGroup(Node* group, Node* n) {
 }
 
 torch::TypePtr get_list_tensor_type() {
-  auto tensor_type = torch::TensorType::get();
-  auto list_type = torch::ListType::create(tensor_type);
+  auto tensor_type = at::TensorType::get();
+  auto list_type = at::ListType::create(tensor_type);
   return list_type;
 }
 

--- a/pytorch_blade/src/compiler/jit/onnx_funcs.cpp
+++ b/pytorch_blade/src/compiler/jit/onnx_funcs.cpp
@@ -27,9 +27,9 @@ void CastDownAllConstantDoubleToFloat(Block* block) {
 
     if (node->kind() == ::c10::onnx::Constant) {
       auto val = node->t(attr::value);
-      torch::ScalarType dtype = val.scalar_type();
-      if (dtype == torch::ScalarType::Double) {
-        val = val.to(torch::ScalarType::Float);
+      at::ScalarType dtype = val.scalar_type();
+      if (dtype == at::ScalarType::Double) {
+        val = val.to(at::ScalarType::Float);
         node->removeAttribute(attr::value);
         node->t_(attr::value, val);
       }

--- a/pytorch_blade/src/compiler/jit/shape_type_spec.cpp
+++ b/pytorch_blade/src/compiler/jit/shape_type_spec.cpp
@@ -40,11 +40,10 @@ const char* ScalarTypeToString(ScalarType t) {
 #undef DEFINE_CASE
 }
 
-c10::optional<torch::ScalarType> ScalarTypeFromString(
-    const std::string& dtype) {
-#define DEFINE_SCALAR_TYPE(_, name) {#name, torch::ScalarType::name},
+c10::optional<at::ScalarType> ScalarTypeFromString(const std::string& dtype) {
+#define DEFINE_SCALAR_TYPE(_, name) {#name, at::ScalarType::name},
 
-  static std::unordered_map<std::string, torch::ScalarType> type_map = {
+  static std::unordered_map<std::string, at::ScalarType> type_map = {
       AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_SCALAR_TYPE)};
 
   auto type = type_map.find(dtype);

--- a/pytorch_blade/src/compiler/jit/shape_type_spec.cpp
+++ b/pytorch_blade/src/compiler/jit/shape_type_spec.cpp
@@ -146,11 +146,11 @@ ShapeTypeSpec ShapeTypeSpec::Deserialize(const std::string& serial_str) {
 }
 
 ShapeTypeSpec ShapeTypeSpec::GetShapeTypeSpec(
-    const torch::List<torch::Tensor>& inputs) {
+    const at::List<at::Tensor>& inputs) {
   std::vector<ShapeType> shape_types(inputs.size());
   for (size_t k = 0; k < inputs.size(); ++k) {
     auto& shape_type = shape_types[k];
-    torch::Tensor inp_tensor = inputs[k];
+    at::Tensor inp_tensor = inputs[k];
     const auto& inp_shape = inp_tensor.sizes();
     std::copy(
         inp_shape.cbegin(),

--- a/pytorch_blade/src/compiler/jit/shape_type_spec.h
+++ b/pytorch_blade/src/compiler/jit/shape_type_spec.h
@@ -19,11 +19,11 @@
 namespace torch {
 namespace blade {
 const char* ScalarTypeToString(ScalarType t);
-c10::optional<torch::ScalarType> ScalarTypeFromString(const std::string& dtype);
+c10::optional<at::ScalarType> ScalarTypeFromString(const std::string& dtype);
 
 struct ShapeType {
   std::vector<int64_t> shape;
-  torch::ScalarType type;
+  at::ScalarType type;
   bool operator==(const ShapeType& rhs) const {
     return shape == rhs.shape && type == rhs.type;
   }

--- a/pytorch_blade/src/compiler/jit/shape_type_spec.h
+++ b/pytorch_blade/src/compiler/jit/shape_type_spec.h
@@ -46,7 +46,7 @@ class ShapeTypeSpec {
 
   std::string Serialize() const;
   static ShapeTypeSpec Deserialize(const std::string&);
-  static ShapeTypeSpec GetShapeTypeSpec(const torch::List<torch::Tensor>&);
+  static ShapeTypeSpec GetShapeTypeSpec(const at::List<at::Tensor>&);
   static ShapeTypeSpec GetShapeTypeSpec(
       const std::vector<const torch::jit::Value*>& values);
 

--- a/pytorch_blade/src/compiler/jit/shape_type_test.cpp
+++ b/pytorch_blade/src/compiler/jit/shape_type_test.cpp
@@ -18,7 +18,7 @@
 using namespace torch::blade;
 TEST(ShapeTypeTest, ShapeTypeString) {
   ShapeType shape_type;
-  shape_type.type = torch::ScalarType::Int;
+  shape_type.type = at::ScalarType::Int;
   shape_type.shape = {1, 3, 224, 224};
 
   std::string serial_str = shape_type.Serialize();

--- a/pytorch_blade/src/compiler/jit/shape_type_test.cpp
+++ b/pytorch_blade/src/compiler/jit/shape_type_test.cpp
@@ -38,7 +38,7 @@ TEST(ShapeTypeTest, ShapeTypeString) {
 }
 
 TEST(ShapeTypeSpecTest, ShapeTypeSpecString) {
-  torch::List<torch::Tensor> list;
+  at::List<at::Tensor> list;
   auto option = torch::dtype(torch::kInt8);
   list.push_back(torch::ones({1, 3, 2, 2}).to(option));
   option = torch::dtype(torch::kDouble);

--- a/pytorch_blade/src/compiler/jit/tool_funcs.cpp
+++ b/pytorch_blade/src/compiler/jit/tool_funcs.cpp
@@ -106,7 +106,7 @@ void set_value_type(
     int64_t dtype,
     bool requires_grad,
     bool is_contiguous) {
-  torch::ScalarType scalar_type = static_cast<torch::ScalarType>(dtype);
+  at::ScalarType scalar_type = static_cast<at::ScalarType>(dtype);
   torch::Device device(device_str);
   c10::VaryingShape<int64_t> sizes = shape_vec;
   c10::VaryingShape<int64_t> strides = stride_vec;

--- a/pytorch_blade/src/compiler/jit/tool_funcs.cpp
+++ b/pytorch_blade/src/compiler/jit/tool_funcs.cpp
@@ -78,7 +78,7 @@ torch::jit::Node* create_get_attr_node(
 }
 
 bool is_concrete_shape_tensor_type(const torch::jit::Value& val) {
-  const auto& tensor_type = val.type()->cast<torch::TensorType>();
+  const auto& tensor_type = val.type()->cast<at::TensorType>();
   if (tensor_type) {
     return tensor_type->scalarType() && tensor_type->sizes().concrete_sizes();
   }
@@ -87,11 +87,11 @@ bool is_concrete_shape_tensor_type(const torch::jit::Value& val) {
 }
 
 bool is_gpu_tensor_type(const torch::jit::Value& val) {
-  if (!val.type()->isSubtypeOf(torch::TensorType::get())) {
+  if (!val.type()->isSubtypeOf(at::TensorType::get())) {
     return false;
   }
   c10::optional<torch::Device> dev =
-      val.type()->cast<torch::TensorType>()->device();
+      val.type()->cast<at::TensorType>()->device();
   if (dev) {
     return dev->is_cuda();
   }
@@ -110,7 +110,7 @@ void set_value_type(
   torch::Device device(device_str);
   c10::VaryingShape<int64_t> sizes = shape_vec;
   c10::VaryingShape<int64_t> strides = stride_vec;
-  auto type = torch::TensorType::create(
+  auto type = at::TensorType::create(
       scalar_type, device, sizes, strides, requires_grad, false, is_contiguous);
 
   CHECK(type->requires_grad() == requires_grad);
@@ -129,22 +129,22 @@ std::string node_schema_str(const torch::jit::Node& node) {
 
 torch::TypePtr fromNumberType(torch::TypePtr typ) {
   if (typ->isSubtypeOf(IntType::get())) {
-    return torch::TensorType::createContiguous(at::kLong, at::kCPU, {});
+    return at::TensorType::createContiguous(at::kLong, at::kCPU, {});
   } else if (typ->isSubtypeOf(FloatType::get())) {
-    return torch::TensorType::createContiguous(at::kFloat, at::kCPU, {});
+    return at::TensorType::createContiguous(at::kFloat, at::kCPU, {});
   } else if (typ->isSubtypeOf(BoolType::get())) {
-    return torch::TensorType::createContiguous(at::kBool, at::kCPU, {});
+    return at::TensorType::createContiguous(at::kBool, at::kCPU, {});
   }
   return nullptr;
 }
 
 bool cast_to_i32_tensor_type(torch::jit::Value& value) {
-  const auto& tensor_type = value.type()->cast<torch::TensorType>();
+  const auto& tensor_type = value.type()->cast<at::TensorType>();
   if (tensor_type) {
     return value.setType(tensor_type->withScalarType(at::kInt));
   } else {
     return value.setType(
-        torch::TensorType::createContiguous(at::kInt, at::kCPU, {}));
+        at::TensorType::createContiguous(at::kInt, at::kCPU, {}));
   }
 }
 

--- a/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_binary.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_binary.cpp
@@ -110,8 +110,8 @@ bool ConvertAtenBinaryCompareOp(
 
   if (GetTrustTracingShape() && jit_inp0->isCompleteTensor() &&
       jit_inp1->isCompleteTensor()) {
-    auto inp_type0 = jit_inp0->type()->cast<torch::TensorType>();
-    auto inp_type1 = jit_inp1->type()->cast<torch::TensorType>();
+    auto inp_type0 = jit_inp0->type()->cast<at::TensorType>();
+    auto inp_type1 = jit_inp1->type()->cast<at::TensorType>();
 
     no_implicit_broadcast = inp_type0->sizes() == inp_type1->sizes();
   }

--- a/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_binary.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_binary.cpp
@@ -214,12 +214,12 @@ bool ConvertAtenArange(
         input_mlir_type.isF32() || input_mlir_type.isF64()) {
       target_scalar_type = default_scalar_type;
     } else {
-      target_scalar_type = torch::ScalarType::Long;
+      target_scalar_type = at::ScalarType::Long;
     }
   } else {
     auto target_dtype_value =
         CastStdConstToI64(ctx.GetMlirValue(node.input(1)));
-    target_scalar_type = static_cast<torch::ScalarType>(*target_dtype_value);
+    target_scalar_type = static_cast<at::ScalarType>(*target_dtype_value);
   }
 
   if (!end.getType().isa<mlir::TensorType>()) {

--- a/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_unary.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/element_wise_unary.cpp
@@ -53,8 +53,7 @@ bool ConvertAtenToDtype(
   }
   // TODO: if the target type is the same with input type, return identity.
   // ScalarType in jit::Graph is type of int
-  torch::ScalarType dtype =
-      static_cast<torch::ScalarType>(dtype_value->toInt());
+  at::ScalarType dtype = static_cast<at::ScalarType>(dtype_value->toInt());
   auto input_val = ctx.GetMlirValue(torch_inp);
   auto elem_type = BuildMlirElemType(*ctx.builder, dtype);
   auto output_val =

--- a/pytorch_blade/src/compiler/mlir/converters/impl/gru_cell.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/gru_cell.cpp
@@ -52,8 +52,8 @@ bool ConvertAtenGRUCell(
   if (!(torch_input_weight->isTensor() && torch_hidden_weight->isTensor())) {
     return false;
   }
-  torch::Tensor input_weight = torch_input_weight->toTensor();
-  torch::Tensor hidden_weight = torch_hidden_weight->toTensor();
+  at::Tensor input_weight = torch_input_weight->toTensor();
+  at::Tensor hidden_weight = torch_hidden_weight->toTensor();
   const auto& loc = GetNodeLocation(ctx, node);
   auto& builder = *ctx.builder;
   auto ml_w_ih_t =

--- a/pytorch_blade/src/compiler/mlir/converters/impl/shapes.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/impl/shapes.cpp
@@ -185,7 +185,7 @@ bool ConvertAtenSqueeze(
     return false;
   }
 
-  auto tensor_type = jit_tensor->type()->cast<torch::TensorType>();
+  auto tensor_type = jit_tensor->type()->cast<at::TensorType>();
   TORCH_CHECK(tensor_type != nullptr);
   c10::optional<uint64_t> optional_rank = tensor_type->sizes().size();
   mlir_dim_t rank = 0;
@@ -368,7 +368,7 @@ bool ConvertAtenUnbind(
   }
   mlir_dim_t dim = CastJitConstToInt64(*jit_dim);
 
-  auto tensor_type = jit_self->type()->cast<torch::TensorType>();
+  auto tensor_type = jit_self->type()->cast<at::TensorType>();
   TORCH_CHECK(tensor_type != nullptr);
 
   // NB: we get number of outputs from the Tensor's shape.

--- a/pytorch_blade/src/compiler/mlir/converters/mhlo_converter_register_test.cpp
+++ b/pytorch_blade/src/compiler/mlir/converters/mhlo_converter_register_test.cpp
@@ -21,7 +21,7 @@
 using namespace torch::blade;
 namespace {
 // the custom dummy function in TorchScript
-torch::Tensor dummy_func(torch::Tensor input) {
+at::Tensor dummy_func(at::Tensor input) {
   return input;
 }
 

--- a/pytorch_blade/src/compiler/mlir/runtime/disc_engine.cpp
+++ b/pytorch_blade/src/compiler/mlir/runtime/disc_engine.cpp
@@ -30,8 +30,7 @@ class DiscEngine : public torch::blade::backends::EngineInterface {
   DISALLOW_COPY_AND_ASSIGN(DiscEngine);
   DiscEngine(const State& state);
 
-  torch::List<torch::Tensor> Execute(
-      const torch::List<torch::Tensor>& inputs) override;
+  at::List<at::Tensor> Execute(const at::List<at::Tensor>& inputs) override;
 
   const State& GetState() const {
     return *engine_state_;
@@ -59,8 +58,7 @@ DiscEngine::DiscEngine(const State& state) {
   CHECK_NOTNULL(engine_ctx);
 }
 
-torch::List<torch::Tensor> DiscEngine::Execute(
-    const torch::List<torch::Tensor>& inputs) {
+at::List<at::Tensor> DiscEngine::Execute(const at::List<at::Tensor>& inputs) {
   auto engine_ctx = FetchRalContext();
   CHECK_NOTNULL(engine_ctx);
   return engine_ctx->Execute(inputs);

--- a/pytorch_blade/src/compiler/mlir/runtime/disc_engine.cpp
+++ b/pytorch_blade/src/compiler/mlir/runtime/disc_engine.cpp
@@ -95,11 +95,11 @@ const char* GetBackendName() {
   return DiscEngine::GetBackendName();
 }
 
-static auto torch_blade_engine_creator =
-    torch::blade::backends::EngineCreatorRegister().RegisterBackend(
-        DiscEngine::GetBackendName(),
-        &DiscEngine::Create);
-
+void InitBladeDiscEngine() {
+  static auto torch_blade_engine_creator =
+      torch::blade::backends::EngineCreatorRegister().RegisterBackend(
+          DiscEngine::GetBackendName(), &DiscEngine::Create);
+}
 } // namespace disc
 } // namespace blade
 } // namespace torch

--- a/pytorch_blade/src/compiler/mlir/runtime/disc_engine.h
+++ b/pytorch_blade/src/compiler/mlir/runtime/disc_engine.h
@@ -15,6 +15,7 @@ namespace torch {
 namespace blade {
 namespace disc {
 const char* GetBackendName();
+void InitBladeDiscEngine();
 } // namespace disc
 } // namespace blade
 } // namespace torch

--- a/pytorch_blade/src/compiler/mlir/runtime/ral_context.h
+++ b/pytorch_blade/src/compiler/mlir/runtime/ral_context.h
@@ -49,17 +49,17 @@ class RalContext {
   RalContext(std::shared_ptr<backends::EngineState> state);
   ~RalContext();
 
-  torch::List<torch::Tensor> Execute(const torch::List<torch::Tensor>&);
+  at::List<at::Tensor> Execute(const at::List<at::Tensor>&);
 
  private:
   void BindingInputs(
-      const torch::List<torch::Tensor>& inputs,
+      const at::List<at::Tensor>& inputs,
       tao::ral::ExecutionContext& exec_ctx) const;
-  bool CheckCurrentDevice(const torch::List<torch::Tensor>& inputs) const;
-  torch::List<torch::Tensor> CreateAndBindingOutputs(
+  bool CheckCurrentDevice(const at::List<at::Tensor>& inputs) const;
+  at::List<at::Tensor> CreateAndBindingOutputs(
       tao::ral::ExecutionContext& exec_ctx) const;
-  torch::List<torch::Tensor> PreProcessInputs(
-      const torch::List<torch::Tensor>& inputs) const;
+  at::List<at::Tensor> PreProcessInputs(
+      const at::List<at::Tensor>& inputs) const;
   std::tuple<void*, void*> LoadEngine(const std::string& ral_engine_bytes);
 
   std::shared_ptr<backends::EngineState> engine_state_;

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine.cpp
@@ -31,8 +31,7 @@ class TRTEngine : public torch::blade::backends::EngineInterface {
   DISALLOW_COPY_AND_ASSIGN(TRTEngine);
   TRTEngine(const State& state);
 
-  torch::List<torch::Tensor> Execute(
-      const torch::List<torch::Tensor>& inputs) override;
+  at::List<at::Tensor> Execute(const at::List<at::Tensor>& inputs) override;
 
   const State& GetState() const {
     return *engine_state_;
@@ -42,7 +41,7 @@ class TRTEngine : public torch::blade::backends::EngineInterface {
     return "TensorRT";
   }
   static std::shared_ptr<TRTEngine> Create(const State& engine_state);
-  bool ShouldFallback(const torch::List<torch::Tensor>& inputs) override;
+  bool ShouldFallback(const at::List<at::Tensor>& inputs) override;
 
  private:
   std::shared_ptr<TRTContext> engine_ctx_;
@@ -54,12 +53,11 @@ TRTEngine::TRTEngine(const State& state) {
   engine_ctx_ = std::make_shared<TRTContext>(engine_state_);
 }
 
-torch::List<torch::Tensor> TRTEngine::Execute(
-    const torch::List<torch::Tensor>& inputs) {
+at::List<at::Tensor> TRTEngine::Execute(const at::List<at::Tensor>& inputs) {
   return engine_ctx_->Execute(inputs);
 }
 
-bool TRTEngine::ShouldFallback(const torch::List<torch::Tensor>& inputs) {
+bool TRTEngine::ShouldFallback(const at::List<at::Tensor>& inputs) {
   return !engine_ctx_->IsInRange(inputs);
 }
 

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
@@ -64,8 +64,7 @@ void NvinferExecutionContextDeleter(nvinfer1::IExecutionContext* ctx) {
 
 // Check if every tensor in a list of tensors matches the current
 // device.
-bool TRTContext::CheckCurrentDevice(
-    const torch::List<torch::Tensor>& inputs) const {
+bool TRTContext::CheckCurrentDevice(const at::List<at::Tensor>& inputs) const {
   if (inputs.empty()) {
     return true;
   }
@@ -76,7 +75,7 @@ bool TRTContext::CheckCurrentDevice(
   auto& inputs_info = engine_state_->inputs;
   TORCH_CHECK(inputs_info.size() == inputs.size());
   for (size_t k = 0; k < inputs.size(); ++k) {
-    torch::Tensor inp = inputs[k];
+    at::Tensor inp = inputs[k];
     auto device = inputs_info[k].device;
     if (device == "cuda" && inp.device() != cur_cuda_device) {
       return false;
@@ -87,7 +86,7 @@ bool TRTContext::CheckCurrentDevice(
 
 std::shared_ptr<nvinfer1::IExecutionContext> TRTContext::GetExecutionContext(
     c10::cuda::CUDAStream& stream,
-    const torch::List<torch::Tensor>& inputs) {
+    const at::List<at::Tensor>& inputs) {
   UpdateProfileIfNeed(inputs);
   auto found = contexts_map_.find(stream);
   if (found != contexts_map_.end() &&
@@ -176,10 +175,10 @@ std::string TRTContext::SerializeAsString() const {
 // Input/output blob mem ptr should be provided by the caller,
 // the TRTEngine is not the owner of the blobs' cuda memory.
 void TRTContext::BindingInputs(
-    const torch::List<torch::Tensor>& inputs,
+    const at::List<at::Tensor>& inputs,
     std::vector<void*>& binding_buffers) const {
   for (size_t k = 0; k < inputs.size(); ++k) {
-    torch::Tensor inp_tensor = inputs[k];
+    at::Tensor inp_tensor = inputs[k];
     int bind_index = input_bind_indices_[optimization_profile_][k];
     // The subgraph input should have been eliminated in TensorRT engine
     if (bind_index < 0) {
@@ -192,17 +191,17 @@ void TRTContext::BindingInputs(
   }
 }
 
-torch::List<torch::Tensor> TRTContext::CreateAndBindingOutputs(
+at::List<at::Tensor> TRTContext::CreateAndBindingOutputs(
     std::vector<void*>& binding_buffers,
     std::shared_ptr<nvinfer1::IExecutionContext>& context) const {
-  torch::List<torch::Tensor> outputs{};
+  at::List<at::Tensor> outputs{};
   const auto& graph_outputs = engine_state_->outputs;
   outputs.reserve(graph_outputs.size());
   // Note: output_blob_names is aligned to the TRTEngine Operator's outputs, it
   // maybe duplicates. However, duplicate outputs to TensorRT engine are not
   // allowed. So, we use output name mapping between the TRTEngine Operator and
   // TensorRT Engine.
-  std::unordered_map<std::string, torch::Tensor> dedup_tensors;
+  std::unordered_map<std::string, at::Tensor> dedup_tensors;
   for (size_t k = 0; k < graph_outputs.size(); ++k) {
     const auto& name = graph_outputs[k].name;
     const auto& found = dedup_tensors.find(name);
@@ -219,7 +218,7 @@ torch::List<torch::Tensor> TRTContext::CreateAndBindingOutputs(
     auto option = torch::device(torch::kCUDA)
                       .dtype(torch_type.type)
                       .memory_format(torch::MemoryFormat::Contiguous);
-    torch::Tensor out_tensor = torch::empty(torch_type.shape, option);
+    at::Tensor out_tensor = torch::empty(torch_type.shape, option);
     binding_buffers[output_bind_indices_[optimization_profile_][k]] =
         out_tensor.data_ptr();
     outputs.push_back(out_tensor);
@@ -229,7 +228,7 @@ torch::List<torch::Tensor> TRTContext::CreateAndBindingOutputs(
 }
 
 bool TRTContext::IsInRange(
-    const torch::List<torch::Tensor>& inputs,
+    const at::List<at::Tensor>& inputs,
     int64_t profile_index) {
   /* Determine whether the inputs shapes in ranges of the profile. */
   const auto& profile_input_bind_indices = input_bind_indices_[profile_index];
@@ -240,7 +239,7 @@ bool TRTContext::IsInRange(
       // skip invalid input
       continue;
     }
-    torch::Tensor inp_tensor = inputs[k];
+    at::Tensor inp_tensor = inputs[k];
     const auto& inp_shape = inp_tensor.sizes();
     // bindingIndex of getProfileDimensions must belong to the given
     // profile, or be between 0 and bindingsPerProfile-1
@@ -263,7 +262,7 @@ bool TRTContext::IsInRange(
   return true;
 }
 
-bool TRTContext::IsInRange(const torch::List<torch::Tensor>& inputs) {
+bool TRTContext::IsInRange(const at::List<at::Tensor>& inputs) {
   for (int64_t j = 0; j < profile_num_; ++j) {
     // start iterate from optimization_profile_
     auto i = (j + optimization_profile_) % profile_num_;
@@ -274,7 +273,7 @@ bool TRTContext::IsInRange(const torch::List<torch::Tensor>& inputs) {
   return false;
 }
 
-void TRTContext::UpdateProfileIfNeed(const torch::List<torch::Tensor>& inputs) {
+void TRTContext::UpdateProfileIfNeed(const at::List<at::Tensor>& inputs) {
   /* Update profile according to the inputs' shapes if multiple profiles are
    * used */
   if (profile_num_ <= 1) {
@@ -291,7 +290,7 @@ void TRTContext::UpdateProfileIfNeed(const torch::List<torch::Tensor>& inputs) {
 }
 
 bool TRTContext::ChangingShape(
-    const torch::List<torch::Tensor>& inputs,
+    const at::List<at::Tensor>& inputs,
     std::shared_ptr<nvinfer1::IExecutionContext>& context) {
   if (!IsInRange(inputs, optimization_profile_)) {
     return false;
@@ -299,7 +298,7 @@ bool TRTContext::ChangingShape(
 
   const auto& graph_inputs = engine_state_->inputs;
   for (size_t k = 0; k < inputs.size(); ++k) {
-    torch::Tensor inp_tensor = inputs[k];
+    at::Tensor inp_tensor = inputs[k];
     int bind_index = input_bind_indices_[optimization_profile_][k];
     // The subgraph input should have been eliminated in TensorRT engine
     if (bind_index < 0) {
@@ -317,8 +316,8 @@ bool TRTContext::ChangingShape(
   return true;
 }
 
-torch::List<torch::Tensor> TRTContext::PreProcessInputs(
-    const torch::List<torch::Tensor>& inputs,
+at::List<at::Tensor> TRTContext::PreProcessInputs(
+    const at::List<at::Tensor>& inputs,
     std::shared_ptr<nvinfer1::IExecutionContext>& context) {
   // TODO: we currently only support inputs on the same device as tensorrt
   TORCH_CHECK(tensorrt_device_ == c10::cuda::current_device());
@@ -327,10 +326,10 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
 
   const auto& graph_inputs = engine_state_->inputs;
   // pre-process the input bindings
-  torch::List<torch::Tensor> cuda_ctu_inputs;
+  at::List<at::Tensor> cuda_ctu_inputs;
   for (int k = 0; k < inputs.size(); ++k) {
     // make sure the input is in contiguous layout
-    torch::Tensor inp_tensor = inputs[k];
+    at::Tensor inp_tensor = inputs[k];
     auto dtype = graph_inputs[k].scalar_type;
     // TODO: the option follow not valid for contiguous
     // auto option = torch::device(torch::kCUDA)
@@ -346,8 +345,7 @@ torch::List<torch::Tensor> TRTContext::PreProcessInputs(
   return cuda_ctu_inputs;
 }
 
-torch::List<torch::Tensor> TRTContext::Execute(
-    const torch::List<torch::Tensor>& inputs) {
+at::List<at::Tensor> TRTContext::Execute(const at::List<at::Tensor>& inputs) {
   std::vector<void*> binding_buffers(engine_->getNbBindings());
 
   // TODO: we assume the inputs are all computed on the current cuda
@@ -361,23 +359,22 @@ torch::List<torch::Tensor> TRTContext::Execute(
   std::lock_guard<std::mutex> guard(lock_);
   // the inputs is pass as args to select a suitable profile
   auto context = GetExecutionContext(stream, inputs);
-  torch::List<torch::Tensor> cuda_ctu_inputs =
-      PreProcessInputs(inputs, context);
+  at::List<at::Tensor> cuda_ctu_inputs = PreProcessInputs(inputs, context);
 
   // Input/output CUDA memory bindings
   BindingInputs(cuda_ctu_inputs, binding_buffers);
-  torch::List<torch::Tensor> outputs =
+  at::List<at::Tensor> outputs =
       CreateAndBindingOutputs(binding_buffers, context);
   context->enqueueV2(&binding_buffers[0], stream, nullptr);
   return PostProcessOutputs(outputs);
 }
 
-torch::List<torch::Tensor> TRTContext::PostProcessOutputs(
-    const torch::List<torch::Tensor>& outputs) const {
-  torch::List<torch::Tensor> new_outputs;
+at::List<at::Tensor> TRTContext::PostProcessOutputs(
+    const at::List<at::Tensor>& outputs) const {
+  at::List<at::Tensor> new_outputs;
   auto const& graph_outputs = engine_state_->outputs;
   for (size_t k = 0; k < outputs.size(); ++k) {
-    torch::Tensor out = outputs[k];
+    at::Tensor out = outputs[k];
     torch::ScalarType type = graph_outputs[k].scalar_type;
     new_outputs.push_back(out.to(type));
   }

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.cpp
@@ -23,8 +23,8 @@
 namespace torch {
 namespace blade {
 namespace tensorrt {
-torch::ScalarType NvDataType2TorchDataType(nvinfer1::DataType dtype) {
-  static std::map<nvinfer1::DataType, torch::ScalarType> d2t = {
+at::ScalarType NvDataType2TorchDataType(nvinfer1::DataType dtype) {
+  static std::map<nvinfer1::DataType, at::ScalarType> d2t = {
       {nvinfer1::DataType::kFLOAT, torch::kFloat},
       {nvinfer1::DataType::kHALF, torch::kFloat16},
       {nvinfer1::DataType::kINT8, torch::kInt8},
@@ -375,7 +375,7 @@ at::List<at::Tensor> TRTContext::PostProcessOutputs(
   auto const& graph_outputs = engine_state_->outputs;
   for (size_t k = 0; k < outputs.size(); ++k) {
     at::Tensor out = outputs[k];
-    torch::ScalarType type = graph_outputs[k].scalar_type;
+    at::ScalarType type = graph_outputs[k].scalar_type;
     new_outputs.push_back(out.to(type));
   }
   return new_outputs;

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
@@ -11,7 +11,11 @@
 
 #pragma once
 
+#include <ATen/core/List.h>
+#include <ATen/core/ScalarType.h>
+#include <ATen/core/Tensor.h>
 #include <c10/cuda/CUDAStream.h>
+
 #include <atomic>
 #include "common_utils/macros.h"
 #include "compiler/backends/engine_interface.h"
@@ -31,34 +35,33 @@ class TRTContext {
   // this is not thread-safe initialization
   TRTContext(std::shared_ptr<State> state);
   std::string SerializeAsString() const;
-  torch::List<torch::Tensor> Execute(const torch::List<torch::Tensor>&);
-  bool IsInRange(const torch::List<torch::Tensor>& inputs);
+  at::List<at::Tensor> Execute(const at::List<at::Tensor>&);
+  bool IsInRange(const at::List<at::Tensor>& inputs);
 
  private:
   // Setup binding buffers to the input/output blobs on the GPU.
   // Input/output blob mem ptr should be provided by the caller,
   // the TRTEngine is not the owner of the blobs' cuda memory.
-  void BindingInputs(
-      const torch::List<torch::Tensor>& inputs,
-      std::vector<void*>&) const;
-  torch::List<torch::Tensor> CreateAndBindingOutputs(
+  void BindingInputs(const at::List<at::Tensor>& inputs, std::vector<void*>&)
+      const;
+  at::List<at::Tensor> CreateAndBindingOutputs(
       std::vector<void*>&,
       std::shared_ptr<nvinfer1::IExecutionContext>& context) const;
-  torch::List<torch::Tensor> PostProcessOutputs(
-      const torch::List<torch::Tensor>& outputs) const;
-  torch::List<torch::Tensor> PreProcessInputs(
-      const torch::List<torch::Tensor>& inputs,
+  at::List<at::Tensor> PostProcessOutputs(
+      const at::List<at::Tensor>& outputs) const;
+  at::List<at::Tensor> PreProcessInputs(
+      const at::List<at::Tensor>& inputs,
       std::shared_ptr<nvinfer1::IExecutionContext>& context);
   bool ChangingShape(
-      const torch::List<torch::Tensor>& inputs,
+      const at::List<at::Tensor>& inputs,
       std::shared_ptr<nvinfer1::IExecutionContext>& context);
 
-  bool CheckCurrentDevice(const torch::List<torch::Tensor>& inputs) const;
+  bool CheckCurrentDevice(const at::List<at::Tensor>& inputs) const;
   std::shared_ptr<nvinfer1::IExecutionContext> GetExecutionContext(
       c10::cuda::CUDAStream& stream,
-      const torch::List<torch::Tensor>& inputs);
-  void UpdateProfileIfNeed(const torch::List<torch::Tensor>& inputs);
-  bool IsInRange(const torch::List<torch::Tensor>&, int64_t);
+      const at::List<at::Tensor>& inputs);
+  void UpdateProfileIfNeed(const at::List<at::Tensor>& inputs);
+  bool IsInRange(const at::List<at::Tensor>&, int64_t);
   int64_t tensorrt_device_;
   mutable std::mutex lock_;
   TrtUniquePtr<nvinfer1::ICudaEngine> engine_;

--- a/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
+++ b/pytorch_blade/src/compiler/tensorrt/tensorrt_engine_context.h
@@ -24,7 +24,7 @@
 namespace torch {
 namespace blade {
 namespace tensorrt {
-torch::ScalarType NvDataType2TorchDataType(nvinfer1::DataType dtype);
+at::ScalarType NvDataType2TorchDataType(nvinfer1::DataType dtype);
 
 class TRTContext {
   using State = torch::blade::backends::EngineState;

--- a/pytorch_blade/src/platform_alibaba
+++ b/pytorch_blade/src/platform_alibaba
@@ -1,1 +1,0 @@
-/home/tianyou.gty/develop/pytorch-addons/pytorch_blade_alibaba/src/platform_alibaba

--- a/pytorch_blade/src/pybind.cpp
+++ b/pytorch_blade/src/pybind.cpp
@@ -23,6 +23,7 @@
 
 #ifdef TORCH_BLADE_BUILD_MLIR
 #include "compiler/mlir/pybind_functions.h"
+#include "compiler/mlir/runtime/disc_engine.h"
 #endif // TORCH_BLADE_BUILD_MLIR
 
 // this include resolve some pybind11 incompatible problem of torch data

--- a/pytorch_blade/src/pybind.cpp
+++ b/pytorch_blade/src/pybind.cpp
@@ -48,6 +48,8 @@ std::string pybind_version() {
 
 template <>
 void initModules<false>(py::module& m) {
+  torch::blade::backends::InitTorchBladeEngine();
+  torch::blade::disc::InitBladeDiscEngine();
   torch::blade::initToolsBindings(m);
   m.def(
       "jit_pass_onnx_constant_f64_to_f32",


### PR DESCRIPTION
The inclusion of TorchScript one-stop header will such as:
```
#include <torch/script.h>
```
will lead to dependencies on un-related header files that are not required.
This will increase the risk of symbol conflicts. Sometimes we will run into segfault and it's hard to reason about.

To make our source files' dependencies clear, the pull request uses as more specific headers as possible.
