### PR TITLE
Support gemm pre-packing via onednn/acl on aarch64

### DIFF
--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
@@ -631,7 +631,7 @@ std::shared_ptr<MatmulPrimitive> getOrCreateMatmulPrimitive(
     it = cached_primitive.insert(std::make_pair(key, std::move(primitive)))
              .first;
   }
-  return it->second.get();
+  return it->second;
 }
 
 template <typename Tinput, int N = 2, typename Tweight = Tinput,

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
@@ -824,8 +824,6 @@ void onednn_ral_batch_gemm(ExecutionContext* ctx, void* stream_handle,
     return;
   }
 
-  TAO_VLOG(0) << "xxxxxx debug";
-
   std::string unique_name = "tao_ral.cpu.onednn_acl_batch_gemm_" +
                             tao::ral::TaoTypeNameHelper<Tinput>::Invoke();
   auto state = ctx->getOrCreateResource<OnednnACLGemmState>(

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.cc
@@ -620,7 +620,7 @@ struct OnednnACLGemmState : public Context::Resource {
   OnednnACLGemmCache cached_primitive{getWeightPrePackingCacheCapacity()};
 };
 
-MatmulPrimitive* getOrCreateMatmulPrimitive(
+std::shared_ptr<MatmulPrimitive> getOrCreateMatmulPrimitive(
     OnednnACLGemmCache& cached_primitive, const OnednnACLGemmKey& key,
     const tensor& src, const tensor& weight, tensor& output) {
   auto it = cached_primitive.find(key);
@@ -674,7 +674,7 @@ void onednn_ral_gemm(ExecutionContext* ctx, void* stream_handle,
                             tao::ral::TaoTypeNameHelper<Tinput>::Invoke();
   auto state = ctx->getOrCreateResource<OnednnACLGemmState>(
       unique_name, []() { return new OnednnACLGemmState; });
-  MatmulPrimitive* primitive;
+  std::shared_ptr<MatmulPrimitive> primitive;
   {
     OnednnACLGemmKey key{m,    n,    k,      1,
                          tp_a, tp_b, B.data, std::this_thread::get_id()};
@@ -844,7 +844,7 @@ void onednn_ral_batch_gemm(ExecutionContext* ctx, void* stream_handle,
                             tao::ral::TaoTypeNameHelper<Tinput>::Invoke();
   auto state = ctx->getOrCreateResource<OnednnACLGemmState>(
       unique_name, []() { return new OnednnACLGemmState; });
-  MatmulPrimitive* primitive;
+  std::shared_ptr<MatmulPrimitive> primitive;
   {
     std::lock_guard<std::mutex> l(state->mu);
     OnednnACLGemmKey key{m,    n,    k,      b,

--- a/tao_compiler/mlir/xla/ral/context/mkldnn/ideep/ideep/operators/matmul.hpp
+++ b/tao_compiler/mlir/xla/ral/context/mkldnn/ideep/ideep/operators/matmul.hpp
@@ -4,7 +4,7 @@
 namespace ideep {
 
 struct matmul_forward : public dnnl::matmul,
-                        utils::computation_cache<dnnl::matmul::primitive_desc> {
+                        utils::computation_cache<dnnl::matmul> {
   using super = dnnl::matmul;
 
   template <bool keep_format = true, bool weight_format_any = false>
@@ -84,7 +84,7 @@ struct matmul_forward : public dnnl::matmul,
  private:
   template <bool with_bias = false, bool keep_format = true,
             bool weight_format_any = false>
-  static primitive_desc get_primitive_desc(
+  static super get_primitive_desc(
       const tensor::desc& src_desc, const tensor::desc& weights_desc,
       const tensor::desc& bias_desc, const tensor::desc& dst_desc,
       const attr_t& attr = attr_t(),
@@ -105,12 +105,13 @@ struct matmul_forward : public dnnl::matmul,
     auto key =
         utils::create_key(src_desc_query, weights_desc_query, with_bias, attr);
     return fetch_or_create(key, [&]() {
-      return with_bias ? primitive_desc({src_desc_query, weights_desc_query,
+      return with_bias
+                 ? super(primitive_desc({src_desc_query, weights_desc_query,
                                          bias_desc_query, dst_desc_query},
-                                        attr, aengine)
-                       : primitive_desc({src_desc_query, weights_desc_query,
-                                         dst_desc_query},
-                                        attr, aengine);
+                                        attr, aengine))
+                 : super(primitive_desc(
+                       {src_desc_query, weights_desc_query, dst_desc_query},
+                       attr, aengine));
     });
   }
 
@@ -127,18 +128,21 @@ struct matmul_forward : public dnnl::matmul,
       bias_desc = bias.get_desc();
     }
     dst_desc = dst.get_desc();
-    auto pd = get_primitive_desc<with_bias, keep_format, weight_format_any>(
-        src_desc, weights_desc, bias_desc, dst_desc, attr, aengine);
+    auto super_primitive =
+        get_primitive_desc<with_bias, keep_format, weight_format_any>(
+            src_desc, weights_desc, bias_desc, dst_desc, attr, aengine);
     if (with_bias) {
-      super(pd).execute(stream::default_stream(), {{DNNL_ARG_SRC, src},
-                                                   {DNNL_ARG_WEIGHTS, weights},
-                                                   {DNNL_ARG_BIAS, bias},
-                                                   {DNNL_ARG_DST, dst}});
+      super_primitive.execute(stream::default_stream(),
+                              {{DNNL_ARG_SRC, src},
+                               {DNNL_ARG_WEIGHTS, weights},
+                               {DNNL_ARG_BIAS, bias},
+                               {DNNL_ARG_DST, dst}});
 
     } else {
-      super(pd).execute(stream::default_stream(), {{DNNL_ARG_SRC, src},
-                                                   {DNNL_ARG_WEIGHTS, weights},
-                                                   {DNNL_ARG_DST, dst}});
+      super_primitive.execute(stream::default_stream(),
+                              {{DNNL_ARG_SRC, src},
+                               {DNNL_ARG_WEIGHTS, weights},
+                               {DNNL_ARG_DST, dst}});
     }
   }
 


### PR DESCRIPTION
ACL NEGEMM itself supports weight pre-packing by default. Without this
PR, we create a new dnnl::matmul primitive for each matmul call, which
in turn creates a new NEGEMM object inside the primitive on aarch64.
We can not re-use the pre-packed weight from previous matmul call even
for the same matmul configuration since the NEGEMM is destroyed after
each matmul call. This RP tries to cache the matmul primitive across
matmul calls and thus can make use of the underlying pre-packed weight
for compatible matmul calls.