### PR TITLE
Support using provided output values as golden

### DIFF
--- a/tao_compiler/mlir/disc/tests/mlir_feature_test.h
+++ b/tao_compiler/mlir/disc/tests/mlir_feature_test.h
@@ -12,17 +12,20 @@
 #include <string>
 #include <vector>
 
+#include "tensorflow/compiler/mlir/disc/tests/mlir_test.h"
+
 namespace mlir_test {
 
 enum class BackendType;
 
-bool feature_test_main(const std::string& mlir_file_path,
-                       const std::vector<BackendType>& backend_types,
-                       int num_inputs, int num_outputs,
-                       const std::vector<std::string>& input_descriptors,
-                       const std::vector<std::string>& output_descriptors,
-                       const std::vector<std::vector<float>>& input_vals = {},
-                       bool profiling = false, bool multi_cc_mode = false,
-                       bool multi_cc_mode_dbg_ptx_only = false);
+bool feature_test_main(
+    const std::string& mlir_file_path,
+    const std::vector<BackendType>& backend_types, int num_inputs,
+    int num_outputs, const std::vector<std::string>& input_descriptors,
+    const std::vector<std::string>& output_descriptors,
+    const std::vector<std::vector<float>>& input_vals = {},
+    const std::vector<tensorflow::Tensor>& expected_output_vals = {},
+    bool profiling = false, bool multi_cc_mode = false,
+    bool multi_cc_mode_dbg_ptx_only = false);
 
 }  // namespace mlir_test

--- a/tao_compiler/mlir/disc/tests/mlir_test.h
+++ b/tao_compiler/mlir/disc/tests/mlir_test.h
@@ -73,6 +73,7 @@ class MlirTest {
                     const std::vector<std::vector<float>>& input_vals,
                     const std::vector<tensorflow::DataType>& out_elem_types,
                     const std::vector<DeviceType>& output_placement,
+                    const std::vector<tensorflow::Tensor>& expected_output_vals,
                     bool profiling = false, bool multi_cc_mode = false,
                     bool multi_cc_mode_dbg_ptx_only = false);
 
@@ -84,6 +85,7 @@ class MlirTest {
   virtual tensorflow::Status GenerateInputAndRun() = 0;
   tensorflow::Status LoadGraph(const std::string& graph_file_name);
   tensorflow::Status RunGoldenTF();
+  tensorflow::Status CompareResults();
   template <class T>
   static bool IsAcceptableNear(T a, T b, double rel_err_limit = 1e-2,
                                double abs_err_limit = 1e-4);
@@ -117,6 +119,9 @@ class MlirTest {
   // actual run results in host memory
   std::vector<std::shared_ptr<void>> actual_results_;
 
+  // Stores the expected output of the test.
+  std::vector<tensorflow::Tensor> expected_output_vals_;
+
   std::unordered_map<std::string, std::string> output_tensor_name_map_;
 };
 
@@ -130,8 +135,10 @@ class MlirTestImpl : public MlirTest {
       const std::vector<DeviceType>& input_placement,
       const std::vector<std::vector<float>>& input_vals,
       const std::vector<tensorflow::DataType>& out_elem_types,
-      const std::vector<DeviceType>& output_placement, bool profiling = false,
-      bool multi_cc_mode = false, bool multi_cc_mode_dbg_ptx_only = false);
+      const std::vector<DeviceType>& output_placement,
+      const std::vector<tensorflow::Tensor>& expected_output_vals,
+      bool profiling = false, bool multi_cc_mode = false,
+      bool multi_cc_mode_dbg_ptx_only = false);
 
   ~MlirTestImpl();
 

--- a/tao_compiler/mlir/disc/tests/regression/data/use_expect_output.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/use_expect_output.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func @main(%arg0: tensor<?x?xui8>) -> (tensor<?x?xf32>) attributes {tf.entry_function = {inputs = "input0", outputs = "output0"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.Cast"(%arg0) : (tensor<?x?xui8>) -> (tensor<?x?xf32>)
+      tf_executor.fetch %0 : tensor<?x?xf32>
+    }
+    return %graph : tensor<?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/use_expect_output.cc
+++ b/tao_compiler/mlir/disc/tests/regression/use_expect_output.cc
@@ -22,34 +22,26 @@ namespace mlir_test {
 const std::string c_ft_path =
     "tensorflow/compiler/mlir/disc/tests/regression/data/";
 
-TEST(MultiCCTest, BasicTest) {
-  EXPECT_TRUE(feature_test_main(
-      /*mlir_file_path*/ c_ft_path + "multi_cc.mlir",
-      /*backend_types*/ {BackendType::kCuda},
-      /*num_inputs*/ 1,
-      /*num_outputs*/ 1,
-      /*input_descriptors*/ {"13x21x100xf32_X"},
-      /*output_descriptors*/ {"f32_X"},
-      /*input_vals*/ {},
-      /*expected_output_vals*/ {},
-      /*profiling*/ false,
-      /*multi_cc_mode*/ true,
-      /*multi_cc_mode_dbg_ptx_only*/ false));
-}
+TEST(UseExpectOutput, BasicTest) {
+  tensorflow::Tensor output(tensorflow::DataType::DT_FLOAT, {2, 3});
+  auto datas = output.flat<float>();
+  datas(0) = 255.0f;
+  datas(1) = 128.0f;
+  datas(2) = 0.0f;
+  datas(3) = 63.0f;
+  datas(4) = 158.0f;
+  datas(5) = 33.0f;
 
-TEST(MultiCCTest, PtxTest) {
   EXPECT_TRUE(feature_test_main(
-      /*mlir_file_path*/ c_ft_path + "multi_cc.mlir",
-      /*backend_types*/ {BackendType::kCuda},
+      /*mlir_file_path*/ c_ft_path + "use_expect_output.mlir",
+      /*backend_types*/
+      kSupportedBackendList,
       /*num_inputs*/ 1,
       /*num_outputs*/ 1,
-      /*input_descriptors*/ {"13x21x100xf32_X"},
+      /*input_descriptors*/ {"2x3xui8_X"},
       /*output_descriptors*/ {"f32_X"},
-      /*input_vals*/ {},
-      /*expected_output_vals*/ {},
-      /*profiling*/ false,
-      /*multi_cc_mode*/ true,
-      /*multi_cc_mode_dbg_ptx_only*/ true));
+      /*input_vals*/ {{255, 128, 0, 63, 158, 33}},
+      /*expect_output_vals*/ {output}));
 }
 
 }  // namespace mlir_test


### PR DESCRIPTION
Some UTs are not runnable by TF (e.g. some custom quantized op).
This PR supports to use a set of provided output values as golden.