### PR TITLE
fix mismatch return types of a lambda function

### DIFF
--- a/tao_compiler/mlir/disc/transforms/disc_for_loop_unroll_interleave.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_for_loop_unroll_interleave.cc
@@ -126,9 +126,7 @@ struct ForLoopUnrollInterleave
       // Currently, it only unrolls and interleaves loops for kStitch and
       // kLoop fusion on GPU.
       // TODO: support more types of fusions.
-      if (!isOnGpu(op)) {
-        return WalkResult::advance();
-      }
+      if (!isOnGpu(op)) return;
       if (isFusionType<FusionType::kStitch, FusionType::kLoop>(op)) {
         SmallVector<scf::ParallelOp, 2> innermostPloops;
         getInnermostParallelLoops(op, innermostPloops);


### PR DESCRIPTION
Without this revision, the return type of the lambda function is not
defined. This error should be raised at compile time. However, it seems
to be ok at compile time in some environments while leading to a very weird
behavior at runtime.