### PR TITLE
[CI] make torch cuda ci config reusable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,98 +123,54 @@ jobs:
         set -e
         bash ./scripts/ci/deploy_tensorflow_blade.sh
   CUDA11-TORCH171:
-    if: github.repository == 'alibaba/BladeDISC'
-    # The type of runner that the job will run on
-    runs-on: [self-hosted, gpu-t4]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Runs a single command using the runners shell
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Build Dev Docker
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker pull bladedisc/bladedisc:latest-devel-cuda11.0
-        docker build --cache-from bladedisc/bladedisc:latest-devel-cuda11.0 -t disc-dev-cuda11.0 \
-          --build-arg BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 \
-          --build-arg DEVICE=cu110 \
-          -f docker/dev/Dockerfile .
-    - name: Build and Test DISC
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u):$(id -g) \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -w /disc \
-          disc-dev-cuda11.0 bash ./scripts/ci/test_pytorch_blade.sh
-    - name: Deploy PyTorch Blade
-      if: github.event.ref == 'refs/heads/main'
-      env:
-        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GITHUB_PULL_REQUEST: ${{ github.event.number }}
-        LOCAL_DEV_DOCKER: disc-dev-cuda11.0
-        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda11.0
-        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-torch1.7.1
-        RUNTIME_BASEIMAGE: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
-        DOCKERFILE: docker/runtime/Dockerfile.pytorch
-      run: |
-        set -e
-        bash ./scripts/ci/deploy_pytorch_blade.sh
+    uses: ./.github/workflows/torch_cuda_reusable.yml
+    with:
+      cuda_version: cu110
+      torch_version: 1.7.1
+      remote_runtime_docker: bladedisc:latest-runtime-torch1.7.1-cu110
+      develop_base_image: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+      runtime_base_image: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+      deploy_command:  bash ./scripts/ci/deploy_pytorch_blade.sh
+    secrets:
+      ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+      ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+ 
   CUDA10_2-TORCH181:
-    if: github.repository == 'alibaba/BladeDISC'
-    # The type of runner that the job will run on
-    runs-on: [self-hosted, gpu-t4]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Runs a single command using the runners shell
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Build Dev Docker
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker build -t disc-dev-cuda10.2 \
-          --build-arg BASEIMAGE=nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04 \
-          --build-arg DEVICE=cu102 \
-          -f docker/dev/Dockerfile .
-    - name: Build and Test DISC
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u):$(id -g) \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -e TORCH_BLADE_BUILD_TENSORRT_STATIC=ON \
-          -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.8.1+cu102 \
-          -w /disc \
-          disc-dev-cuda10.2 bash ./scripts/ci/test_pytorch_blade.sh
-    - name: Deploy PyTorch Blade
-      if: github.event.ref == 'refs/heads/main'
-      env:
-        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GITHUB_PULL_REQUEST: ${{ github.event.number }}
-        LOCAL_DEV_DOCKER: disc-dev-cuda10.2
-        REMOTE_DEV_DOCKER: bladedisc:latest-devel-cuda10.2
-        REMOTE_RUNTIME_DOCKER: bladedisc:latest-runtime-torch1.8.1-cu102
-        RUNTIME_BASEIMAGE: nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
-        DOCKERFILE: docker/runtime/Dockerfile.pytorch
-      run: |
-        set -e
-        bash ./scripts/ci/deploy_pytorch_blade.sh
+    uses: ./.github/workflows/torch_cuda_reusable.yml
+    with:
+      cuda_version: cu102
+      torch_version: 1.8.1
+      remote_runtime_docker: bladedisc:latest-runtime-torch1.8.1-cu102
+      develop_base_image: nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
+      runtime_base_image: nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
+      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+      deploy_command:  bash ./scripts/ci/deploy_pytorch_blade.sh
+    secrets:
+      ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+      ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+ 
+  CUDA11_3-TORCH-1_12:
+    uses: ./.github/workflows/torch_cuda_reusable.yml
+    with:
+      cuda_version: cu113
+      torch_version: 1.12.0
+      remote_runtime_docker: bladedisc:latest-runtime-torch1.12.1-cu113
+      develop_base_image: nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04
+      runtime_base_image: nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04
+      extra_build_args: --build-arg PYTHON_VERSION=PYTHON3.8 --build-arg ENABLE_FIND_FASTEST_APT_SOURCE=OFF
+      exec_command: bash ./scripts/ci/test_pytorch_blade.sh
+      deploy_command:  bash ./scripts/ci/deploy_pytorch_blade.sh
+    secrets:
+      ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+      ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+ 
   CPU-TF115:
     uses: ./.github/workflows/cpu_reusable.yml
     with:
@@ -239,36 +195,7 @@ jobs:
       ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  CUDA11_3-TORCH-1_12:
-    if: github.repository == 'alibaba/BladeDISC'
-    runs-on: [self-hosted, gpu-t4]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Build Dev Docker
-      run: |
-        set -e
-        git submodule sync
-        git submodule update --depth=1 --init --recursive
-        docker build -t disc-dev-cuda11.3-py38 \
-          --build-arg BASEIMAGE=nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04 \
-          --build-arg DEVICE=cu113 \
-          --build-arg PYTHON_VERSION=PYTHON3.8 \
-          --build-arg ENABLE_FIND_FASTEST_APT_SOURCE=OFF \
-          -f docker/dev/Dockerfile .
-    - name: Build and Test DISC
-      run: |
-        set -e
-        nvidia-docker run --rm -t --user $(id -u):$(id -g) \
-          -v $HOME/.cache:$HOME/.cache \
-          -v /etc/passwd:/etc/passwd:ro \
-          -v /etc/group:/etc/group:ro \
-          -v $PWD:/disc \
-          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
-          -e TORCH_BLADE_BUILD_TENSORRT_STATIC=ON \
-          -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=1.12.0+cu113 \
-          -w /disc \
-          disc-dev-cuda11.3-py38  bash ./scripts/ci/test_pytorch_blade.sh
+
   AArch64-CPU-TF280:
     if: github.repository == 'alibaba/BladeDISC'
     # The type of runner that the job will run on

--- a/.github/workflows/torch_cuda_reusable.yml
+++ b/.github/workflows/torch_cuda_reusable.yml
@@ -1,0 +1,98 @@
+name: Torch CUDA Reusable workflow
+
+on:
+  workflow_call:
+    inputs:
+      cuda_version:
+        required: true
+        type: string
+      torch_version:
+        required: true
+        type: string
+      extra_build_args:
+        required: false
+        type: string
+      extra_envs:
+        required: false
+        type: string
+      exec_command:
+        required: true
+        type: string
+      deploy_command:
+        required: false
+        type: string
+      remote_runtime_docker:
+        required: false
+        type: string
+      develop_base_image:
+        required: false
+        type: string
+      runtime_base_image:
+        required: false
+        type: string
+    secrets:
+      ALIYUN_DOCKER_USERNAME:
+        required: false
+      ALIYUN_DOCKER_PASSWORD:
+        required: false
+      DOCKER_USERNAME:
+        required: false
+      DOCKER_PASSWORD:
+        required: false
+
+jobs:
+  CUDA:
+    if: github.repository == 'alibaba/BladeDISC'
+    # The type of runner that the job will run on
+    runs-on: [self-hosted, gpu-t4]
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Runs a single command using the runners shell
+    - name: Checkout
+      uses: actions/checkout@v2.4.0
+    - name: Build Dev Docker
+      run: |
+        set -e
+        git submodule sync
+        git submodule update --depth=1 --init --recursive
+        docker build -t disc-dev-${{ inputs.cuda_version }} \
+          --build-arg BASEIMAGE=${{ inputs.develop_base_image }} \
+          --build-arg DEVICE=${{ inputs.cuda_version }} \
+          ${{ inputs.extra_build_args }} \
+          -f docker/dev/Dockerfile .
+
+    - name: Build And Test
+      run: |
+        set -e
+        nvidia-docker run --rm -t --user $(id -u):$(id -g) \
+          -v $HOME/.cache:$HOME/.cache \
+          -v /etc/passwd:/etc/passwd:ro \
+          -v /etc/group:/etc/group:ro \
+          -v $PWD:/disc \
+          -e GITHUB_WORKFLOW=$GITHUB_WORKFLOW \
+          -e TORCH_BLADE_BUILD_TENSORRT_STATIC=ON \
+          -e TORCH_BLADE_CI_BUILD_TORCH_VERSION=${{ inputs.torch_version }}+${{ inputs.cuda_version }} \
+          ${{ inputs.extra_envs }} \
+          -w /disc \
+          disc-dev-${{ inputs.cuda_version }} ${{ inputs.exec_command }}
+ 
+    - name: Deploy Docker Image
+      if: github.event.ref == 'refs/heads/main'
+      env:
+        ALIYUN_DOCKER_USERNAME: ${{ secrets.ALIYUN_DOCKER_USERNAME }}
+        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        GITHUB_PULL_REQUEST: ${{ github.event.number }}
+        LOCAL_DEV_DOCKER: disc-dev-${{ inputs.cuda_version }}
+        REMOTE_DEV_DOCKER: bladedisc:latest-devel-${{ inputs.cuda_version }}
+        REMOTE_RUNTIME_DOCKER: ${{ inputs.remote_runtime_docker }}
+        RUNTIME_BASEIMAGE: ${{ inputs.runtime_base_image }}
+        DOCKERFILE: docker/runtime/Dockerfile.pytorch
+ 
+      run: |
+        set -e
+        if [[ ! -z "${{ inputs.deploy_command }}" ]]; then
+          echo "executing runtime Docker deployment"
+          ${{ inputs.deploy_command }}
+        fi


### PR DESCRIPTION
Before adding benchmark CI jobs mentioned in https://github.com/alibaba/BladeDISC/issues/450. It's better to make the CUDA CI workflow for PyTorch reusable.