### PR TITLE
[CI] fix install python3 on ubuntu20

### DIFF
--- a/docker/runtime/Dockerfile.pytorch
+++ b/docker/runtime/Dockerfile.pytorch
@@ -12,11 +12,12 @@ RUN bash /install/scripts/patch-cuda.sh "${DEVICE}"
 ADD ./build/torch_blade*.whl  /install/python/
 
 RUN apt-get update -y \
-    && apt-get install -y python3.6 python3-pip protobuf-compiler libprotobuf-dev cmake \
-    && ln -s /usr/bin/python3.6 /usr/bin/python \
-    && python3.6 -m pip install pip --upgrade \
-    && python3.6 -m pip install onnx==1.11.0 \
-    && python3.6 -m pip install /install/python/torch_blade*.whl -f https://download.pytorch.org/whl/torch_stable.html
+    && apt-get install -y python3 python3-pip protobuf-compiler libprotobuf-dev cmake \
+    && ln -s /usr/bin/python3 /usr/bin/python
+
+RUN python3 -m pip install pip --upgrade
+RUN python3 -m pip install onnx==1.11.0
+RUN python3 -m pip install /install/python/torch_blade*.whl -f https://download.pytorch.org/whl/torch_stable.html
 
 ENV PATH /usr/bin:$PATH
 ENV LD_LIBRARY_PATH="/usr/local/TensorRT/lib/:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
Before the deploy docker building failed because of the installation of python3 on ubuntu20. And we want to use the daily built runtime docker images for the TorchBlade benchmark mentioned in #450 