### PR TITLE
DoGeneralOp convert vector to matrix

### DIFF
--- a/tao_compiler/mlir/disc/transforms/disc_shape_optimization.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_optimization.cc
@@ -1111,7 +1111,8 @@ LogicalResult ShapeComputationIRAnalysis::applyMhloDotLikeOpConstraint(
     if (lhsTy.getRank() != lhsDims.size() || rhsTy.getRank() != rhsDims.size())
       return op->emitError("lhs or rhs mismatch rank\n");
 
-    if (failed(mgr_.mapSymbolicDimEqual(lhsDims[1], rhsDims[0])))
+    if (failed(
+            mgr_.mapSymbolicDimEqual(lhsDims[lhsTy.getRank() - 1], rhsDims[0])))
       return op->emitError() << "fail to merge dim\n";
   } else if (auto einsum = dyn_cast<mhlo::EinsumOp>(op)) {
     auto lhsTy = einsum.lhs().getType().dyn_cast<RankedTensorType>();

--- a/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
+++ b/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
@@ -83,6 +83,8 @@ struct DotToDotGeneralConvert : public OpRewritePattern<mhlo::DotOp> {
     Location loc = op.getLoc();
     Value old_lhs = op.lhs();
     Value old_rhs = op.rhs();
+    auto old_lhs_ty = old_lhs.getType().dyn_cast<RankedTensorType>();
+    if (!old_lhs_ty) return failure();
 
     std::vector<int64_t> lhs_contracting_dims;
     std::vector<int64_t> rhs_contracting_dims;
@@ -90,7 +92,12 @@ struct DotToDotGeneralConvert : public OpRewritePattern<mhlo::DotOp> {
     // (or the first if it has rank 1) and the first dimension of rhs. These are
     // the "contracted" dimensions.
     // See https://www.tensorflow.org/xla/operation_semantics#dot
-    lhs_contracting_dims.push_back(1);
+    if (old_lhs_ty.getRank() == 1) {
+      lhs_contracting_dims.push_back(0);
+    } else {
+      lhs_contracting_dims.push_back(1);
+    }
+
     rhs_contracting_dims.push_back(0);
     auto dot_dimension_attr = mhlo::DotDimensionNumbersAttr::get(
         rewriter.getContext(), {}, {}, lhs_contracting_dims,
@@ -100,7 +107,215 @@ struct DotToDotGeneralConvert : public OpRewritePattern<mhlo::DotOp> {
         op.getLoc(), op.getType(), op.lhs(), op.rhs(), dot_dimension_attr,
         nullptr);
     rewriter.replaceOp(op, dot_general);
+    return success();
+  }
+};
 
+// Converts DotGeneralOp if it represents vec * vec, vec * mat, mat * vec.
+// Will first unsqueeze vector to matirx, then convert DoGeneralOp to
+// matrix multiply; After that drop(unsqueeze) the extra-dimensions from
+// the output of DoGeneralOp.
+struct DotGeneralConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
+  explicit DotGeneralConvert(MLIRContext* context)
+      : OpRewritePattern(context) {}
+
+  SmallVector<Value, 4> getDimSizesOfTensor(PatternRewriter& rewriter,
+                                            Operation* op, Value value) const {
+    auto value_ty = value.getType().dyn_cast<RankedTensorType>();
+
+    auto loc = op->getLoc();
+    auto rank = value_ty.getRank();
+    // Get int vector [0, 1, ..., rank-1]
+    SmallVector<Value, 4> dim_sizes;
+    for (size_t d = 0; d < rank; ++d) {
+      dim_sizes.emplace_back(rewriter.create<tensor::DimOp>(loc, value, d));
+    }
+    return dim_sizes;
+  }
+
+  Value unsqueezeTensorDim(PatternRewriter& rewriter, Operation* op,
+                           Value tensor, int64_t dim) const {
+    // Returns a new tensor with dims of size 1 inserted at the specified
+    // position.
+    //
+    // The position indices (must be high to low dimension number of the
+    // returned tensor) are specified with unsqzDims. Indices must be in-order,
+    // and in range of tensor rank. Thus, unsqueeze a rank 1 tensor with {0, 2},
+    // {0, 1, 3}, {0, 1, 2} are all valid dimension sets, but {0, 3}, {2} are
+    // not.
+    auto dim_sizes = getDimSizesOfTensor(rewriter, op, tensor);
+    auto loc = op->getLoc();
+    auto one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    auto rank = dim_sizes.size();
+
+    auto rankTy = tensor.getType().dyn_cast<RankedTensorType>();
+    auto oldShape = rankTy.getShape();
+
+    SmallVector<Value, 4> newDimSizes;
+    SmallVector<int64_t, 4> newShape;
+    newDimSizes.reserve(rank + 1);
+    newShape.reserve(rank + 1);
+    for (size_t k = 0, i = 0; k < rank + 1; ++k) {
+      if (dim == k) {
+        newDimSizes.push_back(one);
+        newShape.push_back(1);
+      } else {
+        newDimSizes.push_back(dim_sizes[i]);
+        newShape.push_back(oldShape[i]);
+        i++;
+      }
+    }
+
+    auto outTy = RankedTensorType::get(newShape, rankTy.getElementType());
+    if (newShape.size() == 0) {
+      return rewriter.create<mhlo::ReshapeOp>(loc, outTy, tensor).getResult();
+    }
+
+    auto mhloShape = rewriter.create<tensor::FromElementsOp>(loc, newDimSizes);
+    return rewriter
+        .create<mhlo::DynamicReshapeOp>(loc, outTy, tensor, mhloShape)
+        .getResult();
+  }
+
+  Value squeezeTensorDim(PatternRewriter& rewriter, Operation* op, Value tensor,
+                         int64_t dim) const {
+    auto dim_sizes = getDimSizesOfTensor(rewriter, op, tensor);
+    auto rank = dim_sizes.size();
+
+    auto rankTy = tensor.getType().dyn_cast<RankedTensorType>();
+    auto oldShape = rankTy.getShape();
+
+    SmallVector<Value, 4> newDimSizes;
+    std::vector<int64_t> newShape;
+    newDimSizes.reserve(rank - 1);
+    newShape.reserve(rank - 1);
+    for (size_t k = 0; k < rank; ++k) {
+      if (dim == k) continue;
+      newDimSizes.push_back(dim_sizes[k]);
+      newShape.push_back(oldShape[k]);
+    }
+
+    auto outTy = RankedTensorType::get(newShape, rankTy.getElementType());
+    auto loc = op->getLoc();
+    if (newShape.size() == 0) {
+      return rewriter.create<mhlo::ReshapeOp>(loc, outTy, tensor).getResult();
+    }
+
+    auto mhloShape = rewriter.create<tensor::FromElementsOp>(loc, newDimSizes);
+    return rewriter
+        .create<mhlo::DynamicReshapeOp>(loc, outTy, tensor, mhloShape)
+        .getResult();
+  }
+
+  LogicalResult matchAndRewrite(mhlo::DotGeneralOp op,
+                                PatternRewriter& rewriter) const override {
+    Location loc = op.getLoc();
+    Value old_lhs = op.lhs();
+    Value old_rhs = op.rhs();
+
+    RankedTensorType old_l_type =
+        old_lhs.getType().dyn_cast<RankedTensorType>();
+    RankedTensorType old_r_type =
+        old_rhs.getType().dyn_cast<RankedTensorType>();
+    if ((!old_l_type || !old_r_type)) {
+      return failure();
+    }
+
+    auto dim_numbers = op.dot_dimension_numbers();
+    auto batching_dims = dim_numbers.getLhsBatchingDimensions();
+    auto n_batch_dims = batching_dims.size();
+    for (auto d : batching_dims)
+      if (d >= n_batch_dims)
+        return rewriter.notifyMatchFailure(
+            op, "the batching_dims must be the leading dimensions");
+
+    auto lhs_contracting_dims = dim_numbers.getLhsContractingDimensions();
+    auto rhs_contracting_dims = dim_numbers.getRhsContractingDimensions();
+    if (lhs_contracting_dims.size() != 1 || rhs_contracting_dims.size() != 1)
+      return rewriter.notifyMatchFailure(op, "multiple contracting dimensions");
+
+    size_t old_lhs_rank = old_l_type.getRank();
+    size_t old_rhs_rank = old_r_type.getRank();
+    Value new_lhs = old_lhs;
+    Value new_rhs = old_rhs;
+
+    auto old_out_ty = op.getType().dyn_cast<RankedTensorType>();
+    auto old_out_shape = old_out_ty.getShape();
+    SmallVector<int64_t, 4> new_out_shape{old_out_shape.begin(),
+                                          old_out_shape.begin() + n_batch_dims};
+    while (new_out_shape.size() < n_batch_dims + 2) new_out_shape.push_back(-1);
+
+    auto old_lhs_matrix_rank = old_lhs_rank - n_batch_dims;
+    auto old_rhs_matrix_rank = old_rhs_rank - n_batch_dims;
+    // Only do conversion for mhlo::DotGeneralOp lowering from mhlo::DotOp,
+    // mhlo::EinsumOp can be convert similar, can be added if it's needed.
+    //
+    // unsqueeze lhs & rhs to matrix if needed
+    if (old_lhs_matrix_rank == 1) {
+      if (old_rhs_matrix_rank == 1) {
+        // equivalent to mhlo::DotOp(vec, vec)
+        assert(n_batch_dims == rhs_contracting_dims[0] &&
+               n_batch_dims == lhs_contracting_dims[0]);
+        new_lhs = unsqueezeTensorDim(rewriter, op, old_lhs, n_batch_dims);
+        new_rhs = unsqueezeTensorDim(rewriter, op, old_rhs, n_batch_dims + 1);
+        new_out_shape[n_batch_dims] = 1;
+        new_out_shape[n_batch_dims + 1] = 1;
+      } else if (old_rhs_matrix_rank == 2 &&
+                 n_batch_dims == rhs_contracting_dims[0]) {
+        // equivalent to mhlo::DotOp(vec, mat)
+        assert(n_batch_dims == lhs_contracting_dims[0]);
+        new_out_shape[n_batch_dims] = 1;
+        new_out_shape[n_batch_dims + 1] =
+            old_r_type.getShape()[n_batch_dims + 1];
+
+        assert(old_rhs_rank == (old_lhs_rank + 1));
+        new_lhs = unsqueezeTensorDim(rewriter, op, old_lhs, n_batch_dims);
+      } else {
+        return failure();
+      }
+    } else if (old_lhs_matrix_rank == 2 && old_rhs_matrix_rank == 1 &&
+               n_batch_dims + 1 == lhs_contracting_dims[0]) {
+      // equivalent to mhlo::DotOp(mat, vec)
+      assert(n_batch_dims == rhs_contracting_dims[0]);
+      new_out_shape[n_batch_dims] = old_l_type.getShape()[n_batch_dims];
+      new_out_shape[n_batch_dims + 1] = 1;
+      new_rhs = unsqueezeTensorDim(rewriter, op, old_rhs, n_batch_dims + 1);
+    } else {
+      return failure();
+    }
+
+    // convert the DotGeneralOp
+    auto new_out_ty =
+        RankedTensorType::get(new_out_shape, old_out_ty.getElementType());
+    auto dot_dimension_attr = mhlo::DotDimensionNumbersAttr::get(
+        rewriter.getContext(), batching_dims, batching_dims, {n_batch_dims + 1},
+        {n_batch_dims});
+    Value dot_general = rewriter.create<mhlo::DotGeneralOp>(
+        op.getLoc(), new_out_ty, new_lhs, new_rhs, dot_dimension_attr, nullptr);
+
+    // squeeze the result of DoGeneralOp
+    if (old_lhs_matrix_rank == 1) {
+      if (old_rhs_matrix_rank == 1) {
+        // equivalent to mhlo::DotOp(vec, vec)
+        dot_general =
+            squeezeTensorDim(rewriter, op, dot_general, n_batch_dims + 1);
+        dot_general = squeezeTensorDim(rewriter, op, dot_general, n_batch_dims);
+      } else if (old_rhs_matrix_rank == 2 &&
+                 n_batch_dims == rhs_contracting_dims[0]) {
+        // equivalent to mhlo::DotOp(vec, mat)
+        dot_general = squeezeTensorDim(rewriter, op, dot_general, n_batch_dims);
+      } else {
+        return failure();
+      }
+    } else if (old_lhs_matrix_rank == 2 && old_rhs_matrix_rank == 1 &&
+               n_batch_dims + 1 == lhs_contracting_dims[0]) {
+      // equivalent to mhlo::DotOp(mat, vec)
+      dot_general =
+          squeezeTensorDim(rewriter, op, dot_general, n_batch_dims + 1);
+    } else {
+      return failure();
+    }
+    rewriter.replaceOp(op, dot_general);
     return success();
   }
 };
@@ -649,7 +864,7 @@ struct DotRewriterPass : public DotRewriterPassBase<DotRewriterPass> {
     MLIRContext* ctx = func.getContext();
     RewritePatternSet patterns(ctx);
     patterns.insert<DotToDotGeneralConvert, TransposeFoldingConvert,
-                    EinsumToDotGeneralPattern>(ctx);
+                    EinsumToDotGeneralPattern, DotGeneralConvert>(ctx);
     if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
       func.emitError("applyPatternsAndFoldGreedily does not converge");
       signalPassFailure();

--- a/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
@@ -29,3 +29,106 @@ func.func @dot_transpose_batching_3d(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?
   // CHECK: lhs_contracting_dimensions = [2]
   return %1: tensor<?x?x?xf32>
 }
+
+// CHECK-LABEL:  func.func @dot_2dx1d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<?xf32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
+// CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf32>
+// CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
+// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         return %[[T4]] : tensor<?xf32>
+func.func @dot_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -> tensor<?xf32> {
+  %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<?x256xf32>, tensor<256xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @dot_1dx2d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<?xf32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
+// CHECK:         %[[C1:.*]] = arith.constant 1 : index
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x?xf32>) -> tensor<1x?xf32>
+// CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf32>
+// CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
+// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         return %[[T4]] : tensor<?xf32>
+func.func @dot_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -> tensor<?xf32> {
+  %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<256xf32>, tensor<256x?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @dot_1dx1d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<f32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
+// CHECK:         %[[CST_0:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
+// CHECK:         %[[CST_1:.*]] = arith.constant dense<1> : tensor<1xindex>
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST_0]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x1xf32>) -> tensor<1x1xf32>
+// CHECK:         %[[T3:.*]] = "mhlo.dynamic_reshape"(%[[T2]], %[[CST_1]]) : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
+// CHECK:         %[[T4:.*]] = "mhlo.reshape"(%[[T3]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         return %[[T4]] : tensor<f32>
+func.func @dot_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> tensor<f32> {
+  %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<256xf32>, tensor<256xf32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @dot_general_1dx2d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<?xf32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
+// CHECK:         %[[C1:.*]] = arith.constant 1 : index
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x?xf32>) -> tensor<1x?xf32>
+// CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf32>
+// CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
+// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         return %[[T4]] : tensor<?xf32>
+// RUN: disc-opt -disc-dot-rewriter -split-input-file %s -o - | FileCheck %s
+func.func @dot_general_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -> tensor<?xf32> {
+  %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<256xf32>, tensor<256x?xf32>) -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @dot_general_2dx1d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<?xf32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
+// CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf32>
+// CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
+// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         return %[[T4]] : tensor<?xf32>
+func.func @dot_general_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -> tensor<?xf32> {
+  %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256xf32>) -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @dot_general_1dx1d(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<f32> {
+// CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
+// CHECK:         %[[CST_0:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
+// CHECK:         %[[CST_1:.*]] = arith.constant dense<1> : tensor<1xindex>
+// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST_0]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x1xf32>) -> tensor<1x1xf32>
+// CHECK:         %[[T3:.*]] = "mhlo.dynamic_reshape"(%[[T2]], %[[CST_1]]) : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
+// CHECK:         %[[T4:.*]] = "mhlo.reshape"(%[[T3]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         return %[[T4]] : tensor<f32>
+func.func @dot_general_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> tensor<f32> {
+  %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<256xf32>, tensor<256xf32>) -> tensor<f32>
+  return %1 : tensor<f32>
+}


### PR DESCRIPTION
This pull request is mainly to convert vector operands of DoGeneralOp into matrixes. Please focus on reviewing `dot_rewriter.cpp` since other TorchToMhlo conversions are modified just to make the unit tests reach the case of DotGeneral rewritten passes. All TorchToMhlo passes will be replaced by the upstream implementations from Torch-MLIR.