### PR TITLE
[AArch64] make ACL target arch configurable

### DIFF
--- a/scripts/python/common_setup.py
+++ b/scripts/python/common_setup.py
@@ -358,7 +358,7 @@ def update_cpu_specific_setting(args):
     if not hasattr(args, 'cpu_only'):
         args.cpu_only = False
     if not hasattr(args, 'target_cpu_arch'):
-        args.target_arch = ""
+        args.target_cpu_arch = ""
 
     if args.cpu_only:
         auto_detect_host_cpu(args)

--- a/scripts/python/common_setup.py
+++ b/scripts/python/common_setup.py
@@ -279,6 +279,7 @@ def config_mkldnn(root, args):
 
     if args.aarch64:
         with cwd(acl_dir):
+            arch =  args.target_cpu_arch or "arm64-v8a"
             # downlaod and build acl for onednn
             cmd = '''
               readonly ACL_REPO="https://github.com/ARM-software/ComputeLibrary.git"
@@ -288,10 +289,10 @@ def config_mkldnn(root, args):
               git clone --branch v22.02 --depth 1 $ACL_REPO $ACL_DIR
               cd $ACL_DIR
 
-              scons --silent $MAKE_NP Werror=0 debug=0 neon=1 opencl=0 openmp=1 embed_kernels=0 os=linux arch=arm64-v8a build=native extra_cxx_flags="-fPIC"
+              scons --silent $MAKE_NP Werror=0 debug=0 neon=1 opencl=0 openmp=1 embed_kernels=0 os=linux arch={} build=native extra_cxx_flags="-fPIC"
 
               exit $?
-            '''.format(acl_dir)
+            '''.format(acl_dir, arch)
             execute(cmd)
             # a workaround for static linking
             execute('rm -f build/*.so')
@@ -356,6 +357,8 @@ def update_cpu_specific_setting(args):
         args.enable_mkldnn = False
     if not hasattr(args, 'cpu_only'):
         args.cpu_only = False
+    if not hasattr(args, 'target_cpu_arch'):
+        args.target_arch = ""
 
     if args.cpu_only:
         auto_detect_host_cpu(args)

--- a/scripts/python/tao_build.py
+++ b/scripts/python/tao_build.py
@@ -159,6 +159,8 @@ def configure_compiler(root, args):
             f.write("startup {}\n".format(bazel_startup_opts))
             if args.dcu or args.rocm:
                 _action_env("ROCM_PATH", get_rocm_path(args))
+            if args.cpu_only and args.aarch64:
+                _action_env("DISC_TARGET_CPU_ARCH", args.target_cpu_arch or "arm64-v8a")
 
     logger.info("Stage [configure compiler] success.")
 
@@ -332,6 +334,7 @@ def configure_bridge_bazel(root, args):
                 _action_env("BUILD_WITH_MKLDNN", "1")
             if args.aarch64:
                 _action_env("BUILD_WITH_AARCH64", "1")
+                _action_env("DISC_TARGET_CPU_ARCH", args.target_cpu_arch or "arm64-v8a")
         else:
             if args.platform_alibaba and args.blade_gemm:
                 _action_env("BLADE_GEMM_TVM", "ON")
@@ -421,7 +424,7 @@ def build_tao_compiler(root, args):
 
         bazel_build(TARGET_TAO_COMPILER_MAIN, flag=flag)
         bazel_build(TARGET_DISC_OPT, flag=flag)
-        # TODO:(fl237079) Support disc_replay for rocm version 
+        # TODO:(fl237079) Support disc_replay for rocm version
         if not args.rocm and not args.dcu:
             bazel_build(TARGET_DISC_REPLAY, flag=flag)
         execute(
@@ -1010,6 +1013,12 @@ def parse_args():
         required=False,
         default="/usr/local/cuda-11.6/bin/nvcc",
         help="Nvcc used for blade gemm kernel build.",
+    )
+    parser.add_argument(
+        "--target_cpu_arch",
+        required=False,
+        default="",
+        help="Specify the target architecture.",
     )
     # flag validation
     args = parser.parse_args()

--- a/tensorflow_blade/workspace0.bzl
+++ b/tensorflow_blade/workspace0.bzl
@@ -98,7 +98,10 @@ def _tf_blade_repositories():
         sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
         strip_prefix = "ComputeLibrary-22.02",
         build_file = "@org_third_party//bazel/acl:acl.BUILD",
-        patch_file = ["@org_third_party//bazel/acl:acl_makefile.patch"],
+        patch_file = [
+            "@org_third_party//bazel/acl:acl_makefile.patch",
+            "@org_third_party//bazel/acl:acl_yitian.patch",
+        ],
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )
 

--- a/third_party/bazel/acl/acl.BUILD
+++ b/third_party/bazel/acl/acl.BUILD
@@ -2,6 +2,10 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
 
 package(default_visibility = ["//visibility:public"])
 
+load("@local_config_blade_disc_helper//:build_defs.bzl",
+    "disc_target_cpu_arch",
+)
+
 filegroup(
     name = "all_source_files",
     srcs = glob(["**"]),
@@ -13,7 +17,7 @@ make(
     env = {
         "np": "24",
         "os": "linux",
-        "arch": "arm64-v8a",  # (TODO): Make this configurable
+        "arch": disc_target_cpu_arch(),
     },
     lib_source = ":all_source_files",
     out_lib_dir = "build",

--- a/third_party/bazel/acl/acl_yitian.patch
+++ b/third_party/bazel/acl/acl_yitian.patch
@@ -1,0 +1,24 @@
+diff --git a/src/common/cpuinfo/CpuInfo.cpp b/src/common/cpuinfo/CpuInfo.cpp
+index 2b85375..3f0e757 100644
+--- a/src/common/cpuinfo/CpuInfo.cpp
++++ b/src/common/cpuinfo/CpuInfo.cpp
+@@ -298,10 +298,17 @@ CpuInfo::CpuInfo(CpuIsaInfo isa, std::vector<CpuModel> cpus)
+ CpuInfo CpuInfo::build()
+ {
+ #if !defined(BARE_METAL) && !defined(__APPLE__) && !defined(__OpenBSD__) && (defined(__arm__) || defined(__aarch64__))
+-    const uint32_t hwcaps   = getauxval(AT_HWCAP);
+-    const uint32_t hwcaps2  = getauxval(AT_HWCAP2);
++    uint32_t hwcaps   = getauxval(AT_HWCAP);
++    uint32_t hwcaps2  = getauxval(AT_HWCAP2);
+     const uint32_t max_cpus = get_max_cpus();
+
++    if (const char* str_hwcaps = getenv("DISC_ACL_HWCAP")) {
++      hwcaps = std::atoll(str_hwcaps);
++    }
++    if (const char* str_hwcaps2 = getenv("DISC_ACL_HWCAP2")) {
++      hwcaps2 = std::atoll(str_hwcaps2);
++    }
++
+     // Populate midr values
+     std::vector<uint32_t> cpus_midr;
+     if(hwcaps & ARM_COMPUTE_CPU_FEATURE_HWCAP_CPUID)

--- a/third_party/bazel/blade_disc_dnn_workspace.bzl
+++ b/third_party/bazel/blade_disc_dnn_workspace.bzl
@@ -29,7 +29,10 @@ def _blade_disc_dnn_repositories():
         sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
         strip_prefix = "ComputeLibrary-22.02",
         build_file = "@org_third_party//bazel/acl:acl.BUILD",
-        patch_file = ["@org_third_party//bazel/acl:acl_makefile.patch"],
+        patch_file = [
+            "@org_third_party//bazel/acl:acl_makefile.patch",
+            "@org_third_party//bazel/acl:acl_yitian.patch",
+        ],
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )
 

--- a/third_party/bazel/blade_disc_helper/blade_disc_helper_configure.bzl
+++ b/third_party/bazel/blade_disc_helper/blade_disc_helper_configure.bzl
@@ -20,6 +20,7 @@ _BLADE_GEMM_NVCC_ARCHS = "BLADE_GEMM_NVCC_ARCHS"
 _BLADE_GEMM_LIBRARY_KERNELS = "BLADE_GEMM_LIBRARY_KERNELS"
 _BLADE_GEMM_TVM = "BLADE_GEMM_TVM"
 _BLADE_GEMM_ROCM_PATH = "BLADE_GEMM_ROCM_PATH"
+_DISC_TARGET_CPU_ARCH = "DISC_TARGET_CPU_ARCH"
 
 def _blade_disc_helper_impl(repository_ctx):
     repository_ctx.template("build_defs.bzl", Label("//bazel/blade_disc_helper:build_defs.bzl.tpl"), {
@@ -42,6 +43,7 @@ def _blade_disc_helper_impl(repository_ctx):
         "%{BLADE_GEMM_LIBRARY_KERNELS}": get_host_environ(repository_ctx, _BLADE_GEMM_LIBRARY_KERNELS, ""),
         "%{BLADE_GEMM_TVM}": get_host_environ(repository_ctx, _BLADE_GEMM_TVM, ""),
         "%{BLADE_GEMM_ROCM_PATH}": get_host_environ(repository_ctx, _BLADE_GEMM_ROCM_PATH, ""),
+        "%{DISC_TARGET_CPU_ARCH}": get_host_environ(repository_ctx, _DISC_TARGET_CPU_ARCH, ""),
     })
 
     repository_ctx.template("BUILD", Label("//bazel/blade_disc_helper:BUILD.tpl"), {
@@ -69,5 +71,6 @@ blade_disc_helper_configure = repository_rule(
         _BLADE_GEMM_LIBRARY_KERNELS,
         _BLADE_GEMM_TVM,
         _BLADE_GEMM_ROCM_PATH,
+        _DISC_TARGET_CPU_ARCH,
     ],
 )

--- a/third_party/bazel/blade_disc_helper/build_defs.bzl.tpl
+++ b/third_party/bazel/blade_disc_helper/build_defs.bzl.tpl
@@ -31,6 +31,9 @@ def cuda_home():
 def cuda_version():
     return "%{CUDA_VERSION}"
 
+def disc_target_cpu_arch():
+    return "%{DISC_TARGET_CPU_ARCH}"
+
 def if_hie_enabled(if_true, if_false = []):
     if %{IF_HIE}:
         return if_true


### PR DESCRIPTION
1, add a new build option `target_cpu_arch` to make ACL target arch
configurable.

2, add a new ACL patch for YITIAN to enable BF16/int8 dot instruction

3, currently only works in TF bridge. Torch bridge will be supported in
the future.