### PR TITLE
tanyo/rebase tf 11

### DIFF
--- a/mhlo_builder/csrc/mlir/mhlo/builder/standard.cpp
+++ b/mhlo_builder/csrc/mlir/mhlo/builder/standard.cpp
@@ -177,7 +177,7 @@ llvm::Optional<mlir::Value> BuildCastStdConstScalarToHloConstTensor(
     return llvm::None;
   }
   const mlir::Attribute& val_attr = def.getValue();
-  auto scalar_ty = mlir::RankedTensorType::get({}, val_attr.getType());
+  auto scalar_ty = mlir::RankedTensorType::get({}, std_scalar.getType());
   auto const_attr = mlir::DenseElementsAttr::get(scalar_ty, val_attr);
   auto result = builder.create<mlir::mhlo::ConstantOp>(loc, const_attr);
   return result.getResult();

--- a/pytorch_blade/bazel/torch_mlir/BUILD
+++ b/pytorch_blade/bazel/torch_mlir/BUILD
@@ -41,6 +41,7 @@ cc_library (
     "python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.h",
     "python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h",
     "python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h",
+    "python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h",
   ],
   deps = [
     ":TorchMLIRCAPI",

--- a/pytorch_blade/src/torch-mlir/lib/Conversion/MhloPasses.cpp
+++ b/pytorch_blade/src/torch-mlir/lib/Conversion/MhloPasses.cpp
@@ -10,9 +10,9 @@
 // limitations under the License.
 
 #include "torch-mlir/Conversion/MhloPasses.h"
+#include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"
 #include "torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
-#include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
 
@@ -56,7 +56,7 @@ void mlir::torch::createDiscTorchBackendToMhloBackendPipeline(
   // pm.addNestedPass<func::FuncOp>(createApplyValueSemanticsPass());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToMhloPass());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToSCFPass());
-  pm.addNestedPass<func::FuncOp>(createConvertTorchToStdPass());
+  pm.addNestedPass<func::FuncOp>(createConvertTorchToArithPass());
 
   // Perform rank broadcasting so MhloToLinalg pass works
   // pm.addNestedPass<func::FuncOp>(createMhloMakeBroadcastablePass());

--- a/pytorch_blade/src/torch-mlir/lib/Dialect/TorchConversion/Transforms/VerifyMhloBackendContract.cpp
+++ b/pytorch_blade/src/torch-mlir/lib/Dialect/TorchConversion/Transforms/VerifyMhloBackendContract.cpp
@@ -34,7 +34,6 @@
 #include "torch-mlir/Conversion/MhloPasses.h"
 #include "torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
-#include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"

--- a/pytorch_blade/tests/mhlo/elementwise.mlir
+++ b/pytorch_blade/tests/mhlo/elementwise.mlir
@@ -1,6 +1,6 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.sigmoid(
+// CHECK-LABEL:  func.func @torch.aten.sigmoid(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[T0:.*]] = "chlo.constant_like"(%[[ARG0]]) {value = 1.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         %[[T1:.*]] = mhlo.negate %[[ARG0]] : tensor<?x?xf32>
@@ -13,10 +13,12 @@ func.func @torch.aten.sigmoid(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtenso
     return %0 : !torch.vtensor<[?,?],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.relu(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.relu(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[T0:.*]] = "chlo.constant_like"(%[[ARG0]]) {value = 0.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:         %[[T1:.*]] = "mhlo.compare"(%[[ARG0]], %[[T0]]) {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction GT>} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
+// CHECK:         %[[T1:.*]] = mhlo.compare  GT, %[[ARG0]], %[[T0]],  NOTYPE : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
 // CHECK:         %[[T2:.*]] = "mhlo.select"(%[[T1]], %[[ARG0]], %[[T0]]) : (tensor<?x?xi1>, tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         return %[[T2]] : tensor<?x?xf32>
 func.func @torch.aten.relu(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
@@ -24,7 +26,9 @@ func.func @torch.aten.relu(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
     return %0 : !torch.vtensor<[?,?],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.gelu(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.gelu(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[T0:.*]] = "chlo.constant_like"(%[[ARG0]]) {value = 1.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         %[[T1:.*]] = "chlo.constant_like"(%[[ARG0]]) {value = 2.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
@@ -42,135 +46,152 @@ func.func @torch.aten.gelu(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
     return %0 : !torch.vtensor<[?,?],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.sub.tensor(
-// CHECK-SAME:            %[[ARG0:.*]]: tensor<?x?x?x?xf32>, %[[ARG1:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:     %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:     %[[T1:.*]] = chlo.broadcast_multiply %[[ARG1]], %[[T0]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
-// CHECK:     %[[T2:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T1]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:     return %[[T2]] : tensor<?x?x?x?xf32>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.sub.tensor(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>, %[[ARG1:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+// CHECK:         %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = chlo.broadcast_multiply %[[ARG1]], %[[T0]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+// CHECK:         %[[T2:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T1]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:         return %[[T2]] : tensor<?x?x?x?xf32>
 func.func @torch.aten.sub.tensor(%arg0: !torch.vtensor<[?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %int1 = torch.constant.int 1
   %0 = torch.aten.sub.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[?,?,?,?],f32>, !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.vtensor<[?,?,?,?],f32>
   return %0 : !torch.vtensor<[?,?,?,?],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.sub.scalar.int(
-// CHECK-SAME:           %[[ARG0:.*]]: tensor<?x?x?x4xf32>, %[[ARG1:.*]]: i64) -> tensor<?x?x?x4xf32> {
-// CHECK:     %[[CST0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:     %[[T0:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xi64>
-// CHECK:     %[[T1:.*]] = mhlo.convert(%[[T0]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:     %[[T2:.*]] = "mhlo.reshape"(%[[T1]]) : (tensor<1xf32>) -> tensor<f32>
-// CHECK:     %[[T3:.*]] = chlo.broadcast_multiply %3, %0 : (tensor<f32>, tensor<f32>) -> tensor<f32>
-// CHECK:     %[[T4:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T3]] : (tensor<?x?x?x4xf32>, tensor<f32>) -> tensor<?x?x?x4xf32>
-// CHECK:     return %[[T4]] : tensor<?x?x?x4xf32>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.sub.scalar.int(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x4xf32>, %[[ARG1:.*]]: i64) -> tensor<?x?x?x4xf32> {
+// CHECK:         %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xi64>
+// CHECK:         %[[T2:.*]] = mhlo.convert(%[[T1]]) : (tensor<1xi64>) -> tensor<1xf32>
+// CHECK:         %[[T3:.*]] = mhlo.reshape %[[T2]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T4:.*]] = chlo.broadcast_multiply %[[T3]], %[[T0]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T5:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T4]] : (tensor<?x?x?x4xf32>, tensor<f32>) -> tensor<?x?x?x4xf32>
+// CHECK:         return %[[T5]] : tensor<?x?x?x4xf32>
 func.func @torch.aten.sub.scalar.int(%arg0: !torch.vtensor<[?,?,?,4],f32>, %arg1: !torch.int) -> !torch.vtensor<[?,?,?,4],f32> {
   %int1 = torch.constant.int 1
   %0 = torch.aten.sub.Scalar %arg0, %arg1, %int1 : !torch.vtensor<[?,?,?,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[?,?,?,4],f32>
   return %0 : !torch.vtensor<[?,?,?,4],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.add.scalar.float(
-// CHECK-SAME:           %[[ARG0:.*]]: tensor<?x?x?x4xf32>, %[[ARG1:.*]]: f64) -> tensor<?x?x?x4xf32> {
-// CHECK:     %[[CST0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:     %[[T0:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xf64>
-// CHECK:     %[[T1:.*]] = mhlo.convert(%[[T0]]) : (tensor<1xf64>) -> tensor<1xf32>
-// CHECK:     %[[T2:.*]] = "mhlo.reshape"(%[[T1]]) : (tensor<1xf32>) -> tensor<f32>
-// CHECK:     %[[T3:.*]] = chlo.broadcast_multiply %[[T2]], %[[CST0]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
-// CHECK:     %[[T4:.*]] = chlo.broadcast_add %[[ARG0]], %[[T3]] : (tensor<?x?x?x4xf32>, tensor<f32>) -> tensor<?x?x?x4xf32>
-// CHECK:     return %[[T4]] : tensor<?x?x?x4xf32>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.add.scalar.float(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x4xf32>, %[[ARG1:.*]]: f64) -> tensor<?x?x?x4xf32> {
+// CHECK:         %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xf64>
+// CHECK:         %[[T2:.*]] = mhlo.convert(%[[T1]]) : (tensor<1xf64>) -> tensor<1xf32>
+// CHECK:         %[[T3:.*]] = mhlo.reshape %[[T2]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T4:.*]] = chlo.broadcast_multiply %[[T3]], %[[T0]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T5:.*]] = chlo.broadcast_add %[[ARG0]], %[[T4]] : (tensor<?x?x?x4xf32>, tensor<f32>) -> tensor<?x?x?x4xf32>
+// CHECK:         return %[[T5]] : tensor<?x?x?x4xf32>
 func.func @torch.aten.add.scalar.float(%arg0: !torch.vtensor<[?,?,?,4],f32>, %arg1: !torch.float) -> !torch.vtensor<[?,?,?,4],f32> {
   %int1 = torch.constant.int 1
   %0 = torch.aten.add.Scalar %arg0, %arg1, %int1 : !torch.vtensor<[?,?,?,4],f32>, !torch.float, !torch.int -> !torch.vtensor<[?,?,?,4],f32>
   return %0 : !torch.vtensor<[?,?,?,4],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.div.Tensor_mode(
-// CHECK-SAME:      %[[ARG0:.*]]: tensor<?x?x?x?xf32>, %[[ARG1:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:     %[[T0:.*]] = chlo.broadcast_divide %[[ARG0]], %[[ARG1]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:     %[[T1:.*]] = mhlo.sign %[[T0]] : tensor<?x?x?x?xf32>
-// CHECK:     %[[T2:.*]] = mhlo.abs %[[T0]] : tensor<?x?x?x?xf32>
-// CHECK:     %[[T3:.*]] = mhlo.floor %[[T2]] : tensor<?x?x?x?xf32>
-// CHECK:     %[[T4:.*]] = mhlo.multiply %[[T1]], %[[T3]] : tensor<?x?x?x?xf32>
-// CHECK:     return %[[T4]] : tensor<?x?x?x?xf32>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.div.Tensor_mode(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>, %[[ARG1:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+// CHECK:         %[[T0:.*]] = chlo.broadcast_divide %[[ARG0]], %[[ARG1]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:         %[[T1:.*]] = mhlo.sign %[[T0]] : tensor<?x?x?x?xf32>
+// CHECK:         %[[T2:.*]] = mhlo.abs %[[T0]] : tensor<?x?x?x?xf32>
+// CHECK:         %[[T3:.*]] = mhlo.floor %[[T2]] : tensor<?x?x?x?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.multiply %[[T1]], %[[T3]] : tensor<?x?x?x?xf32>
+// CHECK:         return %[[T4]] : tensor<?x?x?x?xf32>
 func.func @torch.aten.div.Tensor_mode(%arg0: !torch.vtensor<[?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %str = torch.constant.str "trunc"
   %0 = torch.aten.div.Tensor_mode %arg0, %arg1, %str : !torch.vtensor<[?,?,?,?],f32>, !torch.vtensor<[?,?,?,?],f32>, !torch.str -> !torch.vtensor<[?,?,?,?],f32>
   return %0 : !torch.vtensor<[?,?,?,?],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.ne.scalar(
-// CHECK-SAME:           %[[ARG0:.*]]: tensor<?x?xi32>, %[[ARG1:.*]]: f64) -> tensor<?x?xi1> {
-// CHECK:     %[[T0:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xf64>
-// CHECK:     %[[T1:.*]] = mhlo.convert(%[[T0]]) : (tensor<1xf64>) -> tensor<1xi32>
-// CHECK:     %[[T2:.*]] = "mhlo.reshape"(%[[T1]]) : (tensor<1xi32>) -> tensor<i32>
-// CHECK:     %[[T3:.*]] = chlo.broadcast_compare %[[ARG0]], %[[T2]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction NE>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?x?xi1>
-// CHECK:     return %[[T3]] : tensor<?x?xi1>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.ne.scalar(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xi32>, %[[ARG1:.*]]: f64) -> tensor<?x?xi1> {
+// CHECK:         %[[T0:.*]] = tensor.from_elements %[[ARG1]] : tensor<1xf64>
+// CHECK:         %[[T1:.*]] = mhlo.convert(%[[T0]]) : (tensor<1xf64>) -> tensor<1xi32>
+// CHECK:         %[[T2:.*]] = mhlo.reshape %[[T1]] : (tensor<1xi32>) -> tensor<i32>
+// CHECK:         %[[T3:.*]] = chlo.broadcast_compare %[[ARG0]], %[[T2]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction NE>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?x?xi1>
+// CHECK:         return %[[T3]] : tensor<?x?xi1>
 func.func @torch.aten.ne.scalar(%arg0: !torch.vtensor<[?,?],si32>, %arg1: !torch.float) -> !torch.vtensor<[?,?],i1> {
   %0 = torch.aten.ne.Scalar %arg0, %arg1 : !torch.vtensor<[?,?],si32>, !torch.float -> !torch.vtensor<[?,?],i1>
   return %0 : !torch.vtensor<[?,?],i1>
 }
 
-// CHECK-LABEL:   func @torch.aten.ne.scalar.const(
-// CHECK-SAME:           %[[ARG0:.*]]: tensor<?x?xi32>) -> tensor<?x?xi1> {
-// CHECK:     %[[T0:.*]] = mhlo.constant dense<2> : tensor<i32>
-// CHECK:     %[[T1:.*]] = chlo.broadcast_compare %[[ARG0]], %[[T0]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction GT>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?x?xi1>
-// CHECK:     return %[[T1]] : tensor<?x?xi1>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.ne.scalar.const(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xi32>) -> tensor<?x?xi1> {
+// CHECK:         %[[T0:.*]] = mhlo.constant dense<2> : tensor<i32>
+// CHECK:         %[[T1:.*]] = chlo.broadcast_compare %[[ARG0]], %[[T0]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction GT>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?x?xi1>
+// CHECK:         return %[[T1]] : tensor<?x?xi1>
 func.func @torch.aten.ne.scalar.const(%arg0: !torch.vtensor<[?,?],si32>) -> !torch.vtensor<[?,?],i1> {
   %float2.000000e00 = torch.constant.float 2.000000e+00
   %0 = torch.aten.gt.Scalar %arg0, %float2.000000e00 : !torch.vtensor<[?,?],si32>, !torch.float -> !torch.vtensor<[?,?],i1>
   return %0 : !torch.vtensor<[?,?],i1>
 }
 
-// CHECK-LABEL:   func @torch.aten.gelu_backward(
-// CHECK-SAME:            %[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
-// CHECK:           %[[CST_0:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 5.000000e-01 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           %[[CST_1:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 1.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           %[[CST_2:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 1.12837923 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           %[[CST_3:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 0.707106769 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           %[[T0:.*]] = mhlo.multiply %[[CST_2]], %[[CST_3]] : tensor<?x?xf32>
-// CHECK:           %[[T1:.*]] = mhlo.multiply %[[T0]], %[[CST_0]] : tensor<?x?xf32>
-// CHECK:           %[[T2:.*]] = mhlo.multiply %[[ARG1]], %[[CST_3]] : tensor<?x?xf32>
-// CHECK:           %[[T3:.*]] = chlo.erf %[[T2]] : tensor<?x?xf32> -> tensor<?x?xf32>
-// CHECK:           %[[T4:.*]] = mhlo.negate %[[CST_0]] : tensor<?x?xf32>
-// CHECK:           %[[T5:.*]] = mhlo.multiply %[[ARG1]], %[[T4]] : tensor<?x?xf32>
-// CHECK:           %[[T6:.*]] = mhlo.add %[[CST_1]], %[[T3]] : tensor<?x?xf32>
-// CHECK:           %[[T7:.*]] = mhlo.multiply %[[CST_0]], %[[T6]] : tensor<?x?xf32>
-// CHECK:           %[[T8:.*]] = mhlo.multiply %[[ARG1]], %[[T5]] : tensor<?x?xf32>
-// CHECK:           %[[T9:.*]] = mhlo.multiply %[[T8]], %[[T1]] : tensor<?x?xf32>
-// CHECK:           %[[T10:.*]] = mhlo.add %[[T7]], %[[T9]] : tensor<?x?xf32>
-// CHECK:           %[[T11:.*]] = mhlo.multiply %[[ARG1]], %[[T10]] : tensor<?x?xf32>
-// CHECK:           return %[[T11]] : tensor<?x?xf32>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.gelu_backward(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[T0:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 5.000000e-01 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[T1:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 1.000000e+00 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[T2:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 1.12837923 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[T3:.*]] = "chlo.constant_like"(%[[ARG1]]) {value = 0.707106769 : f32} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.multiply %[[T2]], %[[T3]] : tensor<?x?xf32>
+// CHECK:         %[[T5:.*]] = mhlo.multiply %[[T4]], %[[T0]] : tensor<?x?xf32>
+// CHECK:         %[[T6:.*]] = mhlo.multiply %[[ARG1]], %[[T3]] : tensor<?x?xf32>
+// CHECK:         %[[T7:.*]] = chlo.erf %[[T6]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         %[[T8:.*]] = mhlo.negate %[[T0]] : tensor<?x?xf32>
+// CHECK:         %[[T9:.*]] = mhlo.multiply %[[ARG1]], %[[T8]] : tensor<?x?xf32>
+// CHECK:         %[[T10:.*]] = mhlo.add %[[T1]], %[[T7]] : tensor<?x?xf32>
+// CHECK:         %[[T11:.*]] = mhlo.multiply %[[T0]], %[[T10]] : tensor<?x?xf32>
+// CHECK:         %[[T12:.*]] = mhlo.multiply %[[ARG1]], %[[T9]] : tensor<?x?xf32>
+// CHECK:         %[[T13:.*]] = mhlo.multiply %[[T12]], %[[T5]] : tensor<?x?xf32>
+// CHECK:         %[[T14:.*]] = mhlo.add %[[T11]], %[[T13]] : tensor<?x?xf32>
+// CHECK:         %[[T15:.*]] = mhlo.multiply %[[ARG1]], %[[T14]] : tensor<?x?xf32>
+// CHECK:         return %[[T15]] : tensor<?x?xf32>
 func.func @torch.aten.gelu_backward(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %str_none = torch.constant.str "none"
   %0 = torch.aten.gelu_backward %arg0, %arg1, %str_none: !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32>, !torch.str -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
 }
 
-// CHECK-LABEL:   func @torch.aten.native_dropout.train(
-// CHECK-SAME:            %[[ARG0:.*]]: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xi1>) {
-// CHECK:           %[[CST_0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:           %[[CST_1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK:           %[[CST_2:.*]] =  mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:           %[[SHAPE_0:.*]] = arith.constant 1 : index
-// CHECK:           %[[SHAPE_1:.*]] = arith.constant 0 : index
-// CHECK:           %[[DIM_0:.*]] = tensor.dim %[[ARG0]], %[[SHAPE_1]] : tensor<?x?xf32>
-// CHECK:           %[[DIM_0_I64:.*]] = arith.index_cast %[[DIM_0]] : index to i64
-// CHECK:           %[[DIM_1:.*]] = tensor.dim %[[ARG0]], %[[SHAPE_0]] : tensor<?x?xf32>
-// CHECK:           %[[DIM_1_I64:.*]] = arith.index_cast %[[DIM_1]] : index to i64
-// CHECK:           %[[DIM_0_I32:.*]] = arith.trunci %[[DIM_0_I64]] : i64 to i32
-// CHECK:           %[[DIM_1_I32:.*]] = arith.trunci %[[DIM_1_I64]] : i64 to i32
-// CHECK:           %[[T0:.*]] = tensor.from_elements %[[DIM_0_I32]], %[[DIM_1_I32]] : tensor<2xi32>
-// CHECK:           %[[T1:.*]] = "mhlo_disc.custom_call"(%[[CST_0]], %[[CST_2]], %[[T0]]) {backend_config = "{\22seed\22:1,\22seed2\22:2}", call_target_name = "rng_uniform", has_side_effect = false} : (tensor<f32>, tensor<f32>, tensor<2xi32>) -> tensor<?x?xf32>
-// CHECK:           %[[T2:.*]] = mhlo.convert(%[[T1]]) : (tensor<?x?xf32>) -> tensor<?x?xf64>
-// CHECK:           %[[T3:.*]] = chlo.broadcast_compare %[[T2]], %[[CST_1]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction LT>} : (tensor<?x?xf64>, tensor<f64>) -> tensor<?x?xi1>
-// CHECK:           %[[T4:.*]] = mhlo.convert(%[[T3]]) : (tensor<?x?xi1>) -> tensor<?x?xf32>
-// CHECK:           %[[T5:.*]] = chlo.broadcast_multiply %[[T4]], %[[ARG0]] : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:           %[[T6:.*]] = chlo.broadcast_multiply %[[T5]], %[[CST_0]] : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-// CHECK:           %[[T7:.*]] = chlo.broadcast_compare %[[T4]], %[[CST_2]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction GE>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xi1>
-// CHECK:           return %[[T6]], %[[T7]] : tensor<?x?xf32>, tensor<?x?xi1>
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.native_dropout.train(
+// CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xi1>) {
+// CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK:         %[[T2:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[C1:.*]] = arith.constant 1 : index
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[T3:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?xf32>
+// CHECK:         %[[T4:.*]] = arith.index_cast %[[T3]] : index to i64
+// CHECK:         %[[T5:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?xf32>
+// CHECK:         %[[T6:.*]] = arith.index_cast %[[T5]] : index to i64
+// CHECK:         %[[T7:.*]] = arith.trunci %[[T4]] : i64 to i32
+// CHECK:         %[[T8:.*]] = arith.trunci %[[T6]] : i64 to i32
+// CHECK:         %[[T9:.*]] = tensor.from_elements %[[T7]], %[[T8]] : tensor<2xi32>
+// CHECK:         %[[T10:.*]] = "mhlo_disc.custom_call"(%[[T0]], %[[T2]], %[[T9]]) {backend_config = "{\22seed\22:1,\22seed2\22:2}", call_target_name = "rng_uniform", has_side_effect = false} : (tensor<f32>, tensor<f32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T11:.*]] = mhlo.convert(%[[T10]]) : (tensor<?x?xf32>) -> tensor<?x?xf64>
+// CHECK:         %[[T12:.*]] = chlo.broadcast_compare %[[T11]], %[[T1]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction LT>} : (tensor<?x?xf64>, tensor<f64>) -> tensor<?x?xi1>
+// CHECK:         %[[T13:.*]] = mhlo.convert(%[[T12]]) : (tensor<?x?xi1>) -> tensor<?x?xf32>
+// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T13]], %[[ARG0]] : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[T15:.*]] = chlo.broadcast_multiply %[[T14]], %[[T0]] : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T16:.*]] = chlo.broadcast_compare %[[T13]], %[[T2]] {compare_type = #mhlo<comparison_type NOTYPE>, comparison_direction = #mhlo<comparison_direction GE>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xi1>
+// CHECK:         return %[[T15]], %[[T16]] : tensor<?x?xf32>, tensor<?x?xi1>
 func.func @torch.aten.native_dropout.train(%arg0: !torch.vtensor<[?,?],f32>) -> (!torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],i1>) {
   %float1 = torch.constant.float 1.000000e+00
   %bool_true = torch.constant.bool true
   %result0, %result1 = torch.aten.native_dropout %arg0, %float1, %bool_true: !torch.vtensor<[?,?],f32>, !torch.float, !torch.bool -> !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],i1>
   return %result0, %result1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],i1>
 }
+

--- a/pytorch_blade/tests/mhlo/layer_norm.mlir
+++ b/pytorch_blade/tests/mhlo/layer_norm.mlir
@@ -1,22 +1,22 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.layer_norm(
+// CHECK-LABEL:  func.func @torch.aten.layer_norm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
-// CHECK:         %[[T3:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T5:.*]] = "mhlo.reshape"(%[[T4]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
+// CHECK:         %[[T5:.*]] = mhlo.reshape %[[T4]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T6:.*]] = chlo.broadcast_divide %[[T5]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T7:.*]] = "mhlo.broadcast_in_dim"(%[[T6]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T8:.*]] = chlo.broadcast_multiply %[[T7]], %[[T3]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T8:.*]] = chlo.broadcast_multiply %[[T7]], %[[T1]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T9:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T8]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T9]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T11:.*]] = mhlo.reduce(%[[T10]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T12:.*]] = "mhlo.reshape"(%[[T11]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T11:.*]] = mhlo.reduce(%[[T10]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
+// CHECK:         %[[T12:.*]] = mhlo.reshape %[[T11]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T13:.*]] = chlo.broadcast_divide %[[T12]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T0]], %[[T3]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T15:.*]] = chlo.broadcast_add %[[T13]], %[[T14]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T16:.*]] = mhlo.rsqrt %[[T15]] : tensor<2x3x1x1xf32>
 // CHECK:         %[[T17:.*]] = "mhlo.broadcast_in_dim"(%[[T16]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
@@ -32,31 +32,33 @@ func.func @torch.aten.layer_norm(%arg0: !torch.vtensor<[2,3,224,224],f32>) -> !t
   return %1 : !torch.vtensor<[2,3,224,224],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.layer_norm.affine(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.layer_norm.affine(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
-// CHECK:         %[[T5:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
 // CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T2:.*]] = mhlo.constant dense<1.000000e+00> : tensor<224x224xf32>
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<224x224xf32>
+// CHECK:         %[[T4:.*]] = mhlo.constant dense<1.000000e+00> : tensor<224x224xf32>
+// CHECK:         %[[T5:.*]] = mhlo.constant dense<0.000000e+00> : tensor<224x224xf32>
 // CHECK:         %[[T6:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T7:.*]] = "mhlo.reshape"(%[[T6]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T8:.*]] = chlo.broadcast_divide %[[T7]], %[[T4]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T7:.*]] = mhlo.reshape %[[T6]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T8:.*]] = chlo.broadcast_divide %[[T7]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T9:.*]] = "mhlo.broadcast_in_dim"(%[[T8]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T5]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T1]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T11:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T10]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T12:.*]] = chlo.broadcast_multiply %[[T11]], %[[T11]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T13:.*]] = mhlo.reduce(%[[T12]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T14:.*]] = "mhlo.reshape"(%[[T13]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T15:.*]] = chlo.broadcast_divide %[[T14]], %[[T4]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T0]], %[[T5]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T14:.*]] = mhlo.reshape %[[T13]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T15:.*]] = chlo.broadcast_divide %[[T14]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T17:.*]] = chlo.broadcast_add %[[T15]], %[[T16]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T18:.*]] = mhlo.rsqrt %[[T17]] : tensor<2x3x1x1xf32>
 // CHECK:         %[[T19:.*]] = "mhlo.broadcast_in_dim"(%[[T18]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T20:.*]] = chlo.broadcast_multiply %[[T11]], %[[T19]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T21:.*]] = chlo.broadcast_multiply %[[T20]], %[[T2]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T1]], %[[T5]] : (tensor<224x224xf32>, tensor<f32>) -> tensor<224x224xf32>
+// CHECK:         %[[T21:.*]] = chlo.broadcast_multiply %[[T20]], %[[T4]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T5]], %[[T1]] : (tensor<224x224xf32>, tensor<f32>) -> tensor<224x224xf32>
 // CHECK:         %[[T23:.*]] = chlo.broadcast_add %[[T21]], %[[T22]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         return %[[T23]] : tensor<2x3x224x224xf32>
 func.func @torch.aten.layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,224],f32>) -> !torch.vtensor<[2,3,224,224],f32> {
@@ -70,23 +72,25 @@ func.func @torch.aten.layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,224],f32>
   return %3 : !torch.vtensor<[2,3,224,224],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.layer_norm.dynamic_shape.full(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.layer_norm.dynamic_shape.full(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
 // CHECK:         %[[C3:.*]] = arith.constant 3 : index
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T2:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T3:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T2:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T3:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T2]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T4:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T5:.*]] = arith.index_cast %[[T4]] : index to i32
 // CHECK:         %[[T6:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[T5]], %[[T7]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[T3]], %[[T8]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[T3]], %[[T8]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T10:.*]] = tensor.dim %[[ARG0]], %[[C2]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T11:.*]] = arith.index_cast %[[T10]] : index to i64
 // CHECK:         %[[T12:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
@@ -94,22 +98,22 @@ func.func @torch.aten.layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,224],f32>
 // CHECK:         %[[T14:.*]] = arith.muli %[[T11]], %[[T13]] : i64
 // CHECK:         %[[T15:.*]] = tensor.from_elements %[[T14]] : tensor<1xi64>
 // CHECK:         %[[T16:.*]] = mhlo.convert(%[[T15]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T17:.*]] = "mhlo.reshape"(%[[T16]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T17:.*]] = mhlo.reshape %[[T16]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T18:.*]] = chlo.broadcast_divide %[[T9]], %[[T17]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T19:.*]] = arith.index_cast %[[T10]] : index to i32
 // CHECK:         %[[T20:.*]] = arith.index_cast %[[T12]] : index to i32
 // CHECK:         %[[T21:.*]] = tensor.from_elements %[[T5]], %[[T7]], %[[T19]], %[[T20]] : tensor<4xi32>
 // CHECK:         %[[T22:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T18]], %[[T21]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x?x?xf32>
-// CHECK:         %[[T23:.*]] = chlo.broadcast_multiply %[[T22]], %[[T2]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+// CHECK:         %[[T23:.*]] = chlo.broadcast_multiply %[[T22]], %[[T1]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
 // CHECK:         %[[T24:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T23]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
 // CHECK:         %[[T25:.*]] = chlo.broadcast_multiply %[[T24]], %[[T24]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:         %[[T26:.*]] = mhlo.reduce(%[[T25]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T26:.*]] = mhlo.reduce(%[[T25]] init: %[[T2]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T27:.*]] = tensor.dim %[[T25]], %[[C0]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T28:.*]] = arith.index_cast %[[T27]] : index to i32
 // CHECK:         %[[T29:.*]] = tensor.dim %[[T25]], %[[C1]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T30:.*]] = arith.index_cast %[[T29]] : index to i32
 // CHECK:         %[[T31:.*]] = tensor.from_elements %[[T28]], %[[T30]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T32:.*]] = "mhlo.dynamic_reshape"(%[[T26]], %[[T31]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T32:.*]] = mhlo.dynamic_reshape %[[T26]], %[[T31]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T33:.*]] = tensor.dim %[[T25]], %[[C2]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T34:.*]] = arith.index_cast %[[T33]] : index to i64
 // CHECK:         %[[T35:.*]] = tensor.dim %[[T25]], %[[C3]] : tensor<?x?x?x?xf32>
@@ -117,9 +121,9 @@ func.func @torch.aten.layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,224],f32>
 // CHECK:         %[[T37:.*]] = arith.muli %[[T34]], %[[T36]] : i64
 // CHECK:         %[[T38:.*]] = tensor.from_elements %[[T37]] : tensor<1xi64>
 // CHECK:         %[[T39:.*]] = mhlo.convert(%[[T38]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T40:.*]] = "mhlo.reshape"(%[[T39]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T40:.*]] = mhlo.reshape %[[T39]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T41:.*]] = chlo.broadcast_divide %[[T32]], %[[T40]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
-// CHECK:         %[[T42:.*]] = chlo.broadcast_multiply %[[T0]], %[[T2]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T42:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T43:.*]] = chlo.broadcast_add %[[T41]], %[[T42]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T44:.*]] = mhlo.rsqrt %[[T43]] : tensor<?x?x1x1xf32>
 // CHECK:         %[[T45:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T44]], %[[T21]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x?x?xf32>
@@ -135,39 +139,40 @@ func.func @torch.aten.layer_norm.dynamic_shape.full(%arg0: !torch.vtensor<[?,?,?
   return %1 : !torch.vtensor<[?,?,?,?],f32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.layer_norm.dynamic_shape.partial(
+// CHECK-LABEL:  func.func @torch.aten.layer_norm.dynamic_shape.partial(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x224x224xf32>) -> tensor<?x?x224x224xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
 // CHECK:         %[[C224_I32:.*]] = arith.constant 224 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T3:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T5:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T6:.*]] = arith.index_cast %[[T5]] : index to i32
 // CHECK:         %[[T7:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T8:.*]] = arith.index_cast %[[T7]] : index to i32
 // CHECK:         %[[T9:.*]] = tensor.from_elements %[[T6]], %[[T8]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T10:.*]] = "mhlo.dynamic_reshape"(%[[T4]], %[[T9]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T10:.*]] = mhlo.dynamic_reshape %[[T4]], %[[T9]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T11:.*]] = chlo.broadcast_divide %[[T10]], %[[T2]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T12:.*]] = tensor.from_elements %[[T6]], %[[T8]], %[[C224_I32]], %[[C224_I32]] : tensor<4xi32>
 // CHECK:         %[[T13:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T11]], %[[T12]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x224x224xf32>
-// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T13]], %[[T3]] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?x224x224xf32>
+// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T13]], %[[T1]] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?x224x224xf32>
 // CHECK:         %[[T15:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T14]] : (tensor<?x?x224x224xf32>, tensor<?x?x224x224xf32>) -> tensor<?x?x224x224xf32>
 // CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T15]], %[[T15]] : (tensor<?x?x224x224xf32>, tensor<?x?x224x224xf32>) -> tensor<?x?x224x224xf32>
-// CHECK:         %[[T17:.*]] = mhlo.reduce(%[[T16]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T17:.*]] = mhlo.reduce(%[[T16]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T18:.*]] = tensor.dim %[[T16]], %[[C0]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T19:.*]] = arith.index_cast %[[T18]] : index to i32
 // CHECK:         %[[T20:.*]] = tensor.dim %[[T16]], %[[C1]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T21:.*]] = arith.index_cast %[[T20]] : index to i32
 // CHECK:         %[[T22:.*]] = tensor.from_elements %[[T19]], %[[T21]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T23:.*]] = "mhlo.dynamic_reshape"(%[[T17]], %[[T22]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T23:.*]] = mhlo.dynamic_reshape %[[T17]], %[[T22]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T24:.*]] = chlo.broadcast_divide %[[T23]], %[[T2]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
-// CHECK:         %[[T25:.*]] = chlo.broadcast_multiply %[[T0]], %[[T3]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T25:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T26:.*]] = chlo.broadcast_add %[[T24]], %[[T25]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T27:.*]] = mhlo.rsqrt %[[T26]] : tensor<?x?x1x1xf32>
 // CHECK:         %[[T28:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T27]], %[[T12]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x224x224xf32>
@@ -183,23 +188,25 @@ func.func @torch.aten.layer_norm.dynamic_shape.partial(%arg0: !torch.vtensor<[?,
   return %1 : !torch.vtensor<[?,?,224,224],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.native_layer_norm(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.native_layer_norm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3x224x224xf32>) -> (tensor<2x3x224x224xf32>, tensor<2x3x1x1xf32>, tensor<2x3x1x1xf32>) {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
-// CHECK:         %[[T3:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T5:.*]] = "mhlo.reshape"(%[[T4]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
+// CHECK:         %[[T5:.*]] = mhlo.reshape %[[T4]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T6:.*]] = chlo.broadcast_divide %[[T5]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T7:.*]] = "mhlo.broadcast_in_dim"(%[[T6]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T8:.*]] = chlo.broadcast_multiply %[[T7]], %[[T3]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T8:.*]] = chlo.broadcast_multiply %[[T7]], %[[T1]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T9:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T8]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T9]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T11:.*]] = mhlo.reduce(%[[T10]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T12:.*]] = "mhlo.reshape"(%[[T11]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T11:.*]] = mhlo.reduce(%[[T10]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
+// CHECK:         %[[T12:.*]] = mhlo.reshape %[[T11]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T13:.*]] = chlo.broadcast_divide %[[T12]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T0]], %[[T3]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T15:.*]] = chlo.broadcast_add %[[T13]], %[[T14]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T16:.*]] = mhlo.rsqrt %[[T15]] : tensor<2x3x1x1xf32>
 // CHECK:         %[[T17:.*]] = "mhlo.broadcast_in_dim"(%[[T16]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
@@ -214,31 +221,33 @@ func.func @torch.aten.native_layer_norm(%arg0: !torch.vtensor<[2,3,224,224],f32>
   return %1, %2, %3 : !torch.vtensor<[2,3,224,224],f32>, !torch.vtensor<[2,3,1,1],f32>, !torch.vtensor<[2,3,1,1],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.native_layer_norm.affine(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.native_layer_norm.affine(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3x224x224xf32>) -> (tensor<2x3x224x224xf32>, tensor<2x3x1x1xf32>, tensor<2x3x1x1xf32>) {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
-// CHECK:         %[[T5:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
 // CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T2:.*]] = mhlo.constant dense<1.000000e+00> : tensor<224x224xf32>
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<224x224xf32>
+// CHECK:         %[[T4:.*]] = mhlo.constant dense<1.000000e+00> : tensor<224x224xf32>
+// CHECK:         %[[T5:.*]] = mhlo.constant dense<0.000000e+00> : tensor<224x224xf32>
 // CHECK:         %[[T6:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T7:.*]] = "mhlo.reshape"(%[[T6]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T8:.*]] = chlo.broadcast_divide %[[T7]], %[[T4]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T7:.*]] = mhlo.reshape %[[T6]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T8:.*]] = chlo.broadcast_divide %[[T7]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T9:.*]] = "mhlo.broadcast_in_dim"(%[[T8]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T5]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T10:.*]] = chlo.broadcast_multiply %[[T9]], %[[T1]] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T11:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T10]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T12:.*]] = chlo.broadcast_multiply %[[T11]], %[[T11]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T13:.*]] = mhlo.reduce(%[[T12]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<2x3x224x224xf32>, tensor<f32>) -> tensor<2x3xf32>
-// CHECK:         %[[T14:.*]] = "mhlo.reshape"(%[[T13]]) : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T15:.*]] = chlo.broadcast_divide %[[T14]], %[[T4]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T0]], %[[T5]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T14:.*]] = mhlo.reshape %[[T13]] : (tensor<2x3xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T15:.*]] = chlo.broadcast_divide %[[T14]], %[[T2]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T17:.*]] = chlo.broadcast_add %[[T15]], %[[T16]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T18:.*]] = mhlo.rsqrt %[[T17]] : tensor<2x3x1x1xf32>
 // CHECK:         %[[T19:.*]] = "mhlo.broadcast_in_dim"(%[[T18]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         %[[T20:.*]] = chlo.broadcast_multiply %[[T11]], %[[T19]] : (tensor<2x3x224x224xf32>, tensor<2x3x224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T21:.*]] = chlo.broadcast_multiply %[[T20]], %[[T2]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
-// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T1]], %[[T5]] : (tensor<224x224xf32>, tensor<f32>) -> tensor<224x224xf32>
+// CHECK:         %[[T21:.*]] = chlo.broadcast_multiply %[[T20]], %[[T4]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
+// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T5]], %[[T1]] : (tensor<224x224xf32>, tensor<f32>) -> tensor<224x224xf32>
 // CHECK:         %[[T23:.*]] = chlo.broadcast_add %[[T21]], %[[T22]] : (tensor<2x3x224x224xf32>, tensor<224x224xf32>) -> tensor<2x3x224x224xf32>
 // CHECK:         return %[[T23]], %[[T8]], %[[T18]] : tensor<2x3x224x224xf32>, tensor<2x3x1x1xf32>, tensor<2x3x1x1xf32>
 func.func @torch.aten.native_layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,224],f32>) -> (!torch.vtensor<[2,3,224,224],f32>, !torch.vtensor<[2,3,1,1],f32>, !torch.vtensor<[2,3,1,1],f32>) {
@@ -251,17 +260,19 @@ func.func @torch.aten.native_layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,22
   return %3, %4, %5 : !torch.vtensor<[2,3,224,224],f32>, !torch.vtensor<[2,3,1,1],f32>, !torch.vtensor<[2,3,1,1],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.native_layer_norm.dynamic_shape.full(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.native_layer_norm.dynamic_shape.full(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> (tensor<2x3x224x224xf32>, tensor<2x3x1x1xf32>, tensor<2x3x1x1xf32>) {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
 // CHECK:         %[[C3:.*]] = arith.constant 3 : index
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T2:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T3:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-// CHECK:         %[[T4:.*]] = "mhlo.reshape"(%[[T3]]) : (tensor<?x?xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T2:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T3:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T2]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.reshape %[[T3]] : (tensor<?x?xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T5:.*]] = tensor.dim %[[ARG0]], %[[C2]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T6:.*]] = arith.index_cast %[[T5]] : index to i64
 // CHECK:         %[[T7:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
@@ -269,7 +280,7 @@ func.func @torch.aten.native_layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,22
 // CHECK:         %[[T9:.*]] = arith.muli %[[T6]], %[[T8]] : i64
 // CHECK:         %[[T10:.*]] = tensor.from_elements %[[T9]] : tensor<1xi64>
 // CHECK:         %[[T11:.*]] = mhlo.convert(%[[T10]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T12:.*]] = "mhlo.reshape"(%[[T11]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T12:.*]] = mhlo.reshape %[[T11]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T13:.*]] = chlo.broadcast_divide %[[T4]], %[[T12]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T14:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T15:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x?x?xf32>
@@ -279,11 +290,11 @@ func.func @torch.aten.native_layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,22
 // CHECK:         %[[T19:.*]] = arith.index_cast %[[T7]] : index to i32
 // CHECK:         %[[T20:.*]] = tensor.from_elements %[[T16]], %[[T17]], %[[T18]], %[[T19]] : tensor<4xi32>
 // CHECK:         %[[T21:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T13]], %[[T20]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>, tensor<4xi32>) -> tensor<?x?x?x?xf32>
-// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T21]], %[[T2]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+// CHECK:         %[[T22:.*]] = chlo.broadcast_multiply %[[T21]], %[[T1]] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
 // CHECK:         %[[T23:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T22]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
 // CHECK:         %[[T24:.*]] = chlo.broadcast_multiply %[[T23]], %[[T23]] : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:         %[[T25:.*]] = mhlo.reduce(%[[T24]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-// CHECK:         %[[T26:.*]] = "mhlo.reshape"(%[[T25]]) : (tensor<?x?xf32>) -> tensor<2x3x1x1xf32>
+// CHECK:         %[[T25:.*]] = mhlo.reduce(%[[T24]] init: %[[T2]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T26:.*]] = mhlo.reshape %[[T25]] : (tensor<?x?xf32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T27:.*]] = tensor.dim %[[T24]], %[[C2]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T28:.*]] = arith.index_cast %[[T27]] : index to i64
 // CHECK:         %[[T29:.*]] = tensor.dim %[[T24]], %[[C3]] : tensor<?x?x?x?xf32>
@@ -291,9 +302,9 @@ func.func @torch.aten.native_layer_norm.affine(%arg0: !torch.vtensor<[2,3,224,22
 // CHECK:         %[[T31:.*]] = arith.muli %[[T28]], %[[T30]] : i64
 // CHECK:         %[[T32:.*]] = tensor.from_elements %[[T31]] : tensor<1xi64>
 // CHECK:         %[[T33:.*]] = mhlo.convert(%[[T32]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T34:.*]] = "mhlo.reshape"(%[[T33]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T34:.*]] = mhlo.reshape %[[T33]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T35:.*]] = chlo.broadcast_divide %[[T26]], %[[T34]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
-// CHECK:         %[[T36:.*]] = chlo.broadcast_multiply %[[T0]], %[[T2]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T36:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T37:.*]] = chlo.broadcast_add %[[T35]], %[[T36]] : (tensor<2x3x1x1xf32>, tensor<f32>) -> tensor<2x3x1x1xf32>
 // CHECK:         %[[T38:.*]] = mhlo.rsqrt %[[T37]] : tensor<2x3x1x1xf32>
 // CHECK:         %[[T39:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T38]], %[[T20]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x3x1x1xf32>, tensor<4xi32>) -> tensor<?x?x?x?xf32>
@@ -309,38 +320,40 @@ func.func @torch.aten.native_layer_norm.dynamic_shape.full(%arg0: !torch.vtensor
   return %1, %2, %3 : !torch.vtensor<[2,3,224,224],f32>, !torch.vtensor<[2,3,1,1],f32>, !torch.vtensor<[2,3,1,1],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.native_layer_norm.dynamic_shape.partial(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.native_layer_norm.dynamic_shape.partial(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x224x224xf32>) -> (tensor<?x?x224x224xf32>, tensor<?x?x1x1xf32>, tensor<?x?x1x1xf32>) {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<9.99999974E-6> : tensor<f32>
 // CHECK:         %[[C224_I32:.*]] = arith.constant 224 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T3:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK:         %[[T1:.*]] = mhlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK:         %[[T2:.*]] = mhlo.constant dense<5.017600e+04> : tensor<f32>
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
-// CHECK:         %[[T1:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T3:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:         %[[T4:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T5:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T6:.*]] = arith.index_cast %[[T5]] : index to i32
 // CHECK:         %[[T7:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T8:.*]] = arith.index_cast %[[T7]] : index to i32
 // CHECK:         %[[T9:.*]] = tensor.from_elements %[[T6]], %[[T8]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T10:.*]] = "mhlo.dynamic_reshape"(%[[T4]], %[[T9]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T10:.*]] = mhlo.dynamic_reshape %[[T4]], %[[T9]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T11:.*]] = chlo.broadcast_divide %[[T10]], %[[T2]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T12:.*]] = tensor.from_elements %[[T6]], %[[T8]], %[[C224_I32]], %[[C224_I32]] : tensor<4xi32>
 // CHECK:         %[[T13:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T11]], %[[T12]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x224x224xf32>
-// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T13]], %[[T3]] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?x224x224xf32>
+// CHECK:         %[[T14:.*]] = chlo.broadcast_multiply %[[T13]], %[[T1]] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?x224x224xf32>
 // CHECK:         %[[T15:.*]] = chlo.broadcast_subtract %[[ARG0]], %[[T14]] : (tensor<?x?x224x224xf32>, tensor<?x?x224x224xf32>) -> tensor<?x?x224x224xf32>
 // CHECK:         %[[T16:.*]] = chlo.broadcast_multiply %[[T15]], %[[T15]] : (tensor<?x?x224x224xf32>, tensor<?x?x224x224xf32>) -> tensor<?x?x224x224xf32>
-// CHECK:         %[[T17:.*]] = mhlo.reduce(%[[T16]] init: %[[T1]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
+// CHECK:         %[[T17:.*]] = mhlo.reduce(%[[T16]] init: %[[T3]]) applies mhlo.add across dimensions = [2, 3] : (tensor<?x?x224x224xf32>, tensor<f32>) -> tensor<?x?xf32>
 // CHECK:         %[[T18:.*]] = tensor.dim %[[T16]], %[[C0]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T19:.*]] = arith.index_cast %[[T18]] : index to i32
 // CHECK:         %[[T20:.*]] = tensor.dim %[[T16]], %[[C1]] : tensor<?x?x224x224xf32>
 // CHECK:         %[[T21:.*]] = arith.index_cast %[[T20]] : index to i32
 // CHECK:         %[[T22:.*]] = tensor.from_elements %[[T19]], %[[T21]], %[[C1_I32]], %[[C1_I32]] : tensor<4xi32>
-// CHECK:         %[[T23:.*]] = "mhlo.dynamic_reshape"(%[[T17]], %[[T22]]) : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
+// CHECK:         %[[T23:.*]] = mhlo.dynamic_reshape %[[T17]], %[[T22]] : (tensor<?x?xf32>, tensor<4xi32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T24:.*]] = chlo.broadcast_divide %[[T23]], %[[T2]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
-// CHECK:         %[[T25:.*]] = chlo.broadcast_multiply %[[T0]], %[[T3]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
+// CHECK:         %[[T25:.*]] = chlo.broadcast_multiply %[[T0]], %[[T1]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         %[[T26:.*]] = chlo.broadcast_add %[[T24]], %[[T25]] : (tensor<?x?x1x1xf32>, tensor<f32>) -> tensor<?x?x1x1xf32>
 // CHECK:         %[[T27:.*]] = mhlo.rsqrt %[[T26]] : tensor<?x?x1x1xf32>
 // CHECK:         %[[T28:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[T27]], %[[T12]]) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<?x?x1x1xf32>, tensor<4xi32>) -> tensor<?x?x224x224xf32>
@@ -354,3 +367,4 @@ func.func @torch.aten.native_layer_norm.dynamic_shape.partial(%arg0: !torch.vten
   %1, %2, %3 = torch.aten.native_layer_norm %arg0, %0, %none, %none, %float1.000000e-05 : !torch.vtensor<[?,?,224,224],f32>, !torch.list<int>, !torch.none, !torch.none, !torch.float -> !torch.vtensor<[?,?,224,224],f32>, !torch.vtensor<[?,?,1,1],f32>, !torch.vtensor<[?,?,1,1],f32>
   return %1, %2, %3 : !torch.vtensor<[?,?,224,224],f32>, !torch.vtensor<[?,?,1,1],f32>, !torch.vtensor<[?,?,1,1],f32>
 }
+

--- a/pytorch_blade/tests/mhlo/matmul.mlir
+++ b/pytorch_blade/tests/mhlo/matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.mm(
+// CHECK-LABEL:  func.func @torch.aten.mm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3xf32>, %[[ARG1:.*]]: tensor<3x3xf32>) -> tensor<2x3xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<2x3xf32>, tensor<3x3xf32>) -> tensor<2x3xf32>
 // CHECK:         return %[[T0]] : tensor<2x3xf32>
@@ -10,7 +10,8 @@ func.func @torch.aten.mm(%arg0: !torch.vtensor<[2,3],f32>, %arg1: !torch.vtensor
 }
 
 // -----
-// CHECK-LABEL:  func @torch.aten.bmm(
+
+// CHECK-LABEL:  func.func @torch.aten.bmm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<10x3x4xf32>, %[[ARG1:.*]]: tensor<10x4x5xf32>) -> tensor<10x3x5xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<10x3x4xf32>, tensor<10x4x5xf32>) -> tensor<10x3x5xf32>
 // CHECK:         return %[[T0]] : tensor<10x3x5xf32>
@@ -20,7 +21,8 @@ func.func @torch.aten.bmm(%arg0: !torch.vtensor<[10,3,4],f32>, %arg1: !torch.vte
 }
 
 // -----
-// CHECK-LABEL:  func @torch.aten.bmm.dyn(
+
+// CHECK-LABEL:  func.func @torch.aten.bmm.dyn(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x?x256xf32>, %[[ARG1:.*]]: tensor<4x256x?xf32>) -> tensor<4x?x?xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x?x256xf32>, tensor<4x256x?xf32>) -> tensor<4x?x?xf32>
 // CHECK:         return %[[T0]] : tensor<4x?x?xf32>
@@ -29,9 +31,9 @@ func.func @torch.aten.bmm.dyn(%arg0: !torch.vtensor<[4,?,256],f32>, %arg1: !torc
   return %0 : !torch.vtensor<[4,?,?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.dyn(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.dyn(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x?x256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<4x?x?xf32> {
 // CHECK:         %[[C4_I32:.*]] = arith.constant 4 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
@@ -40,12 +42,12 @@ func.func @torch.aten.bmm.dyn(%arg0: !torch.vtensor<[4,?,256],f32>, %arg1: !torc
 // CHECK:         %[[T1:.*]] = arith.index_cast %[[T0]] : index to i32
 // CHECK:         %[[T2:.*]] = arith.muli %[[T1]], %[[C4_I32]] : i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T3]]) : (tensor<4x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T3]] : (tensor<4x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
 // CHECK:         %[[T5:.*]] = "mhlo.dot_general"(%[[T4]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x?xf32>) -> tensor<?x?xf32>
 // CHECK:         %[[T6:.*]] = tensor.dim %[[T5]], %[[C1]] : tensor<?x?xf32>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[C4_I32]], %[[T1]], %[[T7]] : tensor<3xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T8]]) : (tensor<?x?xf32>, tensor<3xi32>) -> tensor<?x?x?xf32>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T8]] : (tensor<?x?xf32>, tensor<3xi32>) -> tensor<?x?x?xf32>
 // CHECK:         %[[T10:.*]] = mhlo.convert(%[[T9]]) : (tensor<?x?x?xf32>) -> tensor<4x?x?xf32>
 // CHECK:         return %[[T10]] : tensor<4x?x?xf32>
 func.func @torch.aten.matmul.dyn(%arg0: !torch.vtensor<[4,?,256],f32>, %arg1: !torch.vtensor<[256,?],f32>) -> !torch.vtensor<[4,?,?],f32> {
@@ -53,9 +55,9 @@ func.func @torch.aten.matmul.dyn(%arg0: !torch.vtensor<[4,?,256],f32>, %arg1: !t
   return %0 : !torch.vtensor<[4,?,?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256x120xf32>, %[[ARG1:.*]]: tensor<4x120x256xf32>) -> tensor<4x256x256xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.broadcast_in_dim"(%[[ARG0]]) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<256x120xf32>) -> tensor<4x256x120xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x256x120xf32>, tensor<4x120x256xf32>) -> tensor<4x256x256xf32>
@@ -65,28 +67,28 @@ func.func @torch.aten.matmul(%arg0: !torch.vtensor<[256,120],f32>, %arg1: !torch
   return %0 : !torch.vtensor<[4,256,256],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.3dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.3dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<1x?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<1x?xf32> {
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf32>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf32>) -> tensor<256x1xf32>
 // CHECK:         %[[T1:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<1x?x256xf32>
 // CHECK:         %[[T2:.*]] = arith.index_cast %[[T1]] : index to i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T3]]) : (tensor<1x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T3]] : (tensor<1x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
 // CHECK:         %[[T5:.*]] = "mhlo.dot_general"(%[[T4]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[C1_I32]], %[[T2]], %[[C1_I32]] : tensor<3xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T6]]) : (tensor<?x1xf32>, tensor<3xi32>) -> tensor<?x?x1xf32>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T6]] : (tensor<?x1xf32>, tensor<3xi32>) -> tensor<?x?x1xf32>
 // CHECK:         %[[T8:.*]] = tensor.dim %[[T7]], %[[C0]] : tensor<?x?x1xf32>
 // CHECK:         %[[T9:.*]] = arith.index_cast %[[T8]] : index to i32
 // CHECK:         %[[T10:.*]] = tensor.dim %[[T7]], %[[C1]] : tensor<?x?x1xf32>
 // CHECK:         %[[T11:.*]] = arith.index_cast %[[T10]] : index to i32
 // CHECK:         %[[T12:.*]] = tensor.from_elements %[[T9]], %[[T11]] : tensor<2xi32>
-// CHECK:         %[[T13:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T12]]) : (tensor<?x1xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T13:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T12]] : (tensor<?x1xf32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         %[[T14:.*]] = mhlo.convert(%[[T13]]) : (tensor<?x?xf32>) -> tensor<1x?xf32>
 // CHECK:         return %[[T14]] : tensor<1x?xf32>
 func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f32>, %arg1: !torch.vtensor<[256],f32>) -> !torch.vtensor<[1,?],f32> {
@@ -94,15 +96,15 @@ func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f32>, %arg1: 
   return %0 : !torch.vtensor<[1,?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx3d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx3d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<?x256x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf32>) -> tensor<1x256xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf32>) -> tensor<1x256xf32>
 // CHECK:         %[[T1:.*]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?x256x?xf32>
 // CHECK:         %[[T2:.*]] = arith.index_cast %[[T1]] : index to i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C1_I32]], %[[C256_I32]] : tensor<3xi32>
@@ -113,64 +115,64 @@ func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f32>, %arg1: 
 // CHECK:         %[[T8:.*]] = tensor.dim %[[T5]], %[[C2]] : tensor<?x1x?xf32>
 // CHECK:         %[[T9:.*]] = arith.index_cast %[[T8]] : index to i32
 // CHECK:         %[[T10:.*]] = tensor.from_elements %[[T7]], %[[T9]] : tensor<2xi32>
-// CHECK:         %[[T11:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T10]]) : (tensor<?x1x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T11:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T10]] : (tensor<?x1x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         return %[[T11]] : tensor<?x?xf32>
 func.func @torch.aten.matmul.1dx3d(%arg0: !torch.vtensor<[256],f32>, %arg1: !torch.vtensor<[?,256,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f32>, !torch.vtensor<[?,256,?],f32> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.2dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.2dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<?xf32> {
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf32>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf32>) -> tensor<256x1xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf32>
 // CHECK:         %[[T3:.*]] = arith.index_cast %[[T2]] : index to i32
 // CHECK:         %[[T4:.*]] = tensor.from_elements %[[T3]] : tensor<1xi32>
-// CHECK:         %[[T5:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T4]]) : (tensor<?x1xf32>, tensor<1xi32>) -> tensor<?xf32>
+// CHECK:         %[[T5:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T4]] : (tensor<?x1xf32>, tensor<1xi32>) -> tensor<?xf32>
 // CHECK:         return %[[T5]] : tensor<?xf32>
 func.func @torch.aten.matmul.2dx1d(%arg0: !torch.vtensor<[?,256],f32>, %arg1: !torch.vtensor<[256],f32>) -> !torch.vtensor<[?],f32> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,256],f32>, !torch.vtensor<[256],f32> -> !torch.vtensor<[?],f32>
   return %0 : !torch.vtensor<[?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx2d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx2d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<?xf32> {
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf32>) -> tensor<1x256xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf32>) -> tensor<1x256xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x?xf32>) -> tensor<1x?xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf32>
 // CHECK:         %[[T3:.*]] = arith.index_cast %[[T2]] : index to i32
 // CHECK:         %[[T4:.*]] = tensor.from_elements %[[T3]] : tensor<1xi32>
-// CHECK:         %[[T5:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T4]]) : (tensor<1x?xf32>, tensor<1xi32>) -> tensor<?xf32>
+// CHECK:         %[[T5:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T4]] : (tensor<1x?xf32>, tensor<1xi32>) -> tensor<?xf32>
 // CHECK:         return %[[T5]] : tensor<?xf32>
 func.func @torch.aten.matmul.1dx2d(%arg0: !torch.vtensor<[256],f32>, %arg1: !torch.vtensor<[256,?],f32>) -> !torch.vtensor<[?],f32> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f32>, !torch.vtensor<[256,?],f32> -> !torch.vtensor<[?],f32>
   return %0 : !torch.vtensor<[?],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<f32> {
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf32>) -> tensor<1x256xf32>
-// CHECK:         %[[T1:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf32>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf32>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf32>) -> tensor<256x1xf32>
 // CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x1xf32>) -> tensor<1x1xf32>
-// CHECK:         %[[T3:.*]] = "mhlo.reshape"(%[[T2]]) : (tensor<1x1xf32>) -> tensor<f32>
+// CHECK:         %[[T3:.*]] = mhlo.reshape %[[T2]] : (tensor<1x1xf32>) -> tensor<f32>
 // CHECK:         return %[[T3]] : tensor<f32>
 func.func @torch.aten.matmul.1dx1d(%arg0: !torch.vtensor<[256],f32>, %arg1: !torch.vtensor<[256],f32>) -> !torch.vtensor<[],f32> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f32>, !torch.vtensor<[256],f32> -> !torch.vtensor<[],f32>
   return %0 : !torch.vtensor<[],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.proj(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.proj(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x256xf32>) -> tensor<?x?x256xf32> {
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
@@ -182,10 +184,10 @@ func.func @torch.aten.matmul.1dx1d(%arg0: !torch.vtensor<[256],f32>, %arg1: !tor
 // CHECK:         %[[T4:.*]] = arith.index_cast %[[T3]] : index to i32
 // CHECK:         %[[T5:.*]] = arith.muli %[[T2]], %[[T4]] : i32
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[T5]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T6]]) : (tensor<?x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T6]] : (tensor<?x?x256xf32>, tensor<2xi32>) -> tensor<?x256xf32>
 // CHECK:         %[[T8:.*]] = "mhlo.dot_general"(%[[T7]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x256xf32>) -> tensor<?x256xf32>
 // CHECK:         %[[T9:.*]] = tensor.from_elements %[[T2]], %[[T4]], %[[C256_I32]] : tensor<3xi32>
-// CHECK:         %[[T10:.*]] = "mhlo.dynamic_reshape"(%[[T8]], %[[T9]]) : (tensor<?x256xf32>, tensor<3xi32>) -> tensor<?x?x256xf32>
+// CHECK:         %[[T10:.*]] = mhlo.dynamic_reshape %[[T8]], %[[T9]] : (tensor<?x256xf32>, tensor<3xi32>) -> tensor<?x?x256xf32>
 // CHECK:         return %[[T10]] : tensor<?x?x256xf32>
 func.func @torch.aten.matmul.proj(%arg0: !torch.vtensor<[?,?,256],f32>) -> !torch.vtensor<[?,?,256],f32> {
   %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<256x256xf32>) : !torch.vtensor<[256,256],f32>
@@ -193,9 +195,9 @@ func.func @torch.aten.matmul.proj(%arg0: !torch.vtensor<[?,?,256],f32>) -> !torc
   return %1 : !torch.vtensor<[?,?,256],f32>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.mm.proj(
+
+// CHECK-LABEL:  func.func @torch.aten.mm.proj(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>) -> tensor<?x256xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<256x256xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x256xf32>) -> tensor<?x256xf32>

--- a/pytorch_blade/tests/mhlo/matmul_half.mlir
+++ b/pytorch_blade/tests/mhlo/matmul_half.mlir
@@ -1,6 +1,6 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.mm(
+// CHECK-LABEL:  func.func @torch.aten.mm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3xf16>, %[[ARG1:.*]]: tensor<3x3xf16>) -> tensor<2x3xf16> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<2x3xf16>, tensor<3x3xf16>) -> tensor<2x3xf16>
 // CHECK:         return %[[T0]] : tensor<2x3xf16>
@@ -10,7 +10,8 @@ func.func @torch.aten.mm(%arg0: !torch.vtensor<[2,3],f16>, %arg1: !torch.vtensor
 }
 
 // -----
-// CHECK-LABEL:  func @torch.aten.bmm(
+
+// CHECK-LABEL:  func.func @torch.aten.bmm(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<10x3x4xf16>, %[[ARG1:.*]]: tensor<10x4x5xf16>) -> tensor<10x3x5xf16> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<10x3x4xf16>, tensor<10x4x5xf16>) -> tensor<10x3x5xf16>
 // CHECK:         return %[[T0]] : tensor<10x3x5xf16>
@@ -20,7 +21,8 @@ func.func @torch.aten.bmm(%arg0: !torch.vtensor<[10,3,4],f16>, %arg1: !torch.vte
 }
 
 // -----
-// CHECK-LABEL:  func @torch.aten.bmm.dyn(
+
+// CHECK-LABEL:  func.func @torch.aten.bmm.dyn(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x?x256xf16>, %[[ARG1:.*]]: tensor<4x256x?xf16>) -> tensor<4x?x?xf16> {
 // CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x?x256xf16>, tensor<4x256x?xf16>) -> tensor<4x?x?xf16>
 // CHECK:         return %[[T0]] : tensor<4x?x?xf16>
@@ -29,9 +31,9 @@ func.func @torch.aten.bmm.dyn(%arg0: !torch.vtensor<[4,?,256],f16>, %arg1: !torc
   return %0 : !torch.vtensor<[4,?,?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.dyn(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.dyn(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x?x256xf16>, %[[ARG1:.*]]: tensor<256x?xf16>) -> tensor<4x?x?xf16> {
 // CHECK:         %[[C4_I32:.*]] = arith.constant 4 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
@@ -40,12 +42,12 @@ func.func @torch.aten.bmm.dyn(%arg0: !torch.vtensor<[4,?,256],f16>, %arg1: !torc
 // CHECK:         %[[T1:.*]] = arith.index_cast %[[T0]] : index to i32
 // CHECK:         %[[T2:.*]] = arith.muli %[[T1]], %[[C4_I32]] : i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T3]]) : (tensor<4x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T3]] : (tensor<4x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
 // CHECK:         %[[T5:.*]] = "mhlo.dot_general"(%[[T4]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf16>, tensor<256x?xf16>) -> tensor<?x?xf16>
 // CHECK:         %[[T6:.*]] = tensor.dim %[[T5]], %[[C1]] : tensor<?x?xf16>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[C4_I32]], %[[T1]], %[[T7]] : tensor<3xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T8]]) : (tensor<?x?xf16>, tensor<3xi32>) -> tensor<?x?x?xf16>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T8]] : (tensor<?x?xf16>, tensor<3xi32>) -> tensor<?x?x?xf16>
 // CHECK:         %[[T10:.*]] = mhlo.convert(%[[T9]]) : (tensor<?x?x?xf16>) -> tensor<4x?x?xf16>
 // CHECK:         return %[[T10]] : tensor<4x?x?xf16>
 func.func @torch.aten.matmul.dyn(%arg0: !torch.vtensor<[4,?,256],f16>, %arg1: !torch.vtensor<[256,?],f16>) -> !torch.vtensor<[4,?,?],f16> {
@@ -53,9 +55,9 @@ func.func @torch.aten.matmul.dyn(%arg0: !torch.vtensor<[4,?,256],f16>, %arg1: !t
   return %0 : !torch.vtensor<[4,?,?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256x120xf16>, %[[ARG1:.*]]: tensor<4x120x256xf16>) -> tensor<4x256x256xf16> {
 // CHECK:         %[[T0:.*]] = "mhlo.broadcast_in_dim"(%[[ARG0]]) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<256x120xf16>) -> tensor<4x256x120xf16>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x256x120xf16>, tensor<4x120x256xf16>) -> tensor<4x256x256xf16>
@@ -65,28 +67,28 @@ func.func @torch.aten.matmul(%arg0: !torch.vtensor<[256,120],f16>, %arg1: !torch
   return %0 : !torch.vtensor<[4,256,256],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.3dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.3dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<1x?x256xf16>, %[[ARG1:.*]]: tensor<256xf16>) -> tensor<1x?xf16> {
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf16>) -> tensor<256x1xf16>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf16>) -> tensor<256x1xf16>
 // CHECK:         %[[T1:.*]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<1x?x256xf16>
 // CHECK:         %[[T2:.*]] = arith.index_cast %[[T1]] : index to i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T3]]) : (tensor<1x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T3]] : (tensor<1x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
 // CHECK:         %[[T5:.*]] = "mhlo.dot_general"(%[[T4]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf16>, tensor<256x1xf16>) -> tensor<?x1xf16>
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[C1_I32]], %[[T2]], %[[C1_I32]] : tensor<3xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T6]]) : (tensor<?x1xf16>, tensor<3xi32>) -> tensor<?x?x1xf16>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T6]] : (tensor<?x1xf16>, tensor<3xi32>) -> tensor<?x?x1xf16>
 // CHECK:         %[[T8:.*]] = tensor.dim %[[T7]], %[[C0]] : tensor<?x?x1xf16>
 // CHECK:         %[[T9:.*]] = arith.index_cast %[[T8]] : index to i32
 // CHECK:         %[[T10:.*]] = tensor.dim %[[T7]], %[[C1]] : tensor<?x?x1xf16>
 // CHECK:         %[[T11:.*]] = arith.index_cast %[[T10]] : index to i32
 // CHECK:         %[[T12:.*]] = tensor.from_elements %[[T9]], %[[T11]] : tensor<2xi32>
-// CHECK:         %[[T13:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T12]]) : (tensor<?x1xf16>, tensor<2xi32>) -> tensor<?x?xf16>
+// CHECK:         %[[T13:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T12]] : (tensor<?x1xf16>, tensor<2xi32>) -> tensor<?x?xf16>
 // CHECK:         %[[T14:.*]] = mhlo.convert(%[[T13]]) : (tensor<?x?xf16>) -> tensor<1x?xf16>
 // CHECK:         return %[[T14]] : tensor<1x?xf16>
 func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f16>, %arg1: !torch.vtensor<[256],f16>) -> !torch.vtensor<[1,?],f16> {
@@ -94,15 +96,15 @@ func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f16>, %arg1: 
   return %0 : !torch.vtensor<[1,?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx3d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx3d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf16>, %[[ARG1:.*]]: tensor<?x256x?xf16>) -> tensor<?x?xf16> {
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf16>) -> tensor<1x256xf16>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf16>) -> tensor<1x256xf16>
 // CHECK:         %[[T1:.*]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?x256x?xf16>
 // CHECK:         %[[T2:.*]] = arith.index_cast %[[T1]] : index to i32
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]], %[[C1_I32]], %[[C256_I32]] : tensor<3xi32>
@@ -113,64 +115,64 @@ func.func @torch.aten.matmul.3dx1d(%arg0: !torch.vtensor<[1,?,256],f16>, %arg1: 
 // CHECK:         %[[T8:.*]] = tensor.dim %[[T5]], %[[C2]] : tensor<?x1x?xf16>
 // CHECK:         %[[T9:.*]] = arith.index_cast %[[T8]] : index to i32
 // CHECK:         %[[T10:.*]] = tensor.from_elements %[[T7]], %[[T9]] : tensor<2xi32>
-// CHECK:         %[[T11:.*]] = "mhlo.dynamic_reshape"(%[[T5]], %[[T10]]) : (tensor<?x1x?xf16>, tensor<2xi32>) -> tensor<?x?xf16>
+// CHECK:         %[[T11:.*]] = mhlo.dynamic_reshape %[[T5]], %[[T10]] : (tensor<?x1x?xf16>, tensor<2xi32>) -> tensor<?x?xf16>
 // CHECK:         return %[[T11]] : tensor<?x?xf16>
 func.func @torch.aten.matmul.1dx3d(%arg0: !torch.vtensor<[256],f16>, %arg1: !torch.vtensor<[?,256,?],f16>) -> !torch.vtensor<[?,?],f16> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f16>, !torch.vtensor<[?,256,?],f16> -> !torch.vtensor<[?,?],f16>
   return %0 : !torch.vtensor<[?,?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.2dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.2dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf16>, %[[ARG1:.*]]: tensor<256xf16>) -> tensor<?xf16> {
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf16>) -> tensor<256x1xf16>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf16>) -> tensor<256x1xf16>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf16>, tensor<256x1xf16>) -> tensor<?x1xf16>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf16>
 // CHECK:         %[[T3:.*]] = arith.index_cast %[[T2]] : index to i32
 // CHECK:         %[[T4:.*]] = tensor.from_elements %[[T3]] : tensor<1xi32>
-// CHECK:         %[[T5:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T4]]) : (tensor<?x1xf16>, tensor<1xi32>) -> tensor<?xf16>
+// CHECK:         %[[T5:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T4]] : (tensor<?x1xf16>, tensor<1xi32>) -> tensor<?xf16>
 // CHECK:         return %[[T5]] : tensor<?xf16>
 func.func @torch.aten.matmul.2dx1d(%arg0: !torch.vtensor<[?,256],f16>, %arg1: !torch.vtensor<[256],f16>) -> !torch.vtensor<[?],f16> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,256],f16>, !torch.vtensor<[256],f16> -> !torch.vtensor<[?],f16>
   return %0 : !torch.vtensor<[?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx2d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx2d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf16>, %[[ARG1:.*]]: tensor<256x?xf16>) -> tensor<?xf16> {
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf16>) -> tensor<1x256xf16>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf16>) -> tensor<1x256xf16>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf16>, tensor<256x?xf16>) -> tensor<1x?xf16>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf16>
 // CHECK:         %[[T3:.*]] = arith.index_cast %[[T2]] : index to i32
 // CHECK:         %[[T4:.*]] = tensor.from_elements %[[T3]] : tensor<1xi32>
-// CHECK:         %[[T5:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T4]]) : (tensor<1x?xf16>, tensor<1xi32>) -> tensor<?xf16>
+// CHECK:         %[[T5:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T4]] : (tensor<1x?xf16>, tensor<1xi32>) -> tensor<?xf16>
 // CHECK:         return %[[T5]] : tensor<?xf16>
 func.func @torch.aten.matmul.1dx2d(%arg0: !torch.vtensor<[256],f16>, %arg1: !torch.vtensor<[256,?],f16>) -> !torch.vtensor<[?],f16> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f16>, !torch.vtensor<[256,?],f16> -> !torch.vtensor<[?],f16>
   return %0 : !torch.vtensor<[?],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.1dx1d(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.1dx1d(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf16>, %[[ARG1:.*]]: tensor<256xf16>) -> tensor<f16> {
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<256xf16>) -> tensor<1x256xf16>
-// CHECK:         %[[T1:.*]] = "mhlo.reshape"(%[[ARG1]]) : (tensor<256xf16>) -> tensor<256x1xf16>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<256xf16>) -> tensor<1x256xf16>
+// CHECK:         %[[T1:.*]] = mhlo.reshape %[[ARG1]] : (tensor<256xf16>) -> tensor<256x1xf16>
 // CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf16>, tensor<256x1xf16>) -> tensor<1x1xf16>
-// CHECK:         %[[T3:.*]] = "mhlo.reshape"(%[[T2]]) : (tensor<1x1xf16>) -> tensor<f16>
+// CHECK:         %[[T3:.*]] = mhlo.reshape %[[T2]] : (tensor<1x1xf16>) -> tensor<f16>
 // CHECK:         return %[[T3]] : tensor<f16>
 func.func @torch.aten.matmul.1dx1d(%arg0: !torch.vtensor<[256],f16>, %arg1: !torch.vtensor<[256],f16>) -> !torch.vtensor<[],f16> {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[256],f16>, !torch.vtensor<[256],f16> -> !torch.vtensor<[],f16>
   return %0 : !torch.vtensor<[],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.matmul.proj(
+
+// CHECK-LABEL:  func.func @torch.aten.matmul.proj(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x256xf16>) -> tensor<?x?x256xf16> {
 // CHECK:         %[[C256_I32:.*]] = arith.constant 256 : i32
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
@@ -182,10 +184,10 @@ func.func @torch.aten.matmul.1dx1d(%arg0: !torch.vtensor<[256],f16>, %arg1: !tor
 // CHECK:         %[[T4:.*]] = arith.index_cast %[[T3]] : index to i32
 // CHECK:         %[[T5:.*]] = arith.muli %[[T2]], %[[T4]] : i32
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[T5]], %[[C256_I32]] : tensor<2xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T6]]) : (tensor<?x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T6]] : (tensor<?x?x256xf16>, tensor<2xi32>) -> tensor<?x256xf16>
 // CHECK:         %[[T8:.*]] = "mhlo.dot_general"(%[[T7]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf16>, tensor<256x256xf16>) -> tensor<?x256xf16>
 // CHECK:         %[[T9:.*]] = tensor.from_elements %[[T2]], %[[T4]], %[[C256_I32]] : tensor<3xi32>
-// CHECK:         %[[T10:.*]] = "mhlo.dynamic_reshape"(%[[T8]], %[[T9]]) : (tensor<?x256xf16>, tensor<3xi32>) -> tensor<?x?x256xf16>
+// CHECK:         %[[T10:.*]] = mhlo.dynamic_reshape %[[T8]], %[[T9]] : (tensor<?x256xf16>, tensor<3xi32>) -> tensor<?x?x256xf16>
 // CHECK:         return %[[T10]] : tensor<?x?x256xf16>
 func.func @torch.aten.matmul.proj(%arg0: !torch.vtensor<[?,?,256],f16>) -> !torch.vtensor<[?,?,256],f16> {
   %0 = torch.vtensor.literal(dense<1.000000e+00> : tensor<256x256xf16>) : !torch.vtensor<[256,256],f16>
@@ -193,9 +195,9 @@ func.func @torch.aten.matmul.proj(%arg0: !torch.vtensor<[?,?,256],f16>) -> !torc
   return %1 : !torch.vtensor<[?,?,256],f16>
 }
 
-
 // -----
-// CHECK-LABEL:  func @torch.aten.mm.proj(
+
+// CHECK-LABEL:  func.func @torch.aten.mm.proj(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf16>) -> tensor<?x256xf16> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<1.000000e+00> : tensor<256x256xf16>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf16>, tensor<256x256xf16>) -> tensor<?x256xf16>

--- a/pytorch_blade/tests/mhlo/mem_ops.mlir
+++ b/pytorch_blade/tests/mhlo/mem_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.flip(
+// CHECK-LABEL:  func.func @torch.aten.flip(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?xi64>) -> tensor<?x?x?xi64> {
 // CHECK:         %[[T0:.*]] = "mhlo.reverse"(%[[ARG0]]) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<?x?x?xi64>) -> tensor<?x?x?xi64>
 // CHECK:         return %[[T0]] : tensor<?x?x?xi64>
@@ -14,7 +14,7 @@ func.func @torch.aten.flip(%arg0: !torch.vtensor<[?,?,?],si64>) -> !torch.vtenso
 
 // -----
 
-// CHECK-LABEL:  func @torch.aten.index_select(
+// CHECK-LABEL:  func.func @torch.aten.index_select(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x4xf32>, %[[ARG1:.*]]: tensor<2xi64>) -> tensor<2x4xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[1, 4]> : tensor<2xi32>
 // CHECK:         %[[T0:.*]] = "mhlo.dynamic_gather"(%[[ARG0]], %[[ARG1]], %[[CST]]) {dimension_numbers = #mhlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false} : (tensor<?x4xf32>, tensor<2xi64>, tensor<2xi32>) -> tensor<2x4xf32>
@@ -27,7 +27,7 @@ func.func @torch.aten.index_select(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !tor
 
 // -----
 
-// CHECK-LABEL:  func @torch.aten.roll(
+// CHECK-LABEL:  func.func @torch.aten.roll(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[C:.*]]-9_i32 = arith.constant -9 : i32
 // CHECK:         %[[CST:.*]] = arith.constant dense<0> : tensor<2xi32>
@@ -44,11 +44,11 @@ func.func @torch.aten.index_select(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !tor
 // CHECK:         %[[T5:.*]] = arith.remsi %[[T4]], %[[T3]] : i32
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[C0_I32]], %[[T5]] : tensor<2xi32>
 // CHECK:         %[[T7:.*]] = tensor.from_elements %[[T1]], %[[T3]] : tensor<2xi32>
-// CHECK:         %[[T8:.*]] = "mhlo.real_dynamic_slice"(%[[ARG0]], %[[T6]], %[[T7]], %[[CST_0]]) : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T8:.*]] = mhlo.real_dynamic_slice %[[ARG0]], %[[T6]], %[[T7]], %[[CST_0]] : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         %[[T9:.*]] = arith.cmpi eq, %[[T5]], %[[C0_I32]] : i32
 // CHECK:         %[[T10:.*]] = arith.select %[[T9]], %[[T3]], %[[T5]] : i32
 // CHECK:         %[[T11:.*]] = tensor.from_elements %[[T1]], %[[T1]]0 : tensor<2xi32>
-// CHECK:         %[[T12:.*]] = "mhlo.real_dynamic_slice"(%[[ARG0]], %[[CST]], %[[T11]], %[[CST]]_0) : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T12:.*]] = mhlo.real_dynamic_slice %[[ARG0]], %[[CST]], %[[T11]], %[[CST]]_0 : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         %[[T13:.*]] = "mhlo.concatenate"(%[[T8]], %[[T12]]) {dimension = 1 : i64} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         %[[T14:.*]] = tensor.dim %[[T13]], %[[C0]] : tensor<?x?xf32>
 // CHECK:         %[[T15:.*]] = arith.index_cast %[[T14]] : index to i32
@@ -58,11 +58,11 @@ func.func @torch.aten.index_select(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !tor
 // CHECK:         %[[T19:.*]] = arith.remsi %[[T18]], %[[T15]] : i32
 // CHECK:         %[[T20:.*]] = tensor.from_elements %[[T19]], %[[C0_I32]] : tensor<2xi32>
 // CHECK:         %[[T21:.*]] = tensor.from_elements %[[T15]], %[[T17]] : tensor<2xi32>
-// CHECK:         %[[T22:.*]] = "mhlo.real_dynamic_slice"(%[[T13]], %[[T20]], %[[T21]], %[[CST_0]]) : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T22:.*]] = mhlo.real_dynamic_slice %[[T13]], %[[T20]], %[[T21]], %[[CST_0]] : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         %[[T23:.*]] = arith.cmpi eq, %[[T19]], %[[C0_I32]] : i32
 // CHECK:         %[[T24:.*]] = arith.select %[[T23]], %[[T15]], %[[T19]] : i32
 // CHECK:         %[[T25:.*]] = tensor.from_elements %[[T24]], %[[T17]] : tensor<2xi32>
-// CHECK:         %[[T26:.*]] = "mhlo.real_dynamic_slice"(%[[T13]], %[[CST]], %[[T25]], %[[CST]]_0) : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK:         %[[T26:.*]] = mhlo.real_dynamic_slice %[[T13]], %[[CST]], %[[T25]], %[[CST]]_0 : (tensor<?x?xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
 // CHECK:         %[[T27:.*]] = "mhlo.concatenate"(%[[T22]], %[[T26]]) {dimension = 0 : i64} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         return %[[T27]] : tensor<?x?xf32>
 func.func @torch.aten.roll(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
@@ -75,3 +75,4 @@ func.func @torch.aten.roll(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
   %2 = torch.aten.roll %arg0, %0, %1 : !torch.vtensor<[?,?],f32>, !torch.list<int>, !torch.list<int> -> !torch.vtensor<[?,?],f32>
   return %2 : !torch.vtensor<[?,?],f32>
 }
+

--- a/pytorch_blade/tests/mhlo/reduction.mlir
+++ b/pytorch_blade/tests/mhlo/reduction.mlir
@@ -1,6 +1,6 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.sum.div.Scalar(
+// CHECK-LABEL:  func.func @torch.aten.sum.div.Scalar(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<f32> {
 // CHECK:         %[[C3:.*]] = arith.constant 3 : index
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
@@ -22,7 +22,7 @@
 // CHECK:         %[[T13:.*]] = arith.extsi %[[T12]] : i32 to i64
 // CHECK:         %[[T14:.*]] = tensor.from_elements %[[T13]] : tensor<1xi64>
 // CHECK:         %[[T15:.*]] = mhlo.convert(%[[T14]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T16:.*]] = "mhlo.reshape"(%[[T15]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T16:.*]] = mhlo.reshape %[[T15]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T17:.*]] = chlo.broadcast_divide %[[T1]], %[[T1]]6 : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         return %[[T17]] : tensor<f32>
 func.func @torch.aten.sum.div.Scalar(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[],f32> {
@@ -33,7 +33,9 @@ func.func @torch.aten.sum.div.Scalar(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !t
   return %2 : !torch.vtensor<[],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.sum.div.Scalar.si32(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.sum.div.Scalar.si32(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xi32>) -> tensor<f32> {
 // CHECK:         %[[C3:.*]] = arith.constant 3 : index
 // CHECK:         %[[C2:.*]] = arith.constant 2 : index
@@ -56,7 +58,7 @@ func.func @torch.aten.sum.div.Scalar(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !t
 // CHECK:         %[[T14:.*]] = arith.extsi %[[T13]] : i32 to i64
 // CHECK:         %[[T15:.*]] = tensor.from_elements %[[T14]] : tensor<1xi64>
 // CHECK:         %[[T16:.*]] = mhlo.convert(%[[T15]]) : (tensor<1xi64>) -> tensor<1xf32>
-// CHECK:         %[[T17:.*]] = "mhlo.reshape"(%[[T16]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T17:.*]] = mhlo.reshape %[[T16]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         %[[T18:.*]] = chlo.broadcast_divide %[[T2]], %[[T17]] : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK:         return %[[T18]] : tensor<f32>
 func.func @torch.aten.sum.div.Scalar.si32(%arg0: !torch.vtensor<[?,?,?,?],si32>) -> !torch.vtensor<[],f32> {
@@ -67,8 +69,9 @@ func.func @torch.aten.sum.div.Scalar.si32(%arg0: !torch.vtensor<[?,?,?,?],si32>)
   return %2 : !torch.vtensor<[],f32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.outf32(
+// CHECK-LABEL:  func.func @torch.aten.sum.outf32(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<f32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [0, 1, 2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<f32>
@@ -79,8 +82,9 @@ func.func @torch.aten.sum.outf32(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch
   return %0 : !torch.vtensor<[],f32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.outf64(
+// CHECK-LABEL:  func.func @torch.aten.sum.outf64(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<f64> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [0, 1, 2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<f32>
@@ -92,8 +96,9 @@ func.func @torch.aten.sum.outf64(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch
   return %0 : !torch.vtensor<[],f64>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum(
+// CHECK-LABEL:  func.func @torch.aten.sum(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<f32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [0, 1, 2, 3] : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<f32>
@@ -104,8 +109,9 @@ func.func @torch.aten.sum(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtenso
   return %0 : !torch.vtensor<[],f32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.f64(
+// CHECK-LABEL:  func.func @torch.aten.sum.f64(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf64>) -> tensor<f64> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f64>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [0, 1, 2, 3] : (tensor<?x?x?x?xf64>, tensor<f64>) -> tensor<f64>
@@ -116,8 +122,9 @@ func.func @torch.aten.sum.f64(%arg0: !torch.vtensor<[?,?,?,?],f64>) -> !torch.vt
   return %0 : !torch.vtensor<[],f64>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.si32(
+// CHECK-LABEL:  func.func @torch.aten.sum.si32(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xi32>) -> tensor<i32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0> : tensor<i32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [0, 1, 2, 3] : (tensor<?x?x?x?xi32>, tensor<i32>) -> tensor<i32>
@@ -128,8 +135,9 @@ func.func @torch.aten.sum.si32(%arg0: !torch.vtensor<[?,?,?,?],si32>) -> !torch.
   return %0 : !torch.vtensor<[],si32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.dim_IntList(
+// CHECK-LABEL:  func.func @torch.aten.sum.dim_IntList(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x?x?x?xf32>) -> tensor<2xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [1, 2, 3] : (tensor<2x?x?x?xf32>, tensor<f32>) -> tensor<2xf32>
@@ -145,12 +153,13 @@ func.func @torch.aten.sum.dim_IntList(%arg0: !torch.vtensor<[2,?,?,?],f32>) -> !
   return %1 : !torch.vtensor<[2],f32>
 }
 
+// -----
 
-// CHECK-LABEL:  func @torch.aten.sum.dim_IntList.keepdim(
+// CHECK-LABEL:  func.func @torch.aten.sum.dim_IntList.keepdim(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x?x224x?xf32>) -> tensor<2x1x224x1xf32> {
 // CHECK:         %[[T0:.*]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK:         %[[T1:.*]] = mhlo.reduce(%[[ARG0]] init: %[[T0]]) applies mhlo.add across dimensions = [1, 3] : (tensor<2x?x224x?xf32>, tensor<f32>) -> tensor<2x224xf32>
-// CHECK:         %[[T2:.*]] = "mhlo.reshape"(%[[T1]]) : (tensor<2x224xf32>) -> tensor<2x1x224x1xf32>
+// CHECK:         %[[T2:.*]] = mhlo.reshape %[[T1]] : (tensor<2x224xf32>) -> tensor<2x1x224x1xf32>
 // CHECK:         return %[[T2]] : tensor<2x1x224x1xf32>
 func.func @torch.aten.sum.dim_IntList.keepdim(%arg0: !torch.vtensor<[2,?,224,?],f32>) -> !torch.vtensor<[2,1,224,1],f32> {
   %none = torch.constant.none

--- a/pytorch_blade/tests/mhlo/slices.mlir
+++ b/pytorch_blade/tests/mhlo/slices.mlir
@@ -1,9 +1,9 @@
 // RUN: torch-mlir-opt <%s --torch-backend-to-mhlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  func @torch.aten.select.int(
+// CHECK-LABEL:  func.func @torch.aten.select.int(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x65x256xf32>) -> tensor<4x256xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.slice"(%[[ARG0]]) {limit_indices = dense<[4, 2, 256]> : tensor<3xi64>, start_indices = dense<[0, 1, 0]> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<4x65x256xf32>) -> tensor<4x1x256xf32>
-// CHECK:         %[[T1:.*]] = "mhlo.reshape"(%[[T0]]) : (tensor<4x1x256xf32>) -> tensor<4x256xf32>
+// CHECK:         %[[T1:.*]] = mhlo.reshape %[[T0]] : (tensor<4x1x256xf32>) -> tensor<4x256xf32>
 // CHECK:         return %[[T1]] : tensor<4x256xf32>
 func.func @torch.aten.select.int(%arg0: !torch.vtensor<[4,65,256],f32>) -> !torch.vtensor<[4,256],f32> {
   %int1 = torch.constant.int 1
@@ -11,7 +11,9 @@ func.func @torch.aten.select.int(%arg0: !torch.vtensor<[4,65,256],f32>) -> !torc
   return %2 : !torch.vtensor<[4,256],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.slice.stride2(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.slice.stride2(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x65x256xf32>) -> tensor<2x65x256xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.slice"(%[[ARG0]]) {limit_indices = dense<[4, 65, 256]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<[2, 1, 1]> : tensor<3xi64>} : (tensor<4x65x256xf32>) -> tensor<2x65x256xf32>
 // CHECK:         return %[[T0]] : tensor<2x65x256xf32>
@@ -23,7 +25,9 @@ func.func @torch.aten.slice.stride2(%arg0: !torch.vtensor<[4,65,256],f32>) -> !t
   return %0 : !torch.vtensor<[2,65,256],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.slice.dim1(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.slice.dim1(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x65x256xf32>) -> tensor<4x1x256xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.slice"(%[[ARG0]]) {limit_indices = dense<[4, 65, 256]> : tensor<3xi64>, start_indices = dense<[0, 64, 0]> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<4x65x256xf32>) -> tensor<4x1x256xf32>
 // CHECK:         return %[[T0]] : tensor<4x1x256xf32>
@@ -35,7 +39,9 @@ func.func @torch.aten.slice.dim1(%arg0: !torch.vtensor<[4,65,256],f32>) -> !torc
   return %0 : !torch.vtensor<[4,1,256],f32>
 }
 
-// CHECK-LABEL:  func @torch.aten.slice.none(
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.slice.none(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<4x65x256xf32>) -> tensor<4x33x256xf32> {
 // CHECK:         %[[T0:.*]] = "mhlo.slice"(%[[ARG0]]) {limit_indices = dense<[4, 65, 256]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<4x65x256xf32>) -> tensor<4x33x256xf32>
 // CHECK:         return %[[T0]] : tensor<4x33x256xf32>
@@ -46,3 +52,4 @@ func.func @torch.aten.slice.none(%arg0: !torch.vtensor<[4,65,256],f32>) -> !torc
   %0 = torch.aten.slice.Tensor %arg0, %int1, %none, %none, %int2 : !torch.vtensor<[4,65,256],f32>, !torch.int, !torch.none, !torch.none, !torch.int -> !torch.vtensor<[4,33,256],f32>
   return %0 : !torch.vtensor<[4,33,256],f32>
 }
+

--- a/pytorch_blade/tests/mhlo/unsqueeze_and_squeeze.mlir
+++ b/pytorch_blade/tests/mhlo/unsqueeze_and_squeeze.mlir
@@ -9,6 +9,8 @@ func.func @torch.aten.squeeze.dim0(%arg0: !torch.vtensor<[2,1,2,1,2],f32>) -> !t
   return %0 : !torch.vtensor<[2,1,2,1,2],f32>
 }
 
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.squeeze.dim1(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x1x?x1x?xf32>) -> tensor<?x?x1x?xf32> {
 // CHECK:         %[[C1_I32:.*]] = arith.constant 1 : i32
@@ -22,13 +24,15 @@ func.func @torch.aten.squeeze.dim0(%arg0: !torch.vtensor<[2,1,2,1,2],f32>) -> !t
 // CHECK:         %[[T4:.*]] = tensor.dim %[[ARG0]], %[[C4]] : tensor<?x1x?x1x?xf32>
 // CHECK:         %[[T5:.*]] = arith.index_cast %[[T4]] : index to i32
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[T1]], %[[T3]], %[[C1_I32]], %[[T5]] : tensor<4xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T6]]) : (tensor<?x1x?x1x?xf32>, tensor<4xi32>) -> tensor<?x?x1x?xf32>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T6]] : (tensor<?x1x?x1x?xf32>, tensor<4xi32>) -> tensor<?x?x1x?xf32>
 // CHECK:         return %[[T7]] : tensor<?x?x1x?xf32>
 func.func @torch.aten.squeeze.dim1(%arg0: !torch.vtensor<[?,1,?,1,?],f32>) -> !torch.vtensor<[?,?,1,?],f32> {
   %int1 = torch.constant.int 1
   %0 = torch.aten.squeeze.dim %arg0, %int1 : !torch.vtensor<[?,1,?,1,?],f32>, !torch.int -> !torch.vtensor<[?,?,1,?],f32>
   return %0 : !torch.vtensor<[?,?,1,?],f32>
 }
+
+// -----
 
 // CHECK-LABEL:  func.func @torch.aten.squeeze.dim2.from_end(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x1x?x1x?xf32>) -> tensor<?x1x?x?xf32> {
@@ -43,7 +47,7 @@ func.func @torch.aten.squeeze.dim1(%arg0: !torch.vtensor<[?,1,?,1,?],f32>) -> !t
 // CHECK:         %[[T4:.*]] = tensor.dim %[[ARG0]], %[[C4]] : tensor<?x1x?x1x?xf32>
 // CHECK:         %[[T5:.*]] = arith.index_cast %[[T4]] : index to i32
 // CHECK:         %[[T6:.*]] = tensor.from_elements %[[T1]], %[[C1_I32]], %[[T3]], %[[T5]] : tensor<4xi32>
-// CHECK:         %[[T7:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T6]]) : (tensor<?x1x?x1x?xf32>, tensor<4xi32>) -> tensor<?x1x?x?xf32>
+// CHECK:         %[[T7:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T6]] : (tensor<?x1x?x1x?xf32>, tensor<4xi32>) -> tensor<?x1x?x?xf32>
 // CHECK:         return %[[T7]] : tensor<?x1x?x?xf32>
 func.func @torch.aten.squeeze.dim2.from_end(%arg0: !torch.vtensor<[?,1,?,1,?],f32>) -> !torch.vtensor<[?,1,?,?],f32> {
   %int-2 = torch.constant.int -2
@@ -51,14 +55,18 @@ func.func @torch.aten.squeeze.dim2.from_end(%arg0: !torch.vtensor<[?,1,?,1,?],f3
   return %0 : !torch.vtensor<[?,1,?,?],f32>
 }
 
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.squeeze(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x1x2x1x2xf32>) -> tensor<2x2x2xf32> {
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<2x1x2x1x2xf32>) -> tensor<2x2x2xf32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<2x1x2x1x2xf32>) -> tensor<2x2x2xf32>
 // CHECK:         return %[[T0]] : tensor<2x2x2xf32>
 func.func @torch.aten.squeeze(%arg0: !torch.vtensor<[2,1,2,1,2],f32>) -> !torch.vtensor<[2,2,2],f32> {
   %0 = torch.aten.squeeze %arg0 : !torch.vtensor<[2,1,2,1,2],f32> -> !torch.vtensor<[2,2,2],f32>
   return %0 : !torch.vtensor<[2,2,2],f32>
 }
+
+// -----
 
 // CHECK-LABEL:  func.func @torch.aten.unsqueeze.dim0(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<1x?x?x?x?xf32> {
@@ -76,13 +84,15 @@ func.func @torch.aten.squeeze(%arg0: !torch.vtensor<[2,1,2,1,2],f32>) -> !torch.
 // CHECK:         %[[T6:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[C1_I32]], %[[T1]], %[[T3]], %[[T5]], %[[T7]] : tensor<5xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T8]]) : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<1x?x?x?x?xf32>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T8]] : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<1x?x?x?x?xf32>
 // CHECK:         return %[[T9]] : tensor<1x?x?x?x?xf32>
 func.func @torch.aten.unsqueeze.dim0(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[1,?,?,?,?],f32> {
   %int0 = torch.constant.int 0
   %0 = torch.aten.unsqueeze %arg0, %int0 : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.vtensor<[1,?,?,?,?],f32>
   return %0 : !torch.vtensor<[1,?,?,?,?],f32>
 }
+
+// -----
 
 // CHECK-LABEL:  func.func @torch.aten.unsqueeze.dim1(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x1x?x?x?xf32> {
@@ -100,13 +110,15 @@ func.func @torch.aten.unsqueeze.dim0(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !t
 // CHECK:         %[[T6:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[T1]], %[[C1_I32]], %[[T3]], %[[T5]], %[[T7]] : tensor<5xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T8]]) : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<?x1x?x?x?xf32>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T8]] : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<?x1x?x?x?xf32>
 // CHECK:         return %[[T9]] : tensor<?x1x?x?x?xf32>
 func.func @torch.aten.unsqueeze.dim1(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,1,?,?,?],f32> {
   %int1 = torch.constant.int 1
   %0 = torch.aten.unsqueeze %arg0, %int1 : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.vtensor<[?,1,?,?,?],f32>
   return %0 : !torch.vtensor<[?,1,?,?,?],f32>
 }
+
+// -----
 
 // CHECK-LABEL:  func.func @torch.aten.unsqueeze.dim2.from_end(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x1x?xf32> {
@@ -124,10 +136,11 @@ func.func @torch.aten.unsqueeze.dim1(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !t
 // CHECK:         %[[T6:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xf32>
 // CHECK:         %[[T7:.*]] = arith.index_cast %[[T6]] : index to i32
 // CHECK:         %[[T8:.*]] = tensor.from_elements %[[T1]], %[[T3]], %[[T5]], %[[C1_I32]], %[[T7]] : tensor<5xi32>
-// CHECK:         %[[T9:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T8]]) : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<?x?x?x1x?xf32>
+// CHECK:         %[[T9:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T8]] : (tensor<?x?x?x?xf32>, tensor<5xi32>) -> tensor<?x?x?x1x?xf32>
 // CHECK:         return %[[T9]] : tensor<?x?x?x1x?xf32>
 func.func @torch.aten.unsqueeze.dim2.from_end(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,1,?],f32> {
   %int-2 = torch.constant.int -2
   %0 = torch.aten.unsqueeze %arg0, %int-2 : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.vtensor<[?,?,?,1,?],f32>
   return %0 : !torch.vtensor<[?,?,?,1,?],f32>
 }
+

--- a/pytorch_blade/tests/mhlo/views.mlir
+++ b/pytorch_blade/tests/mhlo/views.mlir
@@ -14,6 +14,7 @@ func.func @torch.aten.view(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtens
 }
 
 // -----
+
 // CHECK-LABEL:  func.func @torch.aten.reshape(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?x?xf32>) -> tensor<?x120x4x64xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[-1, 120, 4, 64]> : tensor<4xi32>
@@ -30,6 +31,7 @@ func.func @torch.aten.reshape(%arg0: !torch.vtensor<[?,?,?,?,?],f32>) -> !torch.
 }
 
 // -----
+
 // CHECK-LABEL:  func.func @torch.aten.flatten(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x?x?x?xf32>) -> tensor<?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<-1> : tensor<1xi32>
@@ -43,6 +45,7 @@ func.func @torch.aten.flatten(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vt
 }
 
 // -----
+
 // CHECK-LABEL:  func.func @torch.aten.view.minus1(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<2x3x?x?xf32>) -> tensor<2x3x?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[2, 3, -1]> : tensor<3xi32>
@@ -60,7 +63,7 @@ func.func @torch.aten.view.minus1(%arg0: !torch.vtensor<[2,3,?,?],f32>) -> !torc
 }
 
 // -----
-// CHECK:         module {
+
 // CHECK-LABEL:  func.func @torch.aten.view.to_rank1(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<f32>) -> tensor<1xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<1> : tensor<1xi32>
@@ -74,9 +77,10 @@ func.func @torch.aten.view.to_rank1(%arg0: !torch.vtensor<[],f32>) -> !torch.vte
 }
 
 // -----
+
 // CHECK-LABEL:  func.func @torch.aten.view.to_rank0(
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<1xf32>) -> tensor<f32> {
-// CHECK:         %[[T0:.*]] = "mhlo.reshape"(%[[ARG0]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T0:.*]] = mhlo.reshape %[[ARG0]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         return %[[T0]] : tensor<f32>
 func.func @torch.aten.view.to_rank0(%arg0: !torch.vtensor<[1],f32>) -> !torch.vtensor<[],f32> {
   %0 = torch.prim.ListConstruct  : () -> !torch.list<int>

--- a/tao_compiler/mlir/disc/transforms/disc_lower_gpu_ops_to_rocdl_ops.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_lower_gpu_ops_to_rocdl_ops.cc
@@ -153,8 +153,8 @@ void populateGpuToROCDLConversionPatterns(LLVMTypeConverter& converter,
       converter, /*allocaAddrSpace=*/5,
       StringAttr::get(&converter.getContext(),
                       ROCDL::ROCDLDialect::getKernelFuncAttrName()));
-  patterns.add<OpToFuncCallLowering<math::AbsOp>>(converter, "__ocml_fabs_f32",
-                                                  "__ocml_fabs_f64");
+  patterns.add<OpToFuncCallLowering<math::AbsFOp>>(converter, "__ocml_fabs_f32",
+                                                   "__ocml_fabs_f64");
   patterns.add<OpToFuncCallLowering<math::AtanOp>>(converter, "__ocml_atan_f32",
                                                    "__ocml_atan_f64");
   patterns.add<OpToFuncCallLowering<math::Atan2Op>>(

--- a/tao_compiler/mlir/disc/transforms/lhlo_elemental_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_elemental_utils.cc
@@ -1124,7 +1124,7 @@ Value elementalLower<lmhlo::IsFiniteOp>(OpBuilder* b, Location loc,
   };
 
   Value operand = maybe_load_from_cache(operand_memref);
-  auto abs_operand = b->create<math::AbsOp>(loc, operand);
+  auto abs_operand = b->create<math::AbsFOp>(loc, operand);
   auto float_elem_tp = elem_tp.cast<FloatType>();
   auto INF = b->create<arith::ConstantFloatOp>(
       loc, APFloat::getInf(float_elem_tp.getFloatSemantics()), float_elem_tp);

--- a/tao_compiler/mlir/disc/transforms/tests/disc-shape-optimization.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-shape-optimization.mlir
@@ -67,7 +67,7 @@ func.func @main(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf3
 // CHECK-LABEL: main
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?xf32, [@[[S0:.*]]]>, %[[ARG1:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<f32>) -> tensor<?xf32, [@[[S0]]]>
 func.func @main(%arg0 : tensor<?xf32>, %arg1 : tensor<f32>, %arg2 : tensor<f32>) -> tensor<?xf32> {
-  // CHECK: %[[T0:.*]] = "mhlo.clamp"(%[[ARG1]], %[[ARG0]], %[[ARG2]])
+  // CHECK: %[[T0:.*]] = mhlo.clamp %[[ARG1]], %[[ARG0]], %[[ARG2]]
   // CHECK: return %[[T0]] : tensor<?xf32, [@[[S0]]]>
   %0 = "mhlo.clamp"(%arg1, %arg0, %arg2) : (tensor<f32>, tensor<?xf32>, tensor<f32>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
@@ -80,7 +80,7 @@ func.func @main(%arg0 : tensor<?xf32>, %arg1 : tensor<f32>, %arg2 : tensor<f32>)
 // CHECK-LABEL: main
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?xf32, [@[[S0:.*]]]>, %[[ARG1:.*]]: tensor<?xf32, [@[[S0]]]>, %[[ARG2:.*]]: tensor<?xf32, [@[[S0]]]>) -> tensor<?xf32, [@[[S0]]]>
 func.func @main(%arg0 : tensor<?xf32>, %arg1 : tensor<?xf32>, %arg2 : tensor<?xf32>) -> tensor<?xf32> {
-  // CHECK: %[[T0:.*]] = "mhlo.clamp"(%[[ARG1]], %[[ARG0]], %[[ARG2]])
+  // CHECK: %[[T0:.*]] = mhlo.clamp %[[ARG1]], %[[ARG0]], %[[ARG2]]
   // CHECK: return %[[T0]] : tensor<?xf32, [@[[S0]]]>
   %0 = "mhlo.clamp"(%arg1, %arg0, %arg2) : (tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
@@ -135,7 +135,7 @@ func.func @main(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?x
   // CHECK: %[[T0:.*]] = tensor.dim %[[ARG1]], %c0
   // CHECK: %[[T1:.*]] = tensor.dim %[[ARG1]], %c1
   // CHECK: %[[T2:.*]] = tensor.from_elements %[[T0]], %[[T1]] : tensor<2xindex>
-  // CHECK: %[[T3:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[T2]])
+  // CHECK: %[[T3:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[T2]]
   // CHECK: return %[[T3]] : tensor<?x?xf32, [@[[S3]], @[[S4]]]>
   %0 = tensor.dim %arg0, %c0 : tensor<?x?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?x?xf32>
@@ -210,12 +210,12 @@ func.func @main(%arg0: tensor<?x?x?xf32>, %arg1: tensor<2xindex>) -> (tensor<?x?
 // CHECK-LABEL: @main
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?x?xf32, [@[[S0:.*]], @[[S1:.*]]]>, %[[ARG1:.*]]: tensor<1xindex>, %[[ARG2:.*]]: tensor<3xindex>) -> tensor<?x?x?xf32, [@[[S3:.*]], @[[S4:.*]], @[[S5:.*]]]>
 func.func @main(%arg0 : tensor<?x?xf32>, %arg1 : tensor<1xindex>, %arg2 : tensor<3xindex>) -> tensor<?x?x?xf32> {
-   // CHECK-NEXT: %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[ARG1]])
+   // CHECK-NEXT: %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[ARG1]]
    // CHECK-SAME: tensor<?xf32, [@[[S2:.*]]]>
    %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<1xindex>) -> tensor<?xf32>
    // CHECK-NEXT: %[[T1:.*]] = mhlo.abs %[[T0]] : tensor<?xf32, [@[[S2]]]>
    %1 = "mhlo.abs"(%0) : (tensor<?xf32>) -> tensor<?xf32>
-   // CHECK-NEXT: %[[T2:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[ARG2]])
+   // CHECK-NEXT: %[[T2:.*]] = mhlo.dynamic_reshape %[[T1]], %[[ARG2]]
    // CHECK-SAME: tensor<?x?x?xf32, [@[[S3]], @[[S4]], @[[S5]]]>
    %2 = "mhlo.dynamic_reshape"(%1, %arg2) : (tensor<?xf32>, tensor<3xindex>) -> tensor<?x?x?xf32>
    // CHECK-NEXT: return %[[T2]] : tensor<?x?x?xf32, [@[[S3]], @[[S4]], @[[S5]]]>

--- a/tao_compiler/mlir/disc/transforms/tests/disc-shape-simplifier-tie-shape.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-shape-simplifier-tie-shape.mlir
@@ -5,7 +5,7 @@
 func.func @main(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xi1> {
   // CHECK: %[[T4:.*]] = "disc_shape.tie_shape"(%[[ARG0:.*]], %[[T0:.*]], %[[T1:.*]], %[[T2:.*]], %[[T3:.*]]) :
   // CHECK: %[[T5:.*]] = "disc_shape.tie_shape"(%[[ARG1:.*]], %[[T0]], %[[T1]], %[[T2]], %[[T3]])
-  // CHECK: %[[RESULT:.*]] = "mhlo.compare"
+  // CHECK: %[[RESULT:.*]] = mhlo.compare
   // CHECK: %[[T6:.*]] = "disc_shape.tie_shape"(%[[RESULT]], %[[T0]], %[[T1]], %[[T2]], %[[T3]])
   %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xi1>
   return %0 : tensor<?x?x?x?xi1>

--- a/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
@@ -34,11 +34,11 @@ func.func @dot_transpose_batching_3d(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG1]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf32>
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T3]] : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
 // CHECK:         return %[[T4]] : tensor<?xf32>
 func.func @dot_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -> tensor<?xf32> {
   %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<?x256xf32>, tensor<256xf32>) -> tensor<?xf32>
@@ -51,11 +51,11 @@ func.func @dot_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -> tensor
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x?xf32>) -> tensor<1x?xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf32>
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T3]] : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
 // CHECK:         return %[[T4]] : tensor<?xf32>
 func.func @dot_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -> tensor<?xf32> {
   %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<256xf32>, tensor<256x?xf32>) -> tensor<?xf32>
@@ -69,11 +69,11 @@ func.func @dot_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -> tensor
 // CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
 // CHECK:         %[[CST_0:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
 // CHECK:         %[[CST_1:.*]] = arith.constant dense<1> : tensor<1xindex>
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
-// CHECK:         %[[T1:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST_0]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = mhlo.dynamic_reshape %[[ARG1]], %[[CST_0]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
 // CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x1xf32>) -> tensor<1x1xf32>
-// CHECK:         %[[T3:.*]] = "mhlo.dynamic_reshape"(%[[T2]], %[[CST_1]]) : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
-// CHECK:         %[[T4:.*]] = "mhlo.reshape"(%[[T3]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T3:.*]] = mhlo.dynamic_reshape %[[T2]], %[[CST_1]] : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
+// CHECK:         %[[T4:.*]] = mhlo.reshape %[[T3]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         return %[[T4]] : tensor<f32>
 func.func @dot_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> tensor<f32> {
   %0 = "mhlo.dot"(%arg0, %arg1) : (tensor<256xf32>, tensor<256xf32>) -> tensor<f32>
@@ -86,13 +86,12 @@ func.func @dot_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> tensor<f
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<256xf32>, %[[ARG1:.*]]: tensor<256x?xf32>) -> tensor<?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
 // CHECK:         %[[C1:.*]] = arith.constant 1 : index
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[T0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x?xf32>) -> tensor<1x?xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C1]] : tensor<1x?xf32>
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T3]] : (tensor<1x?xf32>, tensor<1xindex>) -> tensor<?xf32>
 // CHECK:         return %[[T4]] : tensor<?xf32>
-// RUN: disc-opt -disc-dot-rewriter -split-input-file %s -o - | FileCheck %s
 func.func @dot_general_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -> tensor<?xf32> {
   %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<256xf32>, tensor<256x?xf32>) -> tensor<?xf32>
   return %1 : tensor<?xf32>
@@ -104,11 +103,11 @@ func.func @dot_general_1dx2d(%arg0: tensor<256xf32>, %arg1: tensor<256x?xf32>) -
 // CHECK-SAME:         %[[ARG0:.*]]: tensor<?x256xf32>, %[[ARG1:.*]]: tensor<256xf32>) -> tensor<?xf32> {
 // CHECK:         %[[CST:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
 // CHECK:         %[[C0:.*]] = arith.constant 0 : index
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG1]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
 // CHECK:         %[[T1:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[T0]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256x1xf32>) -> tensor<?x1xf32>
 // CHECK:         %[[T2:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x1xf32>
 // CHECK:         %[[T3:.*]] = tensor.from_elements %[[T2]] : tensor<1xindex>
-// CHECK:         %[[T4:.*]] = "mhlo.dynamic_reshape"(%[[T1]], %[[T3]]) : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
+// CHECK:         %[[T4:.*]] = mhlo.dynamic_reshape %[[T1]], %[[T3]] : (tensor<?x1xf32>, tensor<1xindex>) -> tensor<?xf32>
 // CHECK:         return %[[T4]] : tensor<?xf32>
 func.func @dot_general_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -> tensor<?xf32> {
   %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x256xf32>, tensor<256xf32>) -> tensor<?xf32>
@@ -122,11 +121,11 @@ func.func @dot_general_2dx1d(%arg0: tensor<?x256xf32>, %arg1: tensor<256xf32>) -
 // CHECK:         %[[CST:.*]] = arith.constant dense<[1, 256]> : tensor<2xindex>
 // CHECK:         %[[CST_0:.*]] = arith.constant dense<[256, 1]> : tensor<2xindex>
 // CHECK:         %[[CST_1:.*]] = arith.constant dense<1> : tensor<1xindex>
-// CHECK:         %[[T0:.*]] = "mhlo.dynamic_reshape"(%[[ARG0]], %[[CST]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
-// CHECK:         %[[T1:.*]] = "mhlo.dynamic_reshape"(%[[ARG1]], %[[CST_0]]) : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
+// CHECK:         %[[T0:.*]] = mhlo.dynamic_reshape %[[ARG0]], %[[CST]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<1x256xf32>
+// CHECK:         %[[T1:.*]] = mhlo.dynamic_reshape %[[ARG1]], %[[CST_0]] : (tensor<256xf32>, tensor<2xindex>) -> tensor<256x1xf32>
 // CHECK:         %[[T2:.*]] = "mhlo.dot_general"(%[[T0]], %[[T1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<1x256xf32>, tensor<256x1xf32>) -> tensor<1x1xf32>
-// CHECK:         %[[T3:.*]] = "mhlo.dynamic_reshape"(%[[T2]], %[[CST_1]]) : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
-// CHECK:         %[[T4:.*]] = "mhlo.reshape"(%[[T3]]) : (tensor<1xf32>) -> tensor<f32>
+// CHECK:         %[[T3:.*]] = mhlo.dynamic_reshape %[[T2]], %[[CST_1]] : (tensor<1x1xf32>, tensor<1xindex>) -> tensor<1xf32>
+// CHECK:         %[[T4:.*]] = mhlo.reshape %[[T3]] : (tensor<1xf32>) -> tensor<f32>
 // CHECK:         return %[[T4]] : tensor<f32>
 func.func @dot_general_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> tensor<f32> {
   %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<256xf32>, tensor<256xf32>) -> tensor<f32>

--- a/tao_compiler/mlir/disc/transforms/tests/gpu-only-lhlo-fusion.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/gpu-only-lhlo-fusion.mlir
@@ -417,7 +417,7 @@ module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, pr
     memref.store %c0, %2[%c0] : memref<2xindex, "cpu">
     memref.store %c32, %2[%c1] : memref<2xindex, "cpu">
     %3 = memref.alloc() : memref<32x64xf32, "gpu">
-    "lmhlo.constant"(%3) {value = opaque<"elided_large_const", "0xDEADBEEF"> : tensor<32x64xf32>} : (memref<32x64xf32, "gpu">) -> ()
+    "lmhlo.constant"(%3) {value = dense<0.0> : tensor<32x64xf32>} : (memref<32x64xf32, "gpu">) -> ()
     %4 = memref.dim %arg0, %c0 : memref<?x32xf32, "gpu">
     %5 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [%4, 32], strides: [32, 1] {kDiscSymbolicDimAttr = [@S0, @C32]} : memref<?x32xf32, "gpu"> to memref<?x32xf32, "gpu">
     %6 = memref.alloc(%4) {kDiscSymbolicDimAttr = [@S0, @C64]} : memref<?x64xf32, "gpu">


### PR DESCRIPTION
TensorFlow main changes:
1. Add assembly form for `mhlo.dynamic_reshape`, `mhlo.reshape`, `mlhlo.clamp`, `mhlo.real_dynamic_slice`
2. The output type before conversion and after must be the same
3. Some minor ut fix.

LLVM main changes:
1. math::AbsOp -> math::AbsFOp

TorchMLIR changes:
+ Upstream add TorchToMhlo passes; we disable them for now. And will be enable later.