### PR TITLE
[BugFix] fix core dump on DotRewriter pass

### DIFF
--- a/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
+++ b/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
@@ -331,6 +331,7 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
     if (!result_ty) {
       return failure();
     }
+
     Location loc = op.getLoc();
     Value old_lhs = op.lhs();
     Value old_rhs = op.rhs();
@@ -350,6 +351,7 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
         old_lhs, lhs_perm,
         std::unordered_set<int64_t>(lhs_batching_dims.begin(),
                                     lhs_batching_dims.end()));
+
     SmallVector<int64_t, 4> rhs_perm;
     auto rhs_batching_dims = dim_numbers.getRhsBatchingDimensions();
     bool tp_rhs = isNonBatchingTransposeTensorValue(
@@ -360,6 +362,7 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
     if (!tp_lhs && !tp_rhs) {
       return failure();
     }
+
     std::vector<int64_t> lhs_contracting_dims;
     if (tp_lhs) {
       for (auto& en :
@@ -384,6 +387,7 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
         rewriter.getContext(), dim_numbers.getLhsBatchingDimensions(),
         dim_numbers.getRhsBatchingDimensions(), lhs_contracting_dims,
         rhs_contracting_dims);
+
     // Re-direct the lhs/rhs if needed.
     Value lhs = tp_lhs ? old_lhs.getDefiningOp()->getOperand(0) : old_lhs;
     Value rhs = tp_rhs ? old_rhs.getDefiningOp()->getOperand(0) : old_rhs;

--- a/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
+++ b/tao_compiler/mlir/disc/transforms/dot_rewriter.cc
@@ -331,7 +331,6 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
     if (!result_ty) {
       return failure();
     }
-
     Location loc = op.getLoc();
     Value old_lhs = op.lhs();
     Value old_rhs = op.rhs();
@@ -352,7 +351,6 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
         std::unordered_set<int64_t>(lhs_batching_dims.begin(),
                                     lhs_batching_dims.end()));
     SmallVector<int64_t, 4> rhs_perm;
-
     auto rhs_batching_dims = dim_numbers.getRhsBatchingDimensions();
     bool tp_rhs = isNonBatchingTransposeTensorValue(
         old_rhs, rhs_perm,
@@ -362,7 +360,6 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
     if (!tp_lhs && !tp_rhs) {
       return failure();
     }
-
     std::vector<int64_t> lhs_contracting_dims;
     if (tp_lhs) {
       for (auto& en :
@@ -387,7 +384,6 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
         rewriter.getContext(), dim_numbers.getLhsBatchingDimensions(),
         dim_numbers.getRhsBatchingDimensions(), lhs_contracting_dims,
         rhs_contracting_dims);
-
     // Re-direct the lhs/rhs if needed.
     Value lhs = tp_lhs ? old_lhs.getDefiningOp()->getOperand(0) : old_lhs;
     Value rhs = tp_rhs ? old_rhs.getDefiningOp()->getOperand(0) : old_rhs;
@@ -395,15 +391,6 @@ struct TransposeFoldingConvert : public OpRewritePattern<mhlo::DotGeneralOp> {
     Value dot = rewriter.create<mhlo::DotGeneralOp>(
         loc, op.getType(), lhs, rhs, dot_dimension_attr, nullptr);
     rewriter.replaceOp(op, dot);
-
-    // Remove transpose op which outputs into dot.
-    if (tp_lhs) {
-      rewriter.eraseOp(old_lhs.getDefiningOp());
-    }
-    if (tp_rhs) {
-      rewriter.eraseOp(old_rhs.getDefiningOp());
-    }
-
     return success();
   }
 };

--- a/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/dot_rewriter.mlir
@@ -131,3 +131,15 @@ func.func @dot_general_1dx1d(%arg0: tensor<256xf32>, %arg1: tensor<256xf32>) -> 
   %1 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<256xf32>, tensor<256xf32>) -> tensor<f32>
   return %1 : tensor<f32>
 }
+
+// -----
+// CHECK-LABEL: func.func @dot_general_transpose(
+// CHECK-SAME:        %[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[T0:.*]] = "mhlo.dot_general"(%[[ARG0]], %[[ARG1]]) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [0], rhs_contracting_dimensions = [0]>} : (tensor<?x?xf32>, tensor<?xf32>) -> tensor<?x?xf32>
+// CHECK:         return %[[T0]]
+// CHECK:       }
+func.func @dot_general_transpose(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>) -> tensor<?x?xf32> {
+  %1 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = "mhlo.dot_general"(%1, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (tensor<?x?xf32>, tensor<?xf32>) -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}


### PR DESCRIPTION
This PR fixed core dump while two `dot_general` ops have the same producer `transpose` op, the following Canonicalizer pass would remove the transpose op if no consumer.
