### PR TITLE
features/bladedisc rebase 20220818

### DIFF
--- a/pytorch_blade/src/common_utils/logging.h
+++ b/pytorch_blade/src/common_utils/logging.h
@@ -12,4 +12,4 @@
 #pragma once
 
 #include "c10/util/Exception.h"
-#include "tensorflow/core/platform/default/logging.h"
+#include "tensorflow/tsl/platform/default/logging.h"

--- a/tao_compiler/decoupling/tao_compiler_trace.h
+++ b/tao_compiler/decoupling/tao_compiler_trace.h
@@ -17,9 +17,9 @@
 #include <string>
 #include <vector>
 
-#include "tensorflow/core/platform/default/integral_types.h"
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/thread_annotations.h"
+#include "tensorflow/tsl/platform/default/integral_types.h"
 
 namespace tensorflow {
 namespace tao {

--- a/tao_compiler/mlir/xla/ral/context/init_stream_executor.cc
+++ b/tao_compiler/mlir/xla/ral/context/init_stream_executor.cc
@@ -16,9 +16,9 @@
 #include "tensorflow/stream_executor/gpu/gpu_executor.h"
 #include "tensorflow/stream_executor/stream.h"
 #if TENSORFLOW_USE_ROCM
-#include "tensorflow/stream_executor/rocm/rocm_platform.h"
+#include "tensorflow/compiler/xla/stream_executor/rocm/rocm_platform.h"
 #else
-#include "tensorflow/stream_executor/cuda/cuda_platform.h"
+#include "tensorflow/compiler/xla/stream_executor/cuda/cuda_platform.h"
 #endif
 
 namespace tao {


### PR DESCRIPTION

TensorFlow commit summary:

87a6bec205d Cleanup legacy Python2 compatibility on targets under tensorflow/python/debug/.
89cb568fd67     Overview topics for the build sections of tflite model tab.
73faab182e0 Refactor internal keras code to remove deprecated call to tf.concat() with scalars.
61e33180687 [jax][sparse][chlo] Handle primitive sinh and tan 
b45793b50a3 Integrate LLVM at llvm/llvm-project@3f2f23cca9ab
f3859979e39 Integrate graph viewer to HLO to tools conversion.
2a2e18a8a69 Move some files from util.py to save_util_v1 (these utilities are not needed by the new Trackable-based checkpoints)
712c5af8c8c [xla:runtime] Implement a trivial default XLA runtime compilation pipeline for use in XLA:GPU
ba4f850637d Update TFRT dependency to use revision http://github.com/tensorflow/runtime/commit/ed449f35985879f1a1ee0d75a852569b45fab1f5.
2f04d98f7ee [XLA] Make CallGraph::GetComputationCallers const.
b306fb31270 Apply `PyArray_Check` in `FillStringBufferWithPyArray` to avoid a hard crash when user pass in a TF eager tensor as input.
1dc4ff5a547 Revert: Sparse direct solver using QR factorization from cuSOLVER. This is the jaxlib implementation. We will want to combine this with the sparse libraries already existing in JAX.
c9995a7b0c8 [PJRT:C] Fix StatusCodeToPjrtErrorCode definition
87912ff6a94 Merge pull request #56744 from kaixih:revert_nhwc_tf32
43af5910db5 Keep a copy of python callback in HostCallbackContext to ensure it is not deleted during execution
d86181b36ae Remove `tfrt::TfStatusFromAbslStatus()` and use tensorflow version
18f5b4dadb7 Merge requantize part in quantized functions and the following dequantize part
69095800156 Merge pull request #57186 from penpornk:xla-acl
7d16df0d14c Allow specifying optional metadata when creating HLO 
6df241a4237 [XLA] Allow pattern_matcher_gmock to accept non-const HloInstruction*s.
28e6ded7ecf Revert Fix computation of users in fusion_node_indexing_evaluation.
0dfd50d70ba compat: Update forward compatibility horizon to 2022-08-18
f83c47b395c Update GraphDef version to 1227.
01bc5f1fecc [XLA:Docs] Give usage examples for Keras and distributed strategy compilation
bc1ebf3ce95 Clean up collapse-parallel-loops pass
e05c84e88c2 Using HW TensorDescriptor instead of Texture2dDescriptor.
37f4e8c1018 [XLA:GPU Next] NFC: minor polish of fusion rewrite pass.
ceb50b0dd5b [GML] Implement nested tiling in the fusion interface-based tiling pass
892dc6818ac TF changes for sparse QR factorization