### PR TITLE
fix missing nvidia/cuda:11.0-xxx image

### DIFF
--- a/.github/workflows/tf24_gpu.yml
+++ b/.github/workflows/tf24_gpu.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       cuda_version: cu110
       remote_runtime_docker: bladedisc:latest-runtime-tensorflow2.4
-      develop_base_image: nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+      develop_base_image: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
       runtime_base_image: tensorflow/tensorflow:2.4.0-gpu
       extra_build_args: --build-arg DISC_HOST_TF_VERSION="tensorflow-gpu==2.4"
       exec_command: bash ./scripts/ci/build_and_test.sh

--- a/docker/cronjobs/Dockerfile.dummy
+++ b/docker/cronjobs/Dockerfile.dummy
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+ARG BASEIMAGE=nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 FROM ${BASEIMAGE}
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/runtime/Dockerfile.pytorch
+++ b/docker/runtime/Dockerfile.pytorch
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+ARG BASEIMAGE=nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 FROM ${BASEIMAGE}
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/runtime/Dockerfile.tf_blade
+++ b/docker/runtime/Dockerfile.tf_blade
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
+ARG BASEIMAGE=nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
 FROM ${BASEIMAGE}
 
 ADD ./docker/scripts /install/scripts


### PR DESCRIPTION
`nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04` seemed disappear from docker hub, tf 2.4 CI job affected, use `nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04`.