### PR TITLE
[quantization] add a pass to convert fake_quant annotated IR

### DIFF
--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -1753,6 +1753,25 @@ cc_library(
 )
 
 cc_library(
+    name = "disc_convert_fake_quant_op",
+    srcs = ["transforms/disc_convert_fake_quant_op.cc"],
+    deps = [
+        ":disc_shape_optimization_utils",
+        ":mhlo_disc",
+        ":pass_details",
+        "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "all_passes",
     hdrs = [
         "transforms/register_passes.h",
@@ -1770,6 +1789,7 @@ cc_library(
         ":disc_canonicalizer",
         ":disc_dense_to_sparse",
         ":disc_convert_const_to_ral",
+        ":disc_convert_fake_quant_op",
         ":disc_cpu_map_parallel_loop",
         ":disc_duplicate_computation_for_fusion",
         ":disc_flatten_memref_access",

--- a/tao_compiler/mlir/disc/transforms/disc_convert_fake_quant_op.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_convert_fake_quant_op.cc
@@ -1,0 +1,169 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "tensorflow/compiler/mlir/disc/IR/hlo_disc_ops.h"
+#include "tensorflow/compiler/mlir/disc/transforms/PassDetail.h"
+
+#define DEBUG_TYPE "disc-convert-fake-quant-op"
+
+// This file implements the logic to convert fake_quant annotated graph to
+// the real quantized version. An example is shown as following.
+//
+// convert:
+//  const -> fake_quant
+//                      \
+//  input -> fake_quant -> gemm -> fake_quant ->
+// to
+//  const -> quantize
+//                     \
+//  input -> quantize -> quantized_gemm -> dequantize ->
+
+namespace mlir {
+namespace disc_ral {
+namespace {
+
+struct QuantizedDynamicConvOpConverter
+    : public OpRewritePattern<mhlo_disc::FakeQuantOp> {
+  using OpRewritePattern<mhlo_disc::FakeQuantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo_disc::FakeQuantOp op,
+                                PatternRewriter& rewriter) const override {
+    auto convOp = op.input().getDefiningOp<mhlo::DynamicConvOp>();
+    if (!convOp) return failure();
+
+    auto inputFakeQuantOp =
+        convOp.lhs().getDefiningOp<mhlo_disc::FakeQuantOp>();
+    auto weightFakeQuantOp =
+        convOp.rhs().getDefiningOp<mhlo_disc::FakeQuantOp>();
+    if (!inputFakeQuantOp || !weightFakeQuantOp) return failure();
+    if (inputFakeQuantOp.use_signed() != weightFakeQuantOp.use_signed() ||
+        inputFakeQuantOp.num_bits() != weightFakeQuantOp.num_bits()) {
+      return failure();
+    }
+    if (inputFakeQuantOp.use_dynamic() != op.use_dynamic() ||
+        weightFakeQuantOp.use_dynamic() != op.use_dynamic())
+      return failure();
+
+    Location loc = op.getLoc();
+    auto buildQuantizedTensorType = [&](mhlo_disc::FakeQuantOp fakeQuantOp) {
+      Type quantizedElemType =
+          fakeQuantOp.use_signed()
+              ? IntegerType::get(rewriter.getContext(), fakeQuantOp.num_bits())
+              : IntegerType::get(
+                    rewriter.getContext(), fakeQuantOp.num_bits(),
+                    mlir::IntegerType::SignednessSemantics::Unsigned);
+      auto inputTy = fakeQuantOp.input().getType().cast<RankedTensorType>();
+      return RankedTensorType::get(inputTy.getShape(), quantizedElemType,
+                                   inputTy.getEncoding());
+    };
+
+    // Builds a real quantized op by extracting metadata info from the
+    // fake_quant_op
+    auto buildQuantizedOpFromFakeQuantOp =
+        [&](mhlo_disc::FakeQuantOp fakeQuantOp) {
+          auto outTy = buildQuantizedTensorType(fakeQuantOp);
+          Value quantizedInput = rewriter.create<mhlo_disc::QuantizeOp>(
+              loc, outTy, fakeQuantOp.input(), fakeQuantOp.scale(),
+              fakeQuantOp.zero_point(), fakeQuantOp.use_symmetric(),
+              fakeQuantOp.axis(), fakeQuantOp.quant_min(),
+              fakeQuantOp.quant_max(), fakeQuantOp.use_dynamic());
+          return quantizedInput;
+        };
+
+    Value quantizedInput = buildQuantizedOpFromFakeQuantOp(inputFakeQuantOp);
+    Value quantizedWeight = buildQuantizedOpFromFakeQuantOp(weightFakeQuantOp);
+    Value quantizedConv = rewriter.create<mhlo_disc::QuantizedDynamicConvOp>(
+        loc, buildQuantizedTensorType(op), quantizedInput, quantizedWeight,
+        convOp.d_padding(), inputFakeQuantOp.scale(),
+        inputFakeQuantOp.zero_point(), weightFakeQuantOp.scale(),
+        weightFakeQuantOp.zero_point(), op.scale(), op.zero_point(),
+        *convOp.window_strides(), *convOp.padding(), *convOp.lhs_dilation(),
+        *convOp.rhs_dilation(), *convOp.window_reversal(),
+        convOp.dimension_numbers(), convOp.feature_group_count(),
+        convOp.batch_group_count(), op.use_symmetric(),
+        weightFakeQuantOp.axis(), op.use_dynamic());
+
+    Value dequantizedOut = rewriter.create<mhlo_disc::DequantizeOp>(
+        loc, op.getType(), quantizedConv, op.scale(), op.zero_point(),
+        op.use_symmetric(), op.axis(), op.use_dynamic());
+
+    rewriter.replaceOp(op, dequantizedOut);
+    return success();
+  }
+};
+
+void populateQuantizedPatterns(RewritePatternSet& patterns) {
+  // clang-format off
+  patterns.insert<
+    QuantizedDynamicConvOpConverter
+  >(patterns.getContext());
+  // clang-format on
+}
+
+struct FakeQuantOpToIdentityConverter
+    : public OpRewritePattern<mhlo_disc::FakeQuantOp> {
+  using OpRewritePattern<mhlo_disc::FakeQuantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo_disc::FakeQuantOp op,
+                                PatternRewriter& rewriter) const override {
+    rewriter.replaceOp(op, op.input());
+    return success();
+  }
+};
+
+struct DiscConvertFakeQuantOpPass
+    : public DiscConvertFakeQuantOpPassBase<DiscConvertFakeQuantOpPass> {
+  void runOnOperation() override;
+};
+
+void DiscConvertFakeQuantOpPass::runOnOperation() {
+  // Setup rewriter patterns.
+  MLIRContext& ctx = getContext();
+  RewritePatternSet patterns(&ctx);
+  populateQuantizedPatterns(patterns);
+
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    signalPassFailure();
+    return;
+  }
+
+  // Remove fake quant ops after quantization conversion.
+  RewritePatternSet remove_fake_quant_op_patterns(&ctx);
+  remove_fake_quant_op_patterns.insert<FakeQuantOpToIdentityConverter>(&ctx);
+  if (failed(applyPatternsAndFoldGreedily(
+          getOperation(), std::move(remove_fake_quant_op_patterns)))) {
+    signalPassFailure();
+    return;
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscConvertFakeQuantOpPass() {
+  return std::make_unique<DiscConvertFakeQuantOpPass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/transforms/disc_passes.td
+++ b/tao_compiler/mlir/disc/transforms/disc_passes.td
@@ -447,3 +447,11 @@ def DiscSparseGemmTransposeSimplifierPass : Pass<"disc-sparse-gemm-transpose-sim
   let summary = "Remove some redundant transpose ops before sparse gemm/conv";
   let constructor = "createDiscSparseGemmTransposeSimplifierPass()";
 }
+
+def DiscConvertFakeQuantOpPass : Pass<"disc-convert-fake-quant-op", "mlir::func::FuncOp"> {
+  let summary = "Convert fake_quant annotated graph to the real quantized version.";
+  let constructor = "createDiscConvertFakeQuantOpPass()";
+  let dependentDialects = [
+      "disc_shape::DISCShapeDialect",
+  ];
+}

--- a/tao_compiler/mlir/disc/transforms/passes.h
+++ b/tao_compiler/mlir/disc/transforms/passes.h
@@ -241,6 +241,9 @@ std::unique_ptr<OperationPass<FuncOp>> createDiscDenseToSparsePass();
 std::unique_ptr<OperationPass<FuncOp>>
 createDiscSparseGemmTransposeSimplifierPass();
 
+// Converts fake_quant annotated graph to the real quantized version.
+std::unique_ptr<OperationPass<func::FuncOp>> createDiscConvertFakeQuantOpPass();
+
 }  // namespace disc_ral
 }  // namespace mlir
 

--- a/tao_compiler/mlir/disc/transforms/tests/disc-convert-fake-quant-op.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-convert-fake-quant-op.mlir
@@ -1,0 +1,70 @@
+// RUN: disc-opt --disc-convert-fake-quant-op -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @fake_quant_conv
+// CHECK-SAME: (%[[INPUT:.*]]: tensor<?x32x32x6xf32>, %[[WEIGHT:.*]]: tensor<3x3x3x16xf32>
+func.func @fake_quant_conv(
+    %input: tensor<?x32x32x6xf32>, %weight: tensor<3x3x3x16xf32>, %padding: tensor<4xi32>,
+    %input_scale : tensor<f32>, %input_zero_point : tensor<i32>,
+    %weight_scale : tensor<?xf32>, %weight_zero_point : tensor<?xi32>,
+    %result_scale : tensor<f32>, %result_zero_point : tensor<i32>
+) -> tensor<?x8x6x16xf32> {
+  // CHECK: %[[FAKE_QUANT_INPUT:.*]] = "mhlo_disc.quantize"
+  // CHECK-SAME: %[[INPUT]]
+  %fake_quant_input = "mhlo_disc.fake_quant"(%input, %input_scale, %input_zero_point) {
+      use_signed = true,
+      use_symmetric = true,
+      axis = dense<[]> : tensor<0xi64>,
+      num_bits = 8,
+      quant_min = -128,
+      quant_max = 127,
+      use_dynamic = false
+  } : (tensor<?x32x32x6xf32>, tensor<f32>, tensor<i32>) -> tensor<?x32x32x6xf32>
+
+  // CHECK: %[[FAKE_QUANT_WEIGHT:.*]] = "mhlo_disc.quantize"
+  // CHECK-SAME: %[[WEIGHT]]
+  %fake_quant_weight = "mhlo_disc.fake_quant"(%weight, %weight_scale, %weight_zero_point) {
+      use_signed = true,
+      use_symmetric = true,
+      axis = dense<[2]> : tensor<1xi64>,
+      num_bits = 8,
+      quant_min = -128,
+      quant_max = 127,
+      use_dynamic = false
+  } : (tensor<3x3x3x16xf32>, tensor<?xf32>, tensor<?xi32>) -> tensor<3x3x3x16xf32>
+
+  // CHECK: %[[RESULT:.*]] = "mhlo_disc.quantized_dynamic_conv"
+  // CHECK-SAME: %[[FAKE_QUANT_INPUT]]
+  // CHECK-SAME: %[[FAKE_QUANT_WEIGHT]]
+  %result = "mhlo.dynamic_conv"(%fake_quant_input, %fake_quant_weight, %padding) {
+    dimension_numbers = #mhlo.conv<raw
+      input_batch_dimension = 0,
+      input_feature_dimension = 3,
+      input_spatial_dimensions = [1, 2],
+      kernel_input_feature_dimension = 2,
+      kernel_output_feature_dimension = 3,
+      kernel_spatial_dimensions = [0, 1],
+      output_batch_dimension = 0, output_feature_dimension = 3,
+      output_spatial_dimensions = [1, 2]
+    >,
+    batch_group_count = 1 : i64,
+    feature_group_count = 2 : i64,
+    padding = dense<[[1, 2], [3, 1]]> : tensor<2x2xi64>,
+    rhs_dilation = dense<[2, 3]> : tensor<2xi64>,
+    window_strides = dense<[4, 5]> : tensor<2xi64>}
+    : (tensor<?x32x32x6xf32>, tensor<3x3x3x16xf32>, tensor<4xi32>) -> tensor<?x8x6x16xf32>
+
+  // CHECK: %[[FAKE_QUANT_RESULT:.*]] = "mhlo_disc.dequantize"
+  // CHECK-SAME: %[[RESULT]]
+  %fake_quant_result = "mhlo_disc.fake_quant"(%result, %result_scale, %result_zero_point) {
+      use_signed = true,
+      use_symmetric = true,
+      axis = dense<[]> : tensor<0xi64>,
+      num_bits = 8,
+      quant_min = -128,
+      quant_max = 127,
+      use_dynamic = false
+  } : (tensor<?x8x6x16xf32>, tensor<f32>, tensor<i32>) -> tensor<?x8x6x16xf32>
+
+  // CHECK: return %[[FAKE_QUANT_RESULT]] : tensor<?x8x6x16xf32>
+  return %fake_quant_result : tensor<?x8x6x16xf32>
+}


### PR DESCRIPTION
An example is shown as following.

convert:
```
 const -> fake_quant
                     \
 input -> fake_quant -> gemm -> fake_quant ->
```
to
```
 const -> quantize
                    \
 input -> quantize -> quantized_gemm -> dequantize ->
```