### PR TITLE
improve the performance of const lookup in RAL

### DIFF
--- a/pytorch_blade/src/compiler/mlir/runtime/ral_context.h
+++ b/pytorch_blade/src/compiler/mlir/runtime/ral_context.h
@@ -34,6 +34,7 @@ using CUDAStream = ::c10::hip::HIPStream;
 #endif // TORCH_BLADE_BUILD_WITH_CUDA
 // TODO(disc): figure out why the bazel does not trigger re-compile this file
 // after we update ral.
+//
 #include "tensorflow/compiler/mlir/xla/ral/context/base/cpu/cpu_context_impl.h"
 
 #include "common_utils/macros.h"

--- a/tao_compiler/mlir/disc/tests/mlir_test.cc
+++ b/tao_compiler/mlir/disc/tests/mlir_test.cc
@@ -31,7 +31,6 @@
 #else
 // TODO(disc): figure out why the bazel does not trigger re-compile this file
 // after we update ral.
-//
 #include "tensorflow/compiler/mlir/xla/ral/context/base/cpu/cpu_context_impl.h"
 #endif
 

--- a/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
@@ -122,7 +122,7 @@ class DiscConstToRALPass : public DiscConstToRALPassBase<DiscConstToRALPass> {
   int num_processing_const_ops_ = 0;
   // Map each unique name of const to a unique index. Such indices are used to
   // reduce the overhead of const lookup at runtime.
-  std::unordered_map<std::string, int> name2Idx_;
+  std::unordered_map<std::string, int> name_idx_map_;
 };
 
 // llvm.mlir.global internal constant @unique_name("unique_name\00")
@@ -169,8 +169,9 @@ LogicalResult DiscConstToRALPass::convertConstantOp(ConstantOp const_op,
     next_const_idx = proto->device_global_constants_size();
     (*proto->mutable_device_global_constants())[name_str] = data_str;
   }
-  auto it = name2Idx_.find(name_str);
-  if (it == name2Idx_.end()) it = name2Idx_.emplace(name, next_const_idx).first;
+  auto it = name_idx_map_.find(name_str);
+  if (it == name_idx_map_.end())
+    it = name_idx_map_.emplace(name, next_const_idx).first;
 
   std::string symbol_name =
       ("__global_const_" + llvm::Twine(num_processing_const_ops_++)).str();

--- a/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_convert_const_to_ral.cc
@@ -120,6 +120,9 @@ class DiscConstToRALPass : public DiscConstToRALPassBase<DiscConstToRALPass> {
   LogicalResult convertConstantOp(ConstantOp const_op, MetadataProto* proto);
 
   int num_processing_const_ops_ = 0;
+  // Map each unique name of const to a unique index. Such indices are used to
+  // reduce the overhead of const lookup at runtime.
+  std::unordered_map<std::string, int> name2Idx_;
 };
 
 // llvm.mlir.global internal constant @unique_name("unique_name\00")
@@ -158,11 +161,16 @@ LogicalResult DiscConstToRALPass::convertConstantOp(ConstantOp const_op,
   std::string data_str = std::string(data);
 
   // save data
+  int next_const_idx;
   if (on_host) {
+    next_const_idx = proto->host_global_constants_size();
     (*proto->mutable_host_global_constants())[name_str] = data_str;
   } else {
+    next_const_idx = proto->device_global_constants_size();
     (*proto->mutable_device_global_constants())[name_str] = data_str;
   }
+  auto it = name2Idx_.find(name_str);
+  if (it == name2Idx_.end()) it = name2Idx_.emplace(name, next_const_idx).first;
 
   std::string symbol_name =
       ("__global_const_" + llvm::Twine(num_processing_const_ops_++)).str();
@@ -176,8 +184,11 @@ LogicalResult DiscConstToRALPass::convertConstantOp(ConstantOp const_op,
                                                 builder.getI32IntegerAttr(0));
   Value stream_idx = builder.create<LLVM::IntToPtrOp>(loc, pointer_type, zero);
   Value ral_context = const_op->getParentOfType<func::FuncOp>().getArgument(0);
+  Value const_idx_value = builder.create<arith::ConstantIntOp>(
+      loc, it->second, builder.getI32Type());
 
-  SmallVector<Value, 12> newOperands{stream_idx, const_name_global};
+  SmallVector<Value, 12> newOperands{stream_idx, const_name_global,
+                                     const_idx_value};
   auto dispatch_op = builder.create<disc_ral::DispatchOp>(
       loc, memref, ral_context, newOperands, "ral_const", false,
       on_host ? "cpu" : "gpu");

--- a/tao_compiler/mlir/disc/transforms/tests/disc-const-to-ral.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-const-to-ral.mlir
@@ -8,8 +8,10 @@ func.func @simple_test(%arg0: !disc_ral.context) {
   %c1 = arith.constant 1 : index
   %0 = memref.alloc() : memref<100x100xf32, "gpu">
   %1 = memref.alloc() : memref<100x100xf32, "cpu">
-  // CHECK: %[[N0:.*]] = "disc_ral.dispatch"(%[[CTX:.*]], [[T0:.*]], [[T1:.*]]) {backend_config = "gpu", call_target_name = "ral_const", has_side_effect = false}
-  // CHECK: %[[N1:.*]] = "disc_ral.dispatch"(%[[CTX]], [[T0:.*]], [[T1:.*]]) {backend_config = "cpu", call_target_name = "ral_const", has_side_effect = false}
+  // CHECK: %[[C0_CPU:.*]] = arith.constant 0 : i32
+  // CHECK: %[[N0:.*]] = "disc_ral.dispatch"(%[[CTX:.*]], %[[T0:.*]], %[[T1:.*]], %[[C0_CPU]]) {backend_config = "gpu", call_target_name = "ral_const", has_side_effect = false}
+  // CHECK: %[[C0_GPU:.*]] = arith.constant 0 : i32
+  // CHECK: %[[N1:.*]] = "disc_ral.dispatch"(%[[CTX]], %[[T0:.*]], %[[T1:.*]], %[[C0_GPU]]) {backend_config = "cpu", call_target_name = "ral_const", has_side_effect = false}
   // CHECK: "disc_ral.send_output"(%[[CTX]], %c0, %[[N0]])
   // CHECK: "disc_ral.send_output"(%[[CTX]], %c1, %[[N1]])
   "lmhlo.constant"(%0) {disc.device = "gpu", value = dense<1.000000e+00> : tensor<100x100xf32>} : (memref<100x100xf32, "gpu">) -> ()

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_cuda.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_cuda.cc
@@ -58,7 +58,7 @@ void RalGlobalConstantState::onContextFinish(Context* ctx) /* override */ {
 
 static inline buffer_t ral_base_cuda_const_cuda_internal(
     ExecutionContext* ctx, void* stream_handle, const char* unique_name,
-    buffer_shape_t*& shape) {
+    int32_t unique_index_in_module, buffer_shape_t*& shape) {
   auto* state =
       ctx->getResource<RalGlobalConstantState>(kRalGlobalConstantState);
   // if process-level const store is enabled, use it instead of the context
@@ -69,20 +69,16 @@ static inline buffer_t ral_base_cuda_const_cuda_internal(
     use_process_store = true;
   }
 
+  // fast path: using a unique const index to do look up.
+  // Note that the const index is assigned to each const at compile time.
+  // The index is unique within the compiled module level.
+  if (auto item = state->getDeviceConstByIndex(unique_index_in_module)) {
+    shape = &item->second;
+    return item->first;
+  }
+
   {
     std::lock_guard<std::mutex> lock(state->mu);
-
-    // Fast path: just using the raw pointer as key. Note that: any
-    // compiled-const should have a static global const string name, thus it's
-    // safe to just use the pointer as key.
-    {
-      auto it = state->device_constants_by_cstr.find(unique_name);
-      if (it != state->device_constants_by_cstr.end()) {
-        shape = &it->second.second;
-        return it->second.first;
-      }
-    }
-
     std::string key(unique_name);
     TAO_VLOG(2) << "unique_name: " << key;
     auto it = state->device_constants.find(key);
@@ -126,8 +122,8 @@ static inline buffer_t ral_base_cuda_const_cuda_internal(
                .insert(
                    std::make_pair(key, std::make_pair(device_ptr, dim_sizes)))
                .first;
-      state->device_constants_by_cstr.emplace(
-          unique_name, std::make_pair(device_ptr, dim_sizes));
+      state->setDeviceConstByIndex(unique_index_in_module,
+                                   std::make_pair(data_ptr, dim_sizes));
     }
     shape = &it->second.second;
     return it->second.first;
@@ -137,10 +133,11 @@ static inline buffer_t ral_base_cuda_const_cuda_internal(
 template <typename T, int N>
 MemRefType<T, N> ral_base_cuda_const_cuda(ExecutionContext* ctx,
                                           void* stream_handle,
-                                          const char* unique_name) {
+                                          const char* unique_name,
+                                          int32_t unique_index_in_module) {
   buffer_shape_t* shape = nullptr;
-  buffer_t ptr =
-      ral_base_cuda_const_cuda_internal(ctx, stream_handle, unique_name, shape);
+  buffer_t ptr = ral_base_cuda_const_cuda_internal(
+      ctx, stream_handle, unique_name, unique_index_in_module, shape);
   if (!shape || shape->size() != N) {
     ctx->signalError(Context::FAILURE,
                      "unexpected shape string in unique_name");
@@ -152,10 +149,11 @@ MemRefType<T, N> ral_base_cuda_const_cuda(ExecutionContext* ctx,
 template <typename T>
 MemRefType<T, 0> ral_base_cuda_const_cuda_0d(ExecutionContext* ctx,
                                              void* stream_handle,
-                                             const char* unique_name) {
+                                             const char* unique_name,
+                                             int32_t unique_index_in_module) {
   buffer_shape_t* shape = nullptr;
-  buffer_t ptr =
-      ral_base_cuda_const_cuda_internal(ctx, stream_handle, unique_name, shape);
+  buffer_t ptr = ral_base_cuda_const_cuda_internal(
+      ctx, stream_handle, unique_name, unique_index_in_module, shape);
   if (!shape || shape->size() != 0) {
     ctx->signalError(Context::FAILURE,
                      "unexpected shape string in unique_name");
@@ -163,14 +161,16 @@ MemRefType<T, 0> ral_base_cuda_const_cuda_0d(ExecutionContext* ctx,
   return assignMemRef_0d<T>(ptr);
 }
 
-#define RAL_REGISTER_CONST_CUDA_FUNC(T, N)                                   \
-  template MemRefType<T, N> ral_base_cuda_const_cuda<T, N>(                  \
-      ExecutionContext * ctx, void* stream_handle, const char* unique_name); \
+#define RAL_REGISTER_CONST_CUDA_FUNC(T, N)                                  \
+  template MemRefType<T, N> ral_base_cuda_const_cuda<T, N>(                 \
+      ExecutionContext * ctx, void* stream_handle, const char* unique_name, \
+      int32_t unique_index_in_module);                                      \
   TAO_RAL_API(tao::ral::kRalCudaConst, "gpu", ral_base_cuda_const_cuda<T, N>);
 
-#define RAL_REGISTER_CONST_CUDA_FUNC_0D(T)                                   \
-  template MemRefType<T, 0> ral_base_cuda_const_cuda_0d<T>(                  \
-      ExecutionContext * ctx, void* stream_handle, const char* unique_name); \
+#define RAL_REGISTER_CONST_CUDA_FUNC_0D(T)                                  \
+  template MemRefType<T, 0> ral_base_cuda_const_cuda_0d<T>(                 \
+      ExecutionContext * ctx, void* stream_handle, const char* unique_name, \
+      int32_t unique_index_in_module);                                      \
   TAO_RAL_API(tao::ral::kRalCudaConst, "gpu", ral_base_cuda_const_cuda_0d<T>);
 
 RAL_REGISTER_CONST_CUDA_FUNC_0D(double);

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_cuda.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_cuda.cc
@@ -123,7 +123,7 @@ static inline buffer_t ral_base_cuda_const_cuda_internal(
                    std::make_pair(key, std::make_pair(device_ptr, dim_sizes)))
                .first;
       state->setDeviceConstByIndex(unique_index_in_module,
-                                   std::make_pair(data_ptr, dim_sizes));
+                                   std::make_pair(device_ptr, dim_sizes));
     }
     shape = &it->second.second;
     return it->second.first;


### PR DESCRIPTION
1, assign a unique index for each unique const value.

2, using the index to do fast lool up whenever possible at runtime.