### PR TITLE
[CI] Ci time fix

### DIFF
--- a/.github/workflows/cronjobs.yml
+++ b/.github/workflows/cronjobs.yml
@@ -5,7 +5,7 @@ name: Cronjobs
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '30 15 * * *' # 11:30 pm UTC+8
+    - cron: '30 15 * * *' # 11:30 pm UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cronjobs.yml
+++ b/.github/workflows/cronjobs.yml
@@ -5,7 +5,7 @@ name: Cronjobs
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '30 23 * * *' # 11:30 pm
+    - cron: '30 15 * * *' # 11:30 pm UTC+8
   workflow_dispatch:
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       run: bash scripts/ci/auto_rebase.sh
 
   NGC-TorchTRT-D2:
-    if: github.event.schedule != '30 23 * * *'
+    if: github.event.schedule != '30 15 * * *'
     uses: ./.github/workflows/reusable.yml
     with:
       name: torch-trt-and-d2-benchmark

--- a/.github/workflows/pytorch110_aarch64.yml
+++ b/.github/workflows/pytorch110_aarch64.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch110_aarch64.yml
+++ b/.github/workflows/pytorch110_aarch64.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch112_cpu.yml
+++ b/.github/workflows/pytorch112_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch112_cpu.yml
+++ b/.github/workflows/pytorch112_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch112_gpu.yml
+++ b/.github/workflows/pytorch112_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch112_gpu.yml
+++ b/.github/workflows/pytorch112_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch160_cpu.yml
+++ b/.github/workflows/pytorch160_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch160_cpu.yml
+++ b/.github/workflows/pytorch160_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch171_gpu.yml
+++ b/.github/workflows/pytorch171_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch171_gpu.yml
+++ b/.github/workflows/pytorch171_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch181_cpu.yml
+++ b/.github/workflows/pytorch181_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch181_cpu.yml
+++ b/.github/workflows/pytorch181_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch181_gpu.yml
+++ b/.github/workflows/pytorch181_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch181_gpu.yml
+++ b/.github/workflows/pytorch181_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch190_gpu.yml
+++ b/.github/workflows/pytorch190_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytorch190_gpu.yml
+++ b/.github/workflows/pytorch190_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf115_cpu.yml
+++ b/.github/workflows/tf115_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf115_cpu.yml
+++ b/.github/workflows/tf115_cpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf24_gpu.yml
+++ b/.github/workflows/tf24_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf24_gpu.yml
+++ b/.github/workflows/tf24_gpu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf280_aarch64.yml
+++ b/.github/workflows/tf280_aarch64.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 1 * * *' # 1:00 am
+    - cron: '0 17 * * *' # 1:00 am UTC+8
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tf280_aarch64.yml
+++ b/.github/workflows/tf280_aarch64.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 17 * * *' # 1:00 am UTC+8
+    - cron: '0 17 * * *' # 1:00 am UTC+8:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -5,8 +5,8 @@ name: TorchBench
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '30 15 * * *' # 11:30 pm UTC+8
-    - cron: '30 15 * * 5' # 11:30 pm UTC+8 every Friday
+    - cron: '30 15 * * *' # 11:30 pm UTC+8:00
+    - cron: '30 15 * * 5' # 11:30 pm UTC+8:00 every Friday
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -5,13 +5,13 @@ name: TorchBench
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '30 23 * * *' # 11:30 pm
-    - cron: '30 23 * * 5' # 11:30 pm every Friday
+    - cron: '30 15 * * *' # 11:30 pm UTC+8
+    - cron: '30 15 * * 5' # 11:30 pm UTC+8 every Friday
   workflow_dispatch:
 
 jobs:
   TorchBenchPartial:
-    if: github.event.schedule != '30 23 * * 5' # daily or dispatch
+    if: github.event.schedule != '30 15 * * 5' # daily or dispatch
     uses: ./.github/workflows/reusable.yml
     with:
       name: torch-offcial-benchmark
@@ -29,7 +29,7 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   TorchBenchFull:
-    if: github.event.schedule == '30 23 * * 5'
+    if: github.event.schedule == '30 15 * * 5'
     uses: ./.github/workflows/reusable.yml
     with:
       name: torch-offcial-benchmark


### PR DESCRIPTION
As discussed in https://github.com/orgs/community/discussions/13454 , github schedule actions only support UTC now.
So change time to schedule jobs at midnight.