### PR TITLE
thread local api_func cache to reduce the chance of lock conflict

### DIFF
--- a/tao_compiler/mlir/xla/ral/ral_context.h
+++ b/tao_compiler/mlir/xla/ral/ral_context.h
@@ -41,6 +41,11 @@ extern const char* kRalBitcast;
 // Abstraction of a core device driver api set
 class Driver;
 
+struct ThreadLocalIndex {
+  // Returns a unique index for each thread.
+  static int Get();
+};
+
 // Context wrapper for a single execution
 class ExecutionContext;
 


### PR DESCRIPTION
assign a unique ID to each thread, add use a thread local api_func map
to reduce the chance of lock conflict.