### PR TITLE
[bugfix] using reverse transpose permutation in reverseIfOperandsAreConsistentTransposeOps

### DIFF
--- a/tao_compiler/mlir/disc/transforms/disc_transpose_simplifier.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_transpose_simplifier.cc
@@ -687,15 +687,15 @@ LogicalResult reverseIfOperandsAreConsistentTransposeOps(Operation* op,
 
   OpBuilder b(op);
   SmallVector<Value> newOperands;
-  newOperands.push_back(insertTranspose(op, lhs, permLHS, b)->getResult(0));
-  newOperands.push_back(insertTranspose(op, rhs, permLHS, b)->getResult(0));
+  SmallVector<int64_t> reversePerm = getReversePermutation(permLHS);
+  newOperands.push_back(insertTranspose(op, lhs, reversePerm, b)->getResult(0));
+  newOperands.push_back(insertTranspose(op, rhs, reversePerm, b)->getResult(0));
   Operation* clonedOp = b.clone(*op);
   clonedOp->setOperands(newOperands);
-  Type newType = getTransposeOutputType(op->getResult(0), permLHS, b);
+  Type newType = getTransposeOutputType(op->getResult(0), reversePerm, b);
   clonedOp->getResult(0).setType(newType);
-  SmallVector<int64_t> reversePerm = getReversePermutation(permLHS);
   Value newResult =
-      insertTranspose(op, clonedOp->getResult(0), reversePerm, b)->getResult(0);
+      insertTranspose(op, clonedOp->getResult(0), permLHS, b)->getResult(0);
   op->getResult(0).replaceAllUsesWith(newResult);
 
   changed = true;

--- a/tao_compiler/mlir/disc/transforms/tests/disc-transpose-simplifier.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-transpose-simplifier.mlir
@@ -217,6 +217,29 @@ func.func @reverse_transpose_test_2(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x
   return %2 : tensor<?x?x?xf32>
 }
 
+// Check:
+//  convert:
+//   x -> transpose ---
+//                      \
+//                       v
+//   y -> transpose --> add --> ...
+//  to:
+//   x ---
+//        \
+//         v
+//   y --> add -> transpose -> ...
+
+// CHECK-LABEL: reverse_transpose_test_3
+func.func @reverse_transpose_test_3(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  // CHECK-NOT: mhlo.transpose
+  // CHECK: mhlo.add
+  // CHECK: mhlo.transpose
+  %0 = "mhlo.transpose"(%arg0) {permutation = dense<[1, 2, 0]> : tensor<3xi64>} : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  %1 = "mhlo.transpose"(%arg1) {permutation = dense<[1, 2, 0]> : tensor<3xi64>} : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  %2 = "mhlo.add"(%0, %1) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  return %2 : tensor<?x?x?xf32>
+}
+
 // -----
 
 // Check:


### PR DESCRIPTION
The PR fixed infinite conversions loops on optimizations of ResNets