### PR TITLE
add transpose library call

### DIFF
--- a/tao/tao_bridge/test/gpu/mlir/test_mlir_transpose.py
+++ b/tao/tao_bridge/test/gpu/mlir/test_mlir_transpose.py
@@ -55,7 +55,6 @@ class TestTranspose(MlirTestCase):
             self._check_launch_op(fn, "TaoMlirLaunch")
         else:
             self._check_launch_op(fn, "DiscLaunch")
-        self.assertTrue(False)
 
 
 if __name__ == "__main__":

--- a/tao/tao_bridge/test/gpu/mlir/test_mlir_transpose.py
+++ b/tao/tao_bridge/test/gpu/mlir/test_mlir_transpose.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Copyright 2021 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+import numpy as np
+from test.gpu.mlir.base import MlirTestCase
+try:
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
+except:
+    import tensorflow as tf
+from google.protobuf import text_format
+
+tf.debugging.set_log_device_placement(True)
+
+class TestTranspose(MlirTestCase):
+    def setUp(self):
+        os.environ["DISC_GPU_ENABLE_TRANSPOSE_LIBRARY_CALL"] = "true"
+        MlirTestCase.setUpWithMLIR(self._testMethodName)
+
+    def _check_launch_op(self, fn, launch_op_name):
+        with open(fn) as f:
+            graph_def = tf.GraphDef()
+            text_format.Merge(f.read(), graph_def)
+
+            disc_op = self.get_node(graph_def, launch_op_name)
+            mlir_func_name = disc_op.attr["mlir_function"].func.name
+            self.assertNotEqual(mlir_func_name, "")
+
+            mlir_func = self.get_func(graph_def, mlir_func_name)
+            self.get_node(mlir_func, "Transpose")
+
+    def test_transpose(self):
+        input = np.random.rand(6, 7).astype(np.float32)
+        g = tf.Graph()
+        with g.as_default():
+            t1 = tf.placeholder(shape=(6, 7), dtype=np.float32, name="px")
+            t2 = tf.transpose(t1)
+            with super(TestTranspose, self).new_sess() as sess:
+                sess.run(t2, {t1: input})
+            self.assertTrue(t2.shape, (7, 6))
+
+        fn = super(TestTranspose, self).dumped_file('after_tao_pass.pbtxt')
+        if self.is_platform_alibaba():
+            self._check_launch_op(fn, "TaoMlirLaunch")
+        else:
+            self._check_launch_op(fn, "DiscLaunch")
+        self.assertTrue(False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -452,27 +452,6 @@ cc_library(
     ],
     alwayslink = 1,
 )
-cc_library(
-    name = "quantized_dot_rewriter",
-    srcs = ["transforms/quantized_dot_rewriter.cc"],
-    hdrs = ["transforms/passes.h"],
-    includes = [
-        "tensorflow/compiler/xla/mlir_hlo/include",
-        "."
-    ],
-    deps = [
-        "@com_google_absl//absl/strings",
-        ":pass_details",
-        ":placement_utils",
-        "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
-        "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:Transforms",
-        "//tensorflow/core:lib",
-    ],
-    alwayslink = 1,
-)
 
 cc_library(
     name = "quantized_dot_rewriter",

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -487,7 +487,6 @@ cc_library(
     deps = [
         ":disc_util",
         ":pass_details",
-        ":rng_rewriter",
         "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -432,6 +432,47 @@ cc_library(
     ],
     alwayslink = 1,
 )
+cc_library(
+    name = "rng_rewriter",
+    srcs = ["transforms/rng_rewriter.cc"],
+    hdrs = ["transforms/passes.h"],
+    includes = [
+        "tensorflow/compiler/xla/mlir_hlo/include",
+        "."
+    ],
+    deps = [
+        ":disc_util",
+        ":pass_details",
+        "//tensorflow/compiler/mlir/disc:rng_uniform_custom_call",
+        "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+cc_library(
+    name = "quantized_dot_rewriter",
+    srcs = ["transforms/quantized_dot_rewriter.cc"],
+    hdrs = ["transforms/passes.h"],
+    includes = [
+        "tensorflow/compiler/xla/mlir_hlo/include",
+        "."
+    ],
+    deps = [
+        "@com_google_absl//absl/strings",
+        ":pass_details",
+        ":placement_utils",
+        "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+        "//tensorflow/core:lib",
+    ],
+    alwayslink = 1,
+)
 
 cc_library(
     name = "quantized_dot_rewriter",
@@ -486,6 +527,7 @@ cc_library(
     deps = [
         ":disc_util",
         ":pass_details",
+        ":rng_rewriter",
         "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -432,26 +432,7 @@ cc_library(
     ],
     alwayslink = 1,
 )
-cc_library(
-    name = "rng_rewriter",
-    srcs = ["transforms/rng_rewriter.cc"],
-    hdrs = ["transforms/passes.h"],
-    includes = [
-        "tensorflow/compiler/xla/mlir_hlo/include",
-        "."
-    ],
-    deps = [
-        ":disc_util",
-        ":pass_details",
-        "//tensorflow/compiler/mlir/disc:rng_uniform_custom_call",
-        "//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
-        "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:Transforms",
-    ],
-    alwayslink = 1,
-)
+
 
 cc_library(
     name = "quantized_dot_rewriter",

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/data/transpose_2d_s_f32.mlir
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/data/transpose_2d_s_f32.mlir
@@ -1,0 +1,10 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<6x7xf32>) -> tensor<7x6xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %1:2 = tf_executor.island wraps "tf.Const"() {value = dense<[1, 0]> : tensor<2xi32>} : () -> tensor<2xi32>
+      %2:2 = tf_executor.island wraps "tf.Transpose"(%arg0, %1) : (tensor<6x7xf32>, tensor<2xi32>) -> tensor<7x6xf32>
+      tf_executor.fetch %2 : tensor<7x6xf32>
+    }
+    return %graph : tensor<7x6xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/data/transpose_3d_s_f32.mlir
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/data/transpose_3d_s_f32.mlir
@@ -1,0 +1,10 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<6x7x8xf32>) -> tensor<6x8x7xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %1:2 = tf_executor.island wraps "tf.Const"() {value = dense<[0, 2, 1]> : tensor<3xi32>} : () -> tensor<3xi32>
+      %2:2 = tf_executor.island wraps "tf.Transpose"(%arg0, %1) : (tensor<6x7x8xf32>, tensor<3xi32>) -> tensor<6x8x7xf32>
+      tf_executor.fetch %2 : tensor<6x8x7xf32>
+    }
+    return %graph : tensor<6x8x7xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/transpose.cc
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/transpose.cc
@@ -22,8 +22,31 @@ namespace mlir_test {
 const std::string c_ft_path =
     "tensorflow/compiler/mlir/disc/tests/tensorflow_ops/data/";
 
-// static shape test case
+// test with library call
 TEST(TFTransposeOpTest, StaticShape2DF32) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "transpose_2d_s_f32.mlir",
+      /*backend_types*/
+      {BackendType::kCuda},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"6x7xf32_d"},
+      /*output_descriptors*/ {"f32_d"}));
+}
+
+TEST(TFTransposeOpTest, StaticShape3DF32) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "transpose_3d_s_f32.mlir",
+      /*backend_types*/
+      {BackendType::kCuda},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"6x7x8xf32_d"},
+      /*output_descriptors*/ {"f32_d"}));
+}
+
+// static shape test case
+TEST(TFTransposeOpTest, StaticShape4DF32) {
   EXPECT_TRUE(feature_test_main(
       /*mlir_file_path*/ c_ft_path + "transpose_s_f32.mlir",
       /*backend_types*/
@@ -35,7 +58,7 @@ TEST(TFTransposeOpTest, StaticShape2DF32) {
 }
 
 // fully dynamic shape test case
-TEST(TFTransposeOpTest, FullyDynamicShape2DF32) {
+TEST(TFTransposeOpTest, FullyDynamicShape4DF32) {
   EXPECT_TRUE(feature_test_main(
       /*mlir_file_path*/ c_ft_path + "transpose_d_f32.mlir",
       /*backend_types*/
@@ -47,7 +70,7 @@ TEST(TFTransposeOpTest, FullyDynamicShape2DF32) {
 }
 
 // partial dynamic shape test case
-TEST(TFTransposeOpTest, PartialShape2DF32) {
+TEST(TFTransposeOpTest, PartialShape4DF32) {
   EXPECT_TRUE(feature_test_main(
       /*mlir_file_path*/ c_ft_path + "transpose_p_f32.mlir",
       /*backend_types*/

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -149,6 +149,9 @@ bool isRank2ColReduction(Operation* op);
 // engine.
 bool isFusible(Operation* op);
 
+// Return true if enable transpose library call
+bool enableTransposeLibraryCall();
+
 // Returns the number of operands that are supposed to be written.
 // For some ops (e.g. lmhlo ops), some operands are the output memrefs
 // Thus these operands are supposed to be updated.

--- a/tao_compiler/mlir/xla/ral/BUILD
+++ b/tao_compiler/mlir/xla/ral/BUILD
@@ -430,6 +430,62 @@ cc_library(
     alwayslink = 1,
 )
 
+tf_gpu_kernel_library(
+    name = "transpose_gpu_lib",
+    srcs = [
+        "context/custom_library/transpose_gpu.cu.cc",
+        "context/custom_library/tf_transpose.cu.h",
+    ],
+    hdrs = [
+        "context/custom_library/transpose.h",
+        "context/custom_library/dimensions.h",
+        "context/custom_library/gpu_helper.h"
+    ],
+    includes = [
+        "",
+    ],
+    copts = if_cuda_is_configured([
+        "-DGOOGLE_CUDA=1"
+    ]),
+    deps = if_cuda_is_configured([
+        "@cub_archive//:cub",
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+    #alwayslink = 1,
+)
+
+cc_library(
+    name = "transpose",
+    srcs = [
+        "context/transpose_impl.cc",
+    ],
+    deps = [
+        ":ral_context",
+        ":ral_gpu_driver",
+        ":ral_cpu_driver",
+        ":ral_logging",
+        ":context_util",
+        ":transpose_gpu_lib",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:stream_executor_headers_lib",
+        "@com_google_absl//absl/strings",
+    ] + if_cuda_is_configured([
+        "//tensorflow/stream_executor:cuda_platform",
+        "@local_config_cuda//cuda:cuda_driver",
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "//tensorflow/stream_executor:rocm_platform",
+        "//tensorflow/stream_executor/rocm:rocm_driver",
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+    copts = if_cuda_is_configured([
+        "-DGOOGLE_CUDA=1"
+    ]),
+    alwayslink = 1,
+)
+
 cc_library(
     name = "init_stream_executor",
     srcs = [
@@ -508,6 +564,7 @@ disc_cc_library(
         ":ral_library",
         ":ral_logging",
         ":random",
+        ":transpose",
         "//tensorflow/core:lib",
         "@com_google_absl//absl/strings",
         "@curl",
@@ -558,6 +615,7 @@ tf_gpu_kernel_library(
     ],
     hdrs = [
         "context/custom_library/dynamic_sort.h",
+        "context/custom_library/gpu_helper.h"
     ],
     copts = if_rocm_is_configured([
         "-DTENSORFLOW_USE_ROCM=1",
@@ -676,6 +734,7 @@ cuda_library(
     ],
     hdrs = [
         "context/custom_library/dynamic_sort.h",
+        "context/custom_library/gpu_helper.h"
     ],
     copts = [
         "-DDISC_BUILD_FROM_TF_BRIDGE"
@@ -766,6 +825,59 @@ cc_library(
     alwayslink = 1,
 )
 
+cuda_library(
+    name = "transpose_gpu_lib_bridge",
+    srcs = [
+        "context/custom_library/transpose_gpu.cu.cc",
+        "context/custom_library/tf_transpose.cu.h",
+    ],
+    hdrs = [
+        "context/custom_library/transpose.h",
+        "context/custom_library/dimensions.h",
+        "context/custom_library/gpu_helper.h"
+    ],
+    copts = if_rocm_is_configured([
+        "-DTENSORFLOW_USE_ROCM=1",
+        "-x rocm",
+    ]) + cuda_default_copts(),
+    deps = [
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+    ] + if_cuda_is_configured([
+        "@cub_archive//:cub",
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+)
+
+cc_library(
+    name = "transpose_bridge",
+    srcs = [
+        "context/transpose_impl.cc",
+    ],
+    copts = if_rocm_is_configured([
+        "-DTENSORFLOW_USE_ROCM=1",
+        "-x rocm",
+    ]) + cuda_default_copts(),
+    deps = [
+        ":ral_context",
+        ":ral_gpu_driver",
+        ":ral_cpu_driver",
+        ":ral_logging",
+        ":context_util",
+        ":transpose_gpu_lib_bridge",
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_driver",
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+    alwayslink = 1,
+)
+
 cc_library(
     name = "ral_bridge",
     deps = [
@@ -774,6 +886,7 @@ cc_library(
     ] + if_cuda_or_rocm([
         ":dynamic_sort_bridge",
         ":random_bridge",
+        ":transpose_bridge",
     ]),
     alwayslink = 1,
 )

--- a/tao_compiler/mlir/xla/ral/context/custom_library/dimensions.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/dimensions.h
@@ -1,0 +1,100 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAL_CONTEXT_CUSTOM_LIBRARY_DIMENSION_UTILS_H_
+#define RAL_CONTEXT_CUSTOM_LIBRARY_DIMENSION_UTILS_H_
+
+#include <array>
+
+// Function qualifiers that need to work on both CPU and GPU.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+// For nvcc.
+#define EIGEN_DEVICE_FUNC __host__ __device__
+#define EIGEN_STRONG_INLINE __inline__
+#else
+// For non-nvcc.
+#define EIGEN_DEVICE_FUNC
+#define EIGEN_STRONG_INLINE inline
+#endif
+#define EIGEN_DEVICE_INLINE EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+
+namespace tao {
+namespace ral {
+template <typename T, int IndexCount, T DefaultValue>
+struct Array {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T& operator[](int index) const {
+    return data[index];
+  }
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T& operator[](int index) {
+    return data[index];
+  }
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Array() {
+    for (int i = 0; i < IndexCount; i++) {
+      data[i] = DefaultValue;
+    }
+  }
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Array(T a0) {
+    data[0] = a0;
+    for (int i = 1; i < IndexCount; i++) {
+      data[i] = DefaultValue;
+    }
+  }
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Array(T a0, T a1) {
+    data[0] = a0;
+    data[1] = a1;
+    for (int i = 2; i < IndexCount; i++) {
+      data[i] = DefaultValue;
+    }
+  }
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Array(T a0, T a1, T a2) {
+    data[0] = a0;
+    data[1] = a1;
+    data[2] = a2;
+    for (int i = 3; i < IndexCount; i++) {
+      data[i] = DefaultValue;
+    }
+  }
+  EIGEN_STRONG_INLINE Array(const std::array<T, IndexCount>& array) {
+    for (int i = 0; i < IndexCount; i++) {
+      data[i] = array[i];
+    }
+  }
+  T data[IndexCount];
+};
+
+template <int IndexCount>
+struct Dimension : Array<int, IndexCount, 1> {
+  typedef Array<int, IndexCount, 1> Base;
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Dimension() : Base() {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Dimension(int a0) : Base(a0) {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Dimension(int a0, int a1)
+      : Base(a0, a1) {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Dimension(int a0, int a1, int a2)
+      : Base(a0, a1, a2) {}
+  EIGEN_STRONG_INLINE Dimension(const std::array<int, IndexCount>& array)
+      : Base(array) {}
+};
+
+// An index type with compile-time known size.
+template <int IndexCount>
+struct Index : Array<int, IndexCount, 0> {
+  typedef Array<int, IndexCount, 0> Base;
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index() : Base() {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index(int a0) : Base(a0) {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index(int a0, int a1) : Base(a0, a1) {}
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index(int a0, int a1, int a2)
+      : Base(a0, a1, a2) {}
+};
+
+}  //  namespace ral
+}  //  namespace tao
+
+#endif

--- a/tao_compiler/mlir/xla/ral/context/custom_library/gpu_helper.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/gpu_helper.h
@@ -15,6 +15,16 @@
 #include "absl/container/inlined_vector.h"
 #include "absl/types/variant.h"
 
+#if GOOGLE_CUDA
+#include <cuda_runtime.h>
+using gpuStream_t = cudaStream_t;
+#elif TENSORFLOW_USE_ROCM
+#include <hip/hip_runtime.h>
+using cudaError = int;
+using gpuStream_t = hipStream_t;
+#define cudaGetLastError hipGetLastError
+#endif
+
 namespace tao {
 namespace ral {
 

--- a/tao_compiler/mlir/xla/ral/context/custom_library/gpu_helper.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/gpu_helper.h
@@ -1,0 +1,63 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAL_CONTEXT_CUSTOM_LIBRARY_GPU_HELPER_
+#define RAL_CONTEXT_CUSTOM_LIBRARY_GPU_HELPER_
+#include "absl/base/casts.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/types/variant.h"
+
+namespace tao {
+namespace ral {
+
+template <typename... Ts, size_t... Is>
+std::array<void*, sizeof...(Ts)> GetArrayOfElementPointersImpl(
+    std::tuple<Ts...>* tuple, absl::index_sequence<Is...>) {
+  return {{&std::get<Is>(*tuple)...}};
+}
+// Returns an array of void pointers to the elements of the given tuple.
+template <typename... Ts>
+std::array<void*, sizeof...(Ts)> GetArrayOfElementPointers(
+    std::tuple<Ts...>* tuple) {
+  return GetArrayOfElementPointersImpl(tuple,
+                                       absl::index_sequence_for<Ts...>{});
+}
+
+// Launches a GPU kernel through cudaLaunchKernel in CUDA environment, or
+// hipLaunchKernel in ROCm environment with the given arguments.
+//
+// The kernel parameters 'Ts' must be constructible from the arguments 'Args'.
+template <typename... Ts, typename... Args>
+void GpuLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
+                     size_t shared_memory_size_bytes, gpuStream_t stream,
+                     Args... arguments) {
+  // static_assert(detail::NoneIsReference<Ts...>(),
+  //              "Kernels with reference arguments have undefined behaviour.");
+#if GOOGLE_CUDA
+  auto func_ptr = absl::bit_cast<const void*>(function);
+  // Cast arguments and forward them as an array of pointers.
+  auto args_tuple = std::tuple<Ts...>(arguments...);
+  auto arg_ptrs = GetArrayOfElementPointers(&args_tuple);
+  auto result = cudaLaunchKernel(func_ptr, grid_dim, block_dim, arg_ptrs.data(),
+                                 shared_memory_size_bytes, stream);
+  // if (result != cudaSuccess) {
+  //  return errors::Internal(cudaGetErrorString(result));
+  //}
+#elif TENSORFLOW_USE_ROCM
+  hipLaunchKernelGGL(function, grid_dim, block_dim, shared_memory_size_bytes,
+                     stream, std::forward<Args>(arguments)...);
+#endif
+}
+
+}  //  namespace ral
+}  //  namespace tao
+
+#endif

--- a/tao_compiler/mlir/xla/ral/context/custom_library/tf_topk.cu.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/tf_topk.cu.h
@@ -14,6 +14,7 @@
 
 #include "absl/base/casts.h"
 #include "absl/types/optional.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/gpu_helper.h"
 
 #if GOOGLE_CUDA
 #include <cuda_runtime.h>
@@ -355,45 +356,6 @@ TopKKernel(const T* __restrict__ input, int length, int k, bool sorted,
   }
 }
 
-template <typename... Ts, size_t... Is>
-std::array<void*, sizeof...(Ts)> GetArrayOfElementPointersImpl(
-    std::tuple<Ts...>* tuple, absl::index_sequence<Is...>) {
-  return {{&std::get<Is>(*tuple)...}};
-}
-// Returns an array of void pointers to the elements of the given tuple.
-template <typename... Ts>
-std::array<void*, sizeof...(Ts)> GetArrayOfElementPointers(
-    std::tuple<Ts...>* tuple) {
-  return GetArrayOfElementPointersImpl(tuple,
-                                       absl::index_sequence_for<Ts...>{});
-}
-
-// Launches a GPU kernel through cudaLaunchKernel in CUDA environment, or
-// hipLaunchKernel in ROCm environment with the given arguments.
-//
-// The kernel parameters 'Ts' must be constructible from the arguments 'Args'.
-template <typename... Ts, typename... Args>
-void GpuLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
-                     size_t shared_memory_size_bytes, gpuStream_t stream,
-                     Args... arguments) {
-  // static_assert(detail::NoneIsReference<Ts...>(),
-  //              "Kernels with reference arguments have undefined behaviour.");
-#if GOOGLE_CUDA
-  auto func_ptr = absl::bit_cast<const void*>(function);
-  // Cast arguments and forward them as an array of pointers.
-  auto args_tuple = std::tuple<Ts...>(arguments...);
-  auto arg_ptrs = GetArrayOfElementPointers(&args_tuple);
-  auto result = cudaLaunchKernel(func_ptr, grid_dim, block_dim, arg_ptrs.data(),
-                                 shared_memory_size_bytes, stream);
-  // if (result != cudaSuccess) {
-  //  return errors::Internal(cudaGetErrorString(result));
-  //}
-#elif TENSORFLOW_USE_ROCM
-  hipLaunchKernelGGL(function, grid_dim, block_dim, shared_memory_size_bytes,
-                     stream, std::forward<Args>(arguments)...);
-#endif
-}
-
 template <typename T>
 cudaError LaunchTopKKernel(const gpuStream_t& stream, int num_shards,
                            const T* input, int batch_size, int length, int k,
@@ -435,8 +397,9 @@ cudaError LaunchTopKKernel(const gpuStream_t& stream, int num_shards,
   // We are limited by the amount of shared memory we have per block.
   auto shared_memory_size = (num_shards + 1) * k * sizeof(Entry<T>);
 
-  GpuLaunchKernel(TopKKernel<T>, batch_size, num_shards, shared_memory_size,
-                  stream, input, length, k, sorted, output, indices);
+  tao::ral::GpuLaunchKernel(TopKKernel<T>, batch_size, num_shards,
+                            shared_memory_size, stream, input, length, k,
+                            sorted, output, indices);
   return cudaGetLastError();
 }
 

--- a/tao_compiler/mlir/xla/ral/context/custom_library/tf_transpose.cu.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/tf_transpose.cu.h
@@ -1,0 +1,216 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAL_CUSTOM_LIBRARY_TF_TRANSPOSE_H_
+#define RAL_CUSTOM_LIBRARY_TF_TRANSPOSE_H_
+
+#include <cassert>
+#include <vector>
+
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/dimensions.h"
+
+#if GOOGLE_CUDA
+#include <cuda_runtime.h>
+using gpuStream_t = cudaStream_t;
+#elif TENSORFLOW_USE_ROCM
+#include <hip/hip_runtime.h>
+using cudaError = int;
+using gpuStream_t = hipStream_t;
+#define cudaGetLastError hipGetLastError
+#endif
+
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
+dim3 threadIdx, blockDim, blockIdx;
+#endif
+
+namespace tao {
+namespace ral {
+
+// A helper function that converts a flat array index into a tensor index.
+template <int IndexCount>
+EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index<IndexCount> FlatToTensorIndex(
+    int index, const Dimension<IndexCount>& dims) {
+  Index<IndexCount> tensor_index;
+  for (int i = IndexCount - 1; i >= 0; i--) {
+    int new_index = index / dims[i];
+    tensor_index[i] = index - dims[i] * new_index;
+    index = new_index;
+  }
+  return tensor_index;
+}
+
+// A helper function that converts a tensor index into a flat array index.
+template <int IndexCount>
+EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE int TensorIndexToFlat(
+    const Index<IndexCount>& index, const Dimension<IndexCount>& dims) {
+  int flat_index = index[0];
+  for (int i = 1; i < IndexCount; i++) {
+    flat_index = flat_index * dims[i] + index[i];
+  }
+  return flat_index;
+}
+
+// Use shared memory tiles to swap dimension-1 and dimension-2 of a 3D tensor,
+// where dimensions are zero-based: output[i][j][k] = input[i][k][j].
+//
+// Each thread block operates on a single tile, a rectangle of dimensions
+// TileSizeI x TileSizeJ.
+//
+// In general, for best performance, you should probably set TileSizeI,
+// TileSizeJ equal to the number of threads in a warp (32 in nvidia GPUs).
+// With a TileSizeI, TileSizeJ of 32, NumThreads of 128 or 256 seems to get
+// the best performance on K40 GPUs.
+template <typename T, int NumThreads, int TileSizeI, int TileSizeJ>
+__global__ void SwapDimension1And2InTensor3UsingTiles(
+    const T* __restrict__ input, Dimension<3> input_dims,
+    T* __restrict__ output) {
+  assert(blockDim.x == NumThreads);
+  assert(blockDim.y == 1);
+  assert(blockDim.z == 1);
+  assert(gridDim.y == 1);
+  assert(gridDim.z == 1);
+
+  constexpr int ReadRowPerPass = NumThreads / TileSizeJ;
+  constexpr int WriteRowPerPass = NumThreads / TileSizeI;
+  // One extra line in the inner dimension to avoid share memory bank conflict.
+  // This is to mimic the following, but no constructor of T can be invoked.
+  //     __shared__ T shared_memory_tile[TileSizeI][TileSizeJ + 1];
+#if GOOGLE_CUDA
+  __shared__ __align__(
+      alignof(T)) char shared_mem_raw[TileSizeI * (TileSizeJ + 1) * sizeof(T)];
+  typedef T(*SharedMemoryTile)[TileSizeJ + 1];
+  SharedMemoryTile shared_memory_tile =
+      reinterpret_cast<SharedMemoryTile>(shared_mem_raw);
+#elif TENSORFLOW_USE_ROCM
+  __shared__ T shared_memory_tile[TileSizeI][TileSizeJ + 1];
+#endif
+
+  int x = threadIdx.x;
+
+  Dimension<3> output_dims = {
+      input_dims[0],
+      input_dims[2],
+      input_dims[1],
+  };
+
+  Dimension<3> input_dims_in_tiles = {
+      input_dims[0],
+      (input_dims[1] + TileSizeI - 1) / TileSizeI,
+      (input_dims[2] + TileSizeJ - 1) / TileSizeJ,
+  };
+
+  Index<3> input_tile_index =
+      FlatToTensorIndex(blockIdx.x, input_dims_in_tiles);
+
+  Index<3> input_tile_origin = {
+      input_tile_index[0],
+      input_tile_index[1] * TileSizeI,
+      input_tile_index[2] * TileSizeJ,
+  };
+
+  int input_origin_flat_index =
+      TensorIndexToFlat(input_tile_origin, input_dims);
+
+  bool full_tile = true;
+  int tile_width = TileSizeJ;
+
+  // Only the last row or column may not have the full size.
+  if (input_tile_index[2] == input_dims_in_tiles[2] - 1) {
+    tile_width = input_dims[2] - (input_dims_in_tiles[2] - 1) * TileSizeJ;
+    full_tile &= false;
+  }
+
+  int tile_height = TileSizeI;
+
+  if (input_tile_index[1] == input_dims_in_tiles[1] - 1) {
+    tile_height = input_dims[1] - (input_dims_in_tiles[1] - 1) * TileSizeI;
+    full_tile &= false;
+  }
+
+  // Calculate effective thread number. This ensures that we use the largest
+  // number of threads available to form a regular thread block with no
+  // trailing incomplete lines.
+  constexpr int in_effective_thread_num = NumThreads / TileSizeJ * TileSizeJ;
+
+  if (x < in_effective_thread_num) {
+    // Orient the logical thread block with respect to the input array.
+    // ie. align the contiguous dimension of thread blocks with the contiguous
+    // dimension of the input array.
+    int ti = x / TileSizeJ;
+    int tj = x % TileSizeJ;
+    int input_index = input_origin_flat_index + ti * input_dims[2] + tj;
+    int input_increment = ReadRowPerPass * input_dims[2];
+
+    if (full_tile) {
+#pragma unroll
+      for (int i_loc = ti; i_loc < (TileSizeI); i_loc += ReadRowPerPass) {
+        shared_memory_tile[i_loc][tj] = input[input_index];
+        input_index += input_increment;
+      }
+    } else {
+      if (tj < tile_width) {
+        for (int i_loc = ti; i_loc < (tile_height); i_loc += ReadRowPerPass) {
+          shared_memory_tile[i_loc][tj] = input[input_index];
+          input_index += input_increment;
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+
+  Index<3> output_tile_index = {
+      input_tile_index[0],
+      input_tile_index[2],
+      input_tile_index[1],
+  };
+
+  Index<3> output_tile_origin = {
+      output_tile_index[0],
+      output_tile_index[1] * TileSizeJ,
+      output_tile_index[2] * TileSizeI,
+  };
+
+  int output_origin_flat_index =
+      TensorIndexToFlat(output_tile_origin, output_dims);
+
+  constexpr int out_effective_thread_num = NumThreads / TileSizeI * TileSizeI;
+
+  if (x < out_effective_thread_num) {
+    // Re-orient the logical thread block with respect to the output array.
+    // ie. align the contiguous dimension of thread blocks with contiguous
+    // dimension of the output array.
+    int ti = x / TileSizeI;
+    int tj = x % TileSizeI;
+    int output_index = output_origin_flat_index + ti * output_dims[2] + tj;
+    int output_increment = WriteRowPerPass * output_dims[2];
+
+    if (full_tile) {
+#pragma unroll
+      for (int i_loc = ti; i_loc < (TileSizeJ); i_loc += WriteRowPerPass) {
+        output[output_index] = shared_memory_tile[tj][i_loc];
+        output_index += output_increment;
+      }
+    } else {
+      if (tj < tile_height) {
+        for (int i_loc = ti; i_loc < (tile_width); i_loc += WriteRowPerPass) {
+          output[output_index] = shared_memory_tile[tj][i_loc];
+          output_index += output_increment;
+        }
+      }
+    }
+  }
+}
+
+}  //  namespace ral
+}  //  namespace tao
+
+#endif

--- a/tao_compiler/mlir/xla/ral/context/custom_library/transpose.h
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/transpose.h
@@ -1,0 +1,38 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAL_CUSTOM_LIBRARY_TRANSPOSE_H_
+#define RAL_CUSTOM_LIBRARY_TRANSPOSE_H_
+
+#include <vector>
+
+#if GOOGLE_CUDA
+#include <cuda_runtime.h>
+using gpuStream_t = cudaStream_t;
+#elif TENSORFLOW_USE_ROCM
+#include <hip/hip_runtime.h>
+using cudaError = int;
+using gpuStream_t = hipStream_t;
+#define cudaGetLastError hipGetLastError
+#endif
+
+namespace tao {
+namespace ral {
+
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
+template <typename T>
+void LaunchTransposeKernel(gpuStream_t stream, T* input,
+                           std::vector<int64_t> input_dims, T* output);
+#endif
+}  //  namespace ral
+}  //  namespace tao
+
+#endif

--- a/tao_compiler/mlir/xla/ral/context/custom_library/transpose_gpu.cu.cc
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/transpose_gpu.cu.cc
@@ -1,0 +1,60 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/gpu_helper.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/tf_transpose.cu.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/transpose.h"
+
+namespace tao {
+namespace ral {
+
+template <typename IntegralType>
+IntegralType CeilOfRatio(IntegralType numerator, IntegralType denominator) {
+  const IntegralType rounded_toward_zero = numerator / denominator;
+  const IntegralType intermediate_product = rounded_toward_zero * denominator;
+
+  const bool needs_adjustment =
+      (rounded_toward_zero >= 0) &&
+      ((denominator > 0 && numerator > intermediate_product) ||
+       (denominator < 0 && numerator < intermediate_product));
+  const IntegralType adjustment = static_cast<IntegralType>(needs_adjustment);
+  const IntegralType ceil_of_ratio = rounded_toward_zero + adjustment;
+  return ceil_of_ratio;
+}
+
+#ifdef GOOGLE_CUDA
+template <typename T>
+void LaunchTransposeKernel(cudaStream_t stream, T* input,
+                           std::vector<int64_t> input_dims, T* output) {
+  static constexpr int64_t tile_size = 32;
+  static constexpr int64_t num_threads = 256;
+  Dimension<3> input_dims_in_tiles = {
+      input_dims[0],
+      CeilOfRatio(input_dims[1], tile_size),
+      CeilOfRatio(input_dims[2], tile_size),
+  };
+  Dimension<3> dims = {input_dims[0], input_dims[1], input_dims[2]};
+
+  int total_tiles_count =
+      input_dims_in_tiles[0] * input_dims_in_tiles[1] * input_dims_in_tiles[2];
+
+  GpuLaunchKernel(SwapDimension1And2InTensor3UsingTiles<T, num_threads,
+                                                        tile_size, tile_size>,
+                  total_tiles_count, num_threads, 0, stream, input, dims,
+                  output);
+}
+template void LaunchTransposeKernel<float>(cudaStream_t stream, float* input,
+                                           std::vector<int64_t> input_dims,
+                                           float* output);
+#endif
+
+}  //  namespace ral
+}  //  namespace tao

--- a/tao_compiler/mlir/xla/ral/context/transpose_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/transpose_impl.cc
@@ -1,0 +1,64 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef GOOGLE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include "tensorflow/compiler/mlir/xla/ral/context/context_util.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/custom_library/transpose.h"
+#include "tensorflow/compiler/mlir/xla/ral/device/gpu/gpu_driver.h"
+#include "tensorflow/compiler/mlir/xla/ral/ral_context.h"
+#include "tensorflow/compiler/mlir/xla/ral/ral_driver.h"
+#include "tensorflow/compiler/mlir/xla/ral/ral_helper.h"
+#include "tensorflow/compiler/mlir/xla/ral/ral_logging.h"
+
+using tao::ral::buffer_t;
+using tao::ral::Context;
+using tao::ral::ExecutionContext;
+using tao::ral::MemRefType;
+using tao::ral::gpu::GPUDriver;
+using tao::ral::gpu::stream_t;
+
+namespace tao {
+namespace ral {
+
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
+template <typename T, int N>
+void ral_transpose(ExecutionContext* ctx, void* stream_handle,
+                   MemRefType<T, 2> input, MemRefType<int, 1> permute_value,
+                   MemRefType<T, 2> output) {
+  T* d_in = input.data;
+  T* d_out = output.data;
+
+  static_assert(N == 2 || N == 3,
+                "input of ral_transpose op should be rank2 or rank3 tensor");
+
+  std::vector<int64_t> input_dims;
+  if (N == 2)
+    input_dims = {1, input.sizes[0], input.sizes[1]};
+  else if (N == 3)
+    input_dims = {input.sizes[0], input.sizes[1], input.sizes[2]};
+
+  // get GPU driver, since we may need allocate extra temp gpu device workspace
+  auto gpu_driver = ctx->getDriver<GPUDriver>(GPUDriver::name());
+  auto stream =
+      static_cast<gpuStream_t>(gpu_driver->asCUStream(ctx, stream_handle));
+
+  LaunchTransposeKernel<T>(stream, d_in, input_dims, d_out);
+}
+
+TAO_RAL_API("ral_transpose", "gpu", ral_transpose<float, 2>);
+TAO_RAL_API("ral_transpose", "gpu", ral_transpose<float, 3>);
+#endif
+
+}  //  namespace ral
+}  //  namespace tao


### PR DESCRIPTION
This PR added a custom library call for the transpose2D operator, which calls the TF kernel instead of the disc code generator to get higher performance. 
I will improve the disc codegen to get higher performance with fusion with other elementwise operator.

benchmark between disc codegen and custom library call:

(6144x3072xf32) |  latency | compute throughput | memory throughput
-- | -- | -- | --
custom call | 340 ms | 39.29% | 87.84%
disc code gen  | 688 ms | 11.45 % | 72.11 %
