### PR TITLE
[AArch64] re-use ACL conv operator instance for different threads

### DIFF
--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.h
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_mkldnn.h
@@ -765,6 +765,12 @@ using AclConvThreadSafeInfo =
 using AclConvState =
     AclOpThreadSafeState<ConvParamsKey, arm_compute::DISCNEConvolutionLayer>;
 
+using AclConvThreadSafeInfoV2 =
+    AclOpThreadSafeInfoV2<ConvParamsKey, arm_compute::DISCNEConvolutionLayer>;
+using AclConvStateV2 =
+    AclOpThreadSafeState<ConvParamsKey, arm_compute::DISCNEConvolutionLayer,
+                         AclConvThreadSafeInfoV2>;
+
 using AclQGemmInfo = AclOpInfo<arm_compute::DISCNEGEMMLowpMatrixMultiplyCore>;
 using AclQGemmThreadSafeInfo =
     AclOpThreadSafeInfo<GEMMParamsKey,

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_quantization.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_quantization.cc
@@ -101,32 +101,34 @@ void ral_qconv_s8_s8_s8(
     TAO_VLOG(0) << "params.dilates[0] = " << params.dilates[0];
   }
 
+  auto src_shape = TensorShape(Ci, Iw, Ih, N);
+  auto weights_shape = TensorShape(Ci, Kw, Kh, Co);
+  auto dst_shape = TensorShape(Co, Ow, Oh, N);
+
+  DataLayout data_layout = DataLayout::NHWC;
+  DataType data_type = DataType::QASYMM8_SIGNED;
+  TensorInfo src_info = TensorInfo(src_shape, 1, data_type, data_layout);
+  TensorInfo weights_info =
+      TensorInfo(weights_shape, 1, DataType::QSYMM8_PER_CHANNEL, data_layout);
+  TensorInfo dst_info = TensorInfo(dst_shape, 1, data_type, data_layout);
+
+  const QuantizationInfo src_qinfo = QuantizationInfo();
+  src_info.set_quantization_info(QuantizationInfo(*inputScales.data, 0));
+  std::vector<float> scales(filterScales.data,
+                            filterScales.data + filterScales.sizes[0]);
+  weights_info.set_quantization_info(QuantizationInfo(std::move(scales)));
+  dst_info.set_quantization_info(QuantizationInfo(*outputScales.data, 0));
+
+  arm_compute::Tensor src, weights, dst;
+  src.allocator()->init(src_info);
+  weights.allocator()->init(weights_info);
+  dst.allocator()->init(dst_info);
+  src.allocator()->import_memory(input.data);
+  weights.allocator()->import_memory(kernel.data);
+  dst.allocator()->import_memory(output.data);
+
   auto AclQconvCreator = [&](const arm_compute::ITensorPack* pack) {
     std::shared_ptr<AclConvInfo> info(new AclConvInfo);
-    auto src_shape = TensorShape(Ci, Iw, Ih, N);
-    auto weights_shape = TensorShape(Ci, Kw, Kh, Co);
-    auto dst_shape = TensorShape(Co, Ow, Oh, N);
-
-    DataLayout data_layout = DataLayout::NHWC;
-    DataType data_type = DataType::QASYMM8_SIGNED;
-    TensorInfo src_info = TensorInfo(src_shape, 1, data_type, data_layout);
-    TensorInfo weights_info =
-        TensorInfo(weights_shape, 1, DataType::QSYMM8_PER_CHANNEL, data_layout);
-    TensorInfo dst_info = TensorInfo(dst_shape, 1, data_type, data_layout);
-
-    const QuantizationInfo src_qinfo = QuantizationInfo();
-    src_info.set_quantization_info(QuantizationInfo(*inputScales.data, 0));
-    std::vector<float> scales(filterScales.data,
-                              filterScales.data + filterScales.sizes[0]);
-    weights_info.set_quantization_info(QuantizationInfo(std::move(scales)));
-    dst_info.set_quantization_info(QuantizationInfo(*outputScales.data, 0));
-
-    info->src.allocator()->init(src_info);
-    info->weights.allocator()->init(weights_info);
-    info->dst.allocator()->init(dst_info);
-    info->src.allocator()->import_memory(input.data);
-    info->weights.allocator()->import_memory(kernel.data);
-    info->dst.allocator()->import_memory(output.data);
 
     if (!info->op.validate(
             &src_info, &weights_info, nullptr, &dst_info,
@@ -137,7 +139,7 @@ void ral_qconv_s8_s8_s8(
             WeightsInfo{}, Size2D{params.dilates[1], params.dilates[0]})) {
       ctx->signalError(Context::FAILURE, "fail to validate acl depthwise conv");
     } else {
-      info->op.configure(&info->src, &info->weights, nullptr, &info->dst,
+      info->op.configure(&src, &weights, nullptr, &dst,
                          PadStrideInfo{params.strides[1], params.strides[0],
                                        params.padding_l[1], params.padding_r[1],
                                        params.padding_l[0], params.padding_r[0],
@@ -146,16 +148,16 @@ void ral_qconv_s8_s8_s8(
                          Size2D{params.dilates[1], params.dilates[0]});
     }
     if (pack) info->op.reuse_packed_weight(*pack);
-    info->op.prepare(&info->src, &info->weights, nullptr, &info->dst);
+    info->op.prepare(&src, &weights, nullptr, &dst);
     return info;
   };
 
   std::shared_ptr<AclConvInfo> info;
-  std::shared_ptr<AclConvThreadSafeInfo> thread_safe_info;
+  std::shared_ptr<AclConvThreadSafeInfoV2> thread_safe_info;
   if (isWeightPrePackingEnabled() && params.weight_is_const) {
     std::string unique_name = "tao_ral.cpu.acl_qconv_s8s8s8";
-    auto state = ctx->getOrCreateResource<AclConvState>(
-        unique_name, []() { return new AclConvState; });
+    auto state = ctx->getOrCreateResource<AclConvStateV2>(
+        unique_name, []() { return new AclConvStateV2; });
     auto key = makeConvParamsKey(input, kernel, padding, output, metadata,
                                  kDiscCpuDefaultThreadId);
     auto dynamicKey = makeDynamicShapeConvParamsKey(
@@ -166,11 +168,7 @@ void ral_qconv_s8_s8_s8(
     info = AclQconvCreator(nullptr);
   }
 
-  // TOOD(disc): re-import quantization info when online-quantization is
-  // supported.
-  info->src.allocator()->import_memory(input.data);
-  info->dst.allocator()->import_memory(output.data);
-  info->op.run(&info->src, &info->weights, nullptr, &info->dst);
+  info->op.run(&src, &weights, nullptr, &dst);
 
   timer.Stop();
   if (isProfilingEnabled()) {

--- a/tensorflow_blade/workspace0.bzl
+++ b/tensorflow_blade/workspace0.bzl
@@ -102,6 +102,8 @@ def _tf_blade_repositories():
             "@org_third_party//bazel/acl:acl_makefile.patch",
             "@org_third_party//bazel/acl:acl_yitian.patch",
             "@org_third_party//bazel/acl:acl_gemm_hybrid_indirect.patch",
+            "@org_third_party//bazel/acl:acl_cpu_gemm_assembly_dispatch.patch",
+            "@org_third_party//bazel/acl:acl_cpu_winograd_conv2d_kernel.patch",
         ],
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )

--- a/third_party/bazel/acl/acl_cpu_gemm_assembly_dispatch.patch
+++ b/third_party/bazel/acl/acl_cpu_gemm_assembly_dispatch.patch
@@ -1,0 +1,260 @@
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+index 23095d8..e186798 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -169,6 +169,13 @@ private:
+         Count
+     };
+ 
++    struct ThreadSafeParams {
++        std::shared_ptr<arm_gemm::GemmCommon<TypeInput, TypeOutput>> _gemm_kernel_asm{ nullptr };
++        std::unique_ptr<INEKernel> _optimised_kernel{ nullptr };
++        std::unique_ptr<const TypeInput *const *, free_delete> _indirect_arg{};
++        std::unique_ptr<const TypeInput *, free_delete>        _indirect_buf{};
++    };
++
+     /** Configure the indirect buffer
+      *
+      * @param[in]  a    Input tensor containing the Matrix A.
+@@ -209,6 +216,10 @@ private:
+     bool                             _B_pretranspose_required{ false };
+     bool                             _is_b_constant{ true };
+     bool                             _is_c_constant{ true };
++
++    std::unique_ptr<arm_gemm::GemmArgs> _args;
++    OutputStage _os;
++    arm_gemm::GemmConfig _gemm_cfg;
+ };
+ 
+ template <typename TypeInput, typename TypeOutput, class OutputStage>
+@@ -355,13 +366,14 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::configure(const ITensorInfo *
+     _is_b_constant = b->are_values_constant();
+     _is_c_constant = c ? c->are_values_constant() : true;
+ 
+-    arm_gemm::GemmConfig gemm_cfg;
+     _kernel_info = arm_gemm::get_gemm_method<TypeInput, TypeOutput, OutputStage>(args, os);
+     if(_kernel_info.method != arm_gemm::GemmMethod::GEMV_BATCHED)
+     {
+-        gemm_cfg.filter = _kernel_info.name;
+-        args._cfg       = &gemm_cfg;
++        _gemm_cfg.filter = _kernel_info.name;
++        args._cfg       = &_gemm_cfg;
+     }
++    _os = os;
++    _args.reset(new arm_gemm::GemmArgs(args));
+     _gemm_kernel_asm = arm_gemm::gemm<TypeInput, TypeOutput, OutputStage>(args, os);
+     if(_gemm_kernel_asm == nullptr)
+     {
+@@ -372,7 +384,7 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::configure(const ITensorInfo *
+     // arm_compute wrapper for the Gemm object (see above)
+     auto acl_gemm_wrapper = std::make_unique<kernel::CpuGemmAssemblyWrapperKernel<TypeInput, TypeOutput>>();
+     ARM_COMPUTE_ERROR_ON(acl_gemm_wrapper == nullptr);
+-    acl_gemm_wrapper->configure(_gemm_kernel_asm.get(), gemm_cfg.filter);
++    acl_gemm_wrapper->configure(_gemm_kernel_asm.get(), _gemm_cfg.filter);
+     const size_t       workspace_size = _gemm_kernel_asm->get_working_size();
+     const unsigned int alignment      = 4096;
+     _workspace_info                   = TensorInfo(TensorShape(workspace_size), 1, DataType::U8);
+@@ -485,8 +497,68 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     const TypeInput *in1_ptr = nullptr;
+     auto             out_ptr = reinterpret_cast<TypeOutput *>(d->buffer() + d->info()->offset_first_element_in_bytes());
+ 
++    ThreadSafeParams params;
++    {
++        // init thread local params
++        params._gemm_kernel_asm = arm_gemm::gemm<TypeInput, TypeOutput, OutputStage>(*_args, _os);
++        ARM_COMPUTE_ERROR_ON(params._gemm_kernel_asm.get() == nullptr);
++        auto acl_gemm_wrapper = std::make_unique<kernel::CpuGemmAssemblyWrapperKernel<TypeInput, TypeOutput>>();
++        ARM_COMPUTE_ERROR_ON(acl_gemm_wrapper == nullptr);
++        acl_gemm_wrapper->configure(params._gemm_kernel_asm.get(), _gemm_cfg.filter);
++        params._optimised_kernel = std::move(acl_gemm_wrapper);
++
++        //if we disable this code below in brackets then ConvLayer deadlocks when threads > 1 and
++        //the shapes are In=1x1x1024 Weights=1x1x1024x1001 Biases=1001 Out=1x1x1001
++        {
++            const unsigned int window_size = params._gemm_kernel_asm->get_window_size().total_size();
++            if(window_size < static_cast<unsigned int>(_args->_maxthreads))
++            {
++                params._gemm_kernel_asm->set_nthreads(window_size);
++            }
++        }
++
++        // Handle indirect GEMM convolution
++        if (_gemm_info.method == AsmConvMethod::Conv)
++        {
++            params._gemm_kernel_asm->set_convolution_parameters(_cp);
++        }
++
++        if (_gemm_info.method == AsmConvMethod::Indirect)
++        {
++            const unsigned int multis    = 1;
++            const unsigned int batches   = a->info()->tensor_shape().total_size_upper(3);
++            const unsigned int kernel_hw = _cp.kernel_width * _cp.kernel_height;
++            const unsigned int output_hw = _cp.output_width * _cp.output_height;
++
++            using TypeInputPtr        = TypeInput *;
++            const int    batch_size   = kernel_hw * output_hw * sizeof(TypeInputPtr);
++            const size_t batch_stride = batch_size / sizeof(TypeInputPtr);
++            const int    multi_size   = batch_size * batches;
++            const size_t multi_stride = multi_size / sizeof(TypeInputPtr);
++
++            params._indirect_buf = std::unique_ptr<const TypeInput *, free_delete>(reinterpret_cast<const TypeInput **>(malloc(multi_size * multis)));
++            params._indirect_arg = std::unique_ptr<const TypeInput *const *, free_delete>(reinterpret_cast<const TypeInput *const **>(malloc(sizeof(TypeInput **) * kernel_hw * multis * batches)));
++
++            // Set indirect argument
++            int64_t pos = 0;
++            for(int64_t m = 0; m < multis; m++)
++            {
++                for(int64_t b = 0; b < batches; b++)
++                {
++                    for(int64_t kernel_xy = 0; kernel_xy < kernel_hw; kernel_xy++)
++                    {
++                        (params._indirect_arg.get())[pos++] = params._indirect_buf.get() + m * multi_stride + b * batch_stride + kernel_xy * output_hw;
++                    }
++                }
++            }
++
++            params._gemm_kernel_asm->set_indirect_parameters(a->info()->tensor_shape()[0], params._indirect_arg.get());
++        }
++
++    }
++
+     // Check if B is pre-tranposed and de-reference if not
+-    if(!_gemm_kernel_asm->B_is_pretransposed())
++    if(!params._gemm_kernel_asm->B_is_pretransposed())
+     {
+         ldb            = b->info()->strides_in_bytes().y() / sizeof(TypeInput);
+         multi_stride_b = b->info()->strides_in_bytes().z() / sizeof(TypeInput);
+@@ -498,7 +570,7 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     {
+         if(c && c->info()->data_type() == DataType::S32)
+         {
+-            _gemm_kernel_asm->set_quantized_bias(reinterpret_cast<const int32_t *>(c->buffer() + c->info()->offset_first_element_in_bytes()), 0);
++            params._gemm_kernel_asm->set_quantized_bias(reinterpret_cast<const int32_t *>(c->buffer() + c->info()->offset_first_element_in_bytes()), 0);
+         }
+ 
+         // Pretranspose B if required
+@@ -513,11 +585,11 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+ 
+             if(_is_b_constant)
+             {
+-                _gemm_kernel_asm->requantize_bias(pretranspose.get()->buffer(), b_ptr, ldb, multi_stride_b);
++                params._gemm_kernel_asm->requantize_bias(pretranspose.get()->buffer(), b_ptr, ldb, multi_stride_b);
+             }
+             else
+             {
+-                _gemm_kernel_asm->pretranspose_B_array(pretranspose.get()->buffer(), b_ptr, ldb, multi_stride_b);
++                params._gemm_kernel_asm->pretranspose_B_array(pretranspose.get()->buffer(), b_ptr, ldb, multi_stride_b);
+             }
+         }
+     }
+@@ -528,9 +600,9 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     CpuAuxTensorHandler workspace(offset_int_vec(AsmGemmWorkspace), _workspace_info, tensors, false);
+     if(workspace.get()->buffer() != nullptr)
+     {
+-        _gemm_kernel_asm->set_working_space(reinterpret_cast<void *>(workspace.get()->buffer()));
++        params._gemm_kernel_asm->set_working_space(reinterpret_cast<void *>(workspace.get()->buffer()));
+         const unsigned int split_dim   = scheduling_hint.split_dimension();
+-        const unsigned int window_size = _gemm_kernel_asm->get_window_size().total_size();
++        const unsigned int window_size = params._gemm_kernel_asm->get_window_size().total_size();
+         unsigned int       num_threads = NEScheduler::get().num_threads();
+         if(window_size < num_threads)
+         {
+@@ -539,15 +611,81 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+         if(split_dim != IScheduler::split_dimensions_all)
+         {
+             // Make sure the kernel does not expect more threads than we can actually spawn
+-            const unsigned int num_iterations = _optimised_kernel.get()->window().num_iterations(split_dim);
++            const unsigned int num_iterations = params._optimised_kernel.get()->window().num_iterations(split_dim);
+             num_threads                       = std::min(num_iterations, num_threads);
+         }
+-        _gemm_kernel_asm->set_nthreads(num_threads);
++        params._gemm_kernel_asm->set_nthreads(num_threads);
+     }
+ 
+     // Prepare assembly kernel
+     prepare(tensors);
+ 
++    {
++        // prepare for local params
++        // Setup up matrix bias in the assembly kernel, it's just a pointer to matrix C.
++        if(c && c->info()->data_type() == DataType::S32)
++        {
++            params._gemm_kernel_asm->set_quantized_bias(reinterpret_cast<const int32_t *>(c->buffer() + c->info()->offset_first_element_in_bytes()), 0);
++        }
++
++        if(params._gemm_kernel_asm->B_pretranspose_required()) {
++            auto pretranspose = tensors.get_tensor(offset_int_vec(Pretranspose));
++            ARM_COMPUTE_ERROR_ON(pretranspose == nullptr);
++            params._gemm_kernel_asm->set_pretransposed_B_data(pretranspose->buffer());
++        }
++
++        if(_gemm_info.method == AsmConvMethod::Indirect) {
++            const TypeInput *A_ptr          = reinterpret_cast<TypeInput *>(a->buffer());
++            const int        multis         = 1;
++            const int        batches        = a->info()->tensor_shape().total_size_upper(3);
++            const size_t     stride_A       = a->info()->strides_in_bytes().y() / sizeof(TypeInput);
++            const size_t     batch_stride_A = a->info()->strides_in_bytes()[3] / sizeof(TypeInput);
++            const size_t     multi_stride_A = a->info()->strides_in_bytes()[4] / sizeof(TypeInput);
++
++            const size_t output_hw    = _cp.output_height * _cp.output_width;
++            const int    batch_size   = _cp.kernel_height * _cp.kernel_width * output_hw * sizeof(TypeInput);
++            const size_t batch_stride = batch_size / sizeof(TypeInput);
++            const int    multi_size   = batch_size * batches;
++            const size_t multi_stride = multi_size / sizeof(TypeInput);
++
++            for(int64_t m = 0; m < multis; m++)
++            {
++                for(int64_t b = 0; b < batches; b++)
++                {
++                    for(int64_t output_y = 0; output_y < _cp.output_height; output_y++)
++                    {
++                        for(int64_t output_x = 0; output_x < _cp.output_width; output_x++)
++                        {
++                            int64_t output_xy = (output_y * _cp.output_width) + output_x;
++
++                            for(int64_t kernel_y = 0; kernel_y < _cp.kernel_height; kernel_y++)
++                            {
++                                for(int64_t kernel_x = 0; kernel_x < _cp.kernel_width; kernel_x++)
++                                {
++                                    int64_t input_x   = (output_x * _cp.output_stride_w) + kernel_x - _cp.padding_left;
++                                    int64_t input_y   = (output_y * _cp.output_stride_h) + kernel_y - _cp.padding_top;
++                                    int64_t kernel_xy = (kernel_y * _cp.kernel_width) + kernel_x;
++                                    int64_t input_xy  = (input_y * _cp.input_width) + input_x;
++
++                                    if(input_x < 0 || input_x >= _cp.input_width || input_y < 0 || input_y >= _cp.input_height)
++                                    {
++                                        params._indirect_buf.get()[m * multi_stride + b * batch_stride + kernel_xy * output_hw + output_xy] = _indirect_pad.data();
++                                    }
++                                    else
++                                    {
++                                        params._indirect_buf.get()[m * multi_stride + b * batch_stride + kernel_xy * output_hw + output_xy] =
++                                            A_ptr + (m * multi_stride_A + b * batch_stride_A + input_xy * stride_A);
++                                    }
++                                }
++                            }
++                        }
++                    }
++                }
++            }
++        }
++
++    }
++
+     // Setup up matrix bias in the assembly kernel, it's just a pointer to matrix C.
+     TypeOutput *bias = nullptr;
+     if(c && c->info()->data_type() != DataType::S32)
+@@ -564,12 +702,12 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     }
+ 
+     // Set gemm parameters
+-    _gemm_kernel_asm->set_arrays(in0_ptr, lda, batch_stride_a, multi_stride_a,
++    params._gemm_kernel_asm->set_arrays(in0_ptr, lda, batch_stride_a, multi_stride_a,
+                                  in1_ptr, ldb, multi_stride_b,
+                                  out_ptr, ldd, batch_stride_d, multi_stride_d,
+                                  bias, 0);
+     // Schedule
+-    NEScheduler::get().schedule(_optimised_kernel.get(), scheduling_hint);
++    NEScheduler::get().schedule(params._optimised_kernel.get(), scheduling_hint);
+ }
+ 
+ template <typename TypeInput, typename TypeOutput>

--- a/third_party/bazel/acl/acl_cpu_winograd_conv2d_kernel.patch
+++ b/third_party/bazel/acl/acl_cpu_winograd_conv2d_kernel.patch
@@ -1,0 +1,143 @@
+diff --git a/src/cpu/kernels/CpuWinogradConv2dKernel.cpp b/src/cpu/kernels/CpuWinogradConv2dKernel.cpp
+index 803af09..9498163 100644
+--- a/src/cpu/kernels/CpuWinogradConv2dKernel.cpp
++++ b/src/cpu/kernels/CpuWinogradConv2dKernel.cpp
+@@ -222,6 +222,7 @@ void CpuWinogradConv2dTransformWeightsKernel<T, OutputTileRows, OutputTileCols,
+     ARM_COMPUTE_UNUSED(weights_hwio, output);
+ 
+     _transform           = std::make_unique<WeightsTransform>(num_output_channels, num_input_channels);
++    _num_input_channels = num_input_channels;
+     _num_output_channels = num_output_channels;
+     _matrix_stride       = matrix_stride;
+ 
+@@ -245,12 +246,13 @@ void CpuWinogradConv2dTransformWeightsKernel<T, OutputTileRows, OutputTileCols,
+     const ITensor *weights_hwio = tensors.get_const_tensor(TensorType::ACL_SRC);
+     ITensor       *output       = tensors.get_tensor(TensorType::ACL_DST);
+ 
+-    _transform->set_weight_tensor(weights_hwio->buffer());
++    auto transform = std::make_unique<WeightsTransform>(_num_output_channels, _num_input_channels);
++    transform->set_weight_tensor(weights_hwio->buffer());
+     const int matrix_row_stride = roundup(_num_output_channels, WinogradConv::N_BLOCK);
+-    _transform->set_output_matrices(output->buffer(), _matrix_stride, matrix_row_stride);
+-    _transform->set_working_space(output->buffer());
++    transform->set_output_matrices(output->buffer(), _matrix_stride, matrix_row_stride);
++    transform->set_working_space(output->buffer());
+ 
+-    _transform->run(fst, lst);
++    transform->run(fst, lst);
+ }
+ 
+ template <typename T, int OutputTileRows, int OutputTileCols, int KernelRows, int KernelCols>
+@@ -346,7 +348,8 @@ void CpuWinogradConv2dTransformInputKernel<T, OutputTileRows, OutputTileCols, Ke
+     const int padding_bottom = (padding == PADDING_SAME) ? iceildiv(KernelRows - 1, 2) : 0;
+     const int padding_right  = (padding == PADDING_SAME) ? iceildiv(KernelCols - 1, 2) : 0;
+ 
+-    _transform = std::make_unique<InputTransform>(
++    __transform_creator = [=]() {
++        return std::make_unique<InputTransform>(
+                      KernelRows,
+                      KernelCols,
+                      num_batches,
+@@ -358,6 +361,9 @@ void CpuWinogradConv2dTransformInputKernel<T, OutputTileRows, OutputTileCols, Ke
+                      padding_bottom, /**< Padding to apply to the bottom of the image. */
+                      padding_right   /**< Padding to apply to the right of the image. */
+                  );
++    };
++
++    _transform = __transform_creator();
+ 
+     Window win;
+     auto   win_last = _transform->get_window();
+@@ -384,15 +390,16 @@ void CpuWinogradConv2dTransformInputKernel<T, OutputTileRows, OutputTileCols, Ke
+     auto       output_ptr            = reinterpret_cast<T *>(output->buffer() + output->info()->offset_first_element_in_bytes());
+     ARM_COMPUTE_ERROR_ON_NULLPTR(output_ptr);
+ 
+-    _transform->set_input_tensor(input_nhwc_ptr, input_batch_stride, input_row_stride, input_col_stride);
+-    _transform->set_output_matrices(output_ptr, _matrix_stride, _num_channels);
++    auto transform = __transform_creator();
++    transform->set_input_tensor(input_nhwc_ptr, input_batch_stride, input_row_stride, input_col_stride);
++    transform->set_output_matrices(output_ptr, _matrix_stride, _num_channels);
+ 
+-    _transform->set_working_space(workspace->buffer());
++    transform->set_working_space(workspace->buffer());
+ 
+     // The code below cannot be moved to configure because biases hasn't been allocated at that point
+     const size_t fst = window.x().start();
+     const size_t lst = window.x().end();
+-    _transform->run(fst, lst, info.thread_id);
++    transform->run(fst, lst, info.thread_id);
+ }
+ 
+ template <typename T, int OutputTileRows, int OutputTileCols, int KernelRows, int KernelCols>
+@@ -489,7 +496,11 @@ void CpuWinogradConv2dTransformOutputKernel<T, OutputTileRows, OutputTileCols, K
+     _matrix_row_stride = roundup(num_channels, WinogradConv::N_BLOCK);
+ 
+     // We don't have the biases buffer at this stage as it hasn't been allocated, we pass in nullptr OutputTransform is only used here to compute the window
+-    _transform = std::make_unique<OutputTransform>(num_batches, num_rows, num_cols, num_channels, activation);
++    __transform_creator = [=]() {
++        return std::make_unique<OutputTransform>(num_batches, num_rows, num_cols, num_channels, activation);
++    };
++
++    _transform = __transform_creator();
+     Window win;
+     auto   win_last = _transform->get_window();
+     win.set(Window::DimX, Window::Dimension(0, win_last, 1));
+@@ -512,15 +523,16 @@ void CpuWinogradConv2dTransformOutputKernel<T, OutputTileRows, OutputTileCols, K
+     const int out_row_stride   = dst_nhwc->info()->strides_in_bytes()[2] / sizeof(T);
+     const int out_col_stride   = dst_nhwc->info()->strides_in_bytes()[1] / sizeof(T);
+ 
+-    _transform->set_input_matrices(transformed_output->buffer(), _matrix_stride, _matrix_row_stride);
+-    _transform->set_bias((biases ? reinterpret_cast<T *>(biases->buffer() + biases->info()->offset_first_element_in_bytes()) : nullptr));
+-    _transform->set_output_tensor(dst_nhwc->buffer() + dst_nhwc->info()->offset_first_element_in_bytes(), out_batch_stride, out_row_stride, out_col_stride);
+-    _transform->set_working_space(workspace->buffer());
++    auto transform = __transform_creator();
++    transform->set_input_matrices(transformed_output->buffer(), _matrix_stride, _matrix_row_stride);
++    transform->set_bias((biases ? reinterpret_cast<T *>(biases->buffer() + biases->info()->offset_first_element_in_bytes()) : nullptr));
++    transform->set_output_tensor(dst_nhwc->buffer() + dst_nhwc->info()->offset_first_element_in_bytes(), out_batch_stride, out_row_stride, out_col_stride);
++    transform->set_working_space(workspace->buffer());
+ 
+     // The code below cannot be moved to configure because biases hasn't been allocated at that point
+     const size_t fst = window.x().start();
+     const size_t lst = window.x().end();
+-    _transform->run(fst, lst, info.thread_id);
++    transform->run(fst, lst, info.thread_id);
+ }
+ 
+ template <typename T, int OutputTileRows, int OutputTileCols, int KernelRows, int KernelCols>
+diff --git a/src/cpu/kernels/CpuWinogradConv2dKernel.h b/src/cpu/kernels/CpuWinogradConv2dKernel.h
+index 6909216..8613ace 100644
+--- a/src/cpu/kernels/CpuWinogradConv2dKernel.h
++++ b/src/cpu/kernels/CpuWinogradConv2dKernel.h
+@@ -30,6 +30,8 @@
+ 
+ #include "src/core/NEON/kernels/convolution/winograd/winograd_layer.hpp"
+ 
++#include <functional>
++
+ namespace arm_compute
+ {
+ namespace cpu
+@@ -213,6 +215,7 @@ private:
+     std::unique_ptr<InputTransform> _transform{ nullptr };
+     int                             _num_channels;  /**< Number of channels in input tensor. */
+     int                             _matrix_stride; /**< Stride between output matrices. */
++    std::function<std::unique_ptr<InputTransform>()> __transform_creator;
+ };
+ 
+ /** Interface for the kernel to perform Winograd output transform. */
+@@ -415,6 +418,7 @@ private:
+     std::unique_ptr<OutputTransform> _transform{ nullptr };
+     int                              _matrix_stride;
+     int                              _matrix_row_stride;
++    std::function<std::unique_ptr<OutputTransform>()> __transform_creator;
+ };
+ 
+ /** Interface for the kernel to perform Winograd weights transform. */
+@@ -550,6 +554,7 @@ private:
+     using WeightsTransform = typename WinogradBase::template WeightsTransform<T, T>;
+ 
+     std::unique_ptr<WeightsTransform> _transform{ nullptr };
++    int                               _num_input_channels;
+     int                               _num_output_channels;
+     int                               _matrix_stride;
+ };

--- a/third_party/bazel/blade_disc_dnn_workspace.bzl
+++ b/third_party/bazel/blade_disc_dnn_workspace.bzl
@@ -33,6 +33,8 @@ def _blade_disc_dnn_repositories():
             "@org_third_party//bazel/acl:acl_makefile.patch",
             "@org_third_party//bazel/acl:acl_yitian.patch",
             "@org_third_party//bazel/acl:acl_gemm_hybrid_indirect.patch",
+            "@org_third_party//bazel/acl:acl_cpu_gemm_assembly_dispatch.patch",
+            "@org_third_party//bazel/acl:acl_cpu_winograd_conv2d_kernel.patch",
         ],
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )


### PR DESCRIPTION
1, patch ACL to support parallel `conv.run(...)`
2, change DISC accordingly to enable the above feature.