### PR TITLE
Fix torchBench nsys problem

### DIFF
--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -13,7 +13,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update -y && \
     wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb \
-    -O /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
+        -O /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb

--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -11,12 +11,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2004/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu2004/amd64/ /" >> /etc/apt/sources.list.d/nsight.list && \
-    apt-get update -y && \
+RUN wget https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb &&
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-systems-2022.2.1 && \
+        ./nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     rm -rf /var/lib/apt/lists/* 
-ENV PATH="/opt/nvidia/nsight-systems/2022.2.1/bin:${PATH}"
+ENV PATH="/opt/nvidia/nsight-systems/2022.4.1/bin:${PATH}"
 
 RUN python3 -m pip install virtualenv

--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -11,7 +11,8 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
+RUN apt-get update -y && \
+    wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ./nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     rm -rf /var/lib/apt/lists/* 

--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -12,10 +12,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update -y && \
-    wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
+    wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb -O /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ./nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
-    rm -rf /var/lib/apt/lists/* 
+        /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/* /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb
 ENV PATH="/opt/nvidia/nsight-systems/2022.4.1/bin:${PATH}"
 
 RUN python3 -m pip install virtualenv

--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -12,7 +12,8 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update -y && \
-    wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb -O /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
+    wget -q https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb \
+    -O /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb

--- a/docker/cronjobs/Dockerfile.torch.bench
+++ b/docker/cronjobs/Dockerfile.torch.bench
@@ -11,7 +11,7 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb &&
+RUN wget https://bladedisc-ci.oss-cn-hongkong.aliyuncs.com/download/nsys/nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ./nsight-systems-2022.4.1_2022.4.1.21-1_amd64.deb && \
     rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
nsys 2022.2.1 not available now. Update and download it from oss instead.