### PR TITLE
several shape related improvements

### DIFF
--- a/tao_compiler/mlir/disc/transforms/disc_shape_optimization.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_optimization.cc
@@ -860,7 +860,7 @@ LogicalResult ShapeComputationIRAnalysis::applyIndexOpConstraint(
   Type ty = op->getResult(0).getType();
   if (!ty.isIntOrIndex()) return success();
 
-  if (isa<arith::IndexCastOp>(op)) {
+  if (isa<arith::IndexCastOp, arith::TruncIOp>(op)) {
     Value in = op->getOperand(0);
     Value out = op->getResult(0);
     if (failed(mgr_.mapSymbolicDimEqual(value2SymDim_[in], value2SymDim_[out])))

--- a/tao_compiler/mlir/disc/transforms/disc_shape_optimization_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_optimization_utils.cc
@@ -325,6 +325,14 @@ LogicalResult SymbolicDimMgr::mapSymbolicDimProductEqual(
   if (newLhs.factor == newRhs.factor && newLhs.symbols.size() == 1 &&
       newRhs.symbols.size() == 1) {
     return mapSymbolicDimEqual(newLhs.symbols[0], newRhs.symbols[0]);
+  } else if (newLhs.symbols.size() == 0 && newRhs.symbols.size() == 1 &&
+             newRhs.factor == 1) {
+    return mapSymbolicDimEqual(newConstantSymbolicDim(newLhs.factor),
+                               newRhs.symbols[0]);
+  } else if (newRhs.symbols.size() == 0 && newLhs.symbols.size() == 1 &&
+             newLhs.factor == 1) {
+    return mapSymbolicDimEqual(newConstantSymbolicDim(newRhs.factor),
+                               newLhs.symbols[0]);
   }
 
   productEqualityMap_[newLhs][newRhs] = productEqualityMap_[newRhs][newLhs] =


### PR DESCRIPTION
* propagate shape related info. through arith::trunci op
* simplify pattern like: `dynamic_reshape(tensor<8xf32>, ...) ->
  tensor<1x?xf32>` to `reshape<8xf32> -> tensor<1x8xf32>`