### PR TITLE
skip mark mhlo.where as shape calc op

### DIFF
--- a/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
+++ b/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
@@ -90,6 +90,19 @@ void DiscMarkShapeCalc::MarkShapeCalcOps() {
   }
 }
 
+// NOTE(lanbo.llb): mhlo.disc op will produce 2 outputs, the 2nd output is i64 tensor with single element
+// represent number of valid elements in the 1st output, this will be used to calc the final output
+// shape. It is indeed a shape calc, but where op should not be considered as shape calc op.
+// By marking it as shape calc op will cause mhlo_disc.where impossible to fuse in later fusion pass.
+bool with_input_from_where_op(Operation* op) {
+  for (Value operand : op->getOperands()) {
+    if (isa<mhlo_disc::WhereOp>(operand.getDefiningOp())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void DiscMarkShapeCalc::markShapeCalculationOps(
     func::FuncOp func, llvm::DenseSet<Operation*>& marked_ops) {
   auto& block = func.getBlocks().front();
@@ -100,7 +113,7 @@ void DiscMarkShapeCalc::markShapeCalculationOps(
     if (!marked_ops.contains(&op)) {
       // Mark following Ops into shape calculation set
       if (isa<mhlo::GetDimensionSizeOp, tensor::FromElementsOp,
-              tensor::ExtractOp>(&op)) {
+              tensor::ExtractOp>(&op) && !with_input_from_where_op(&op)) {
         marked_ops.insert(&op);
         continue;
       }

--- a/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
+++ b/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
@@ -90,11 +90,13 @@ void DiscMarkShapeCalc::MarkShapeCalcOps() {
   }
 }
 
-// NOTE(lanbo.llb): mhlo.disc op will produce 2 outputs, the 2nd output is i64 tensor with single element
-// represent number of valid elements in the 1st output, this will be used to calc the final output
-// shape. It is indeed a shape calc, but where op should not be considered as shape calc op.
-// By marking it as shape calc op will cause mhlo_disc.where impossible to fuse in later fusion pass.
-bool with_input_from_where_op(Operation* op) {
+// NOTE(lanbo.llb): mhlo.disc op will produce 2 outputs, the 2nd output is i64
+// tensor with single element represent number of valid elements in the 1st
+// output, this will be used to calc the final output shape. It is indeed a
+// shape calc, but where op should not be considered as shape calc op. By
+// marking it as shape calc op will cause mhlo_disc.where impossible to fuse in
+// later fusion pass.
+bool withInputFromWhereOp(Operation* op) {
   for (Value operand : op->getOperands()) {
     if (isa<mhlo_disc::WhereOp>(operand.getDefiningOp())) {
       return true;
@@ -113,7 +115,8 @@ void DiscMarkShapeCalc::markShapeCalculationOps(
     if (!marked_ops.contains(&op)) {
       // Mark following Ops into shape calculation set
       if (isa<mhlo::GetDimensionSizeOp, tensor::FromElementsOp,
-              tensor::ExtractOp>(&op) && !with_input_from_where_op(&op)) {
+              tensor::ExtractOp>(&op) &&
+          !withInputFromWhereOp(&op)) {
         marked_ops.insert(&op);
         continue;
       }

--- a/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
+++ b/tao_compiler/mlir/disc/transforms/mhlo_mark_shape_calc.cc
@@ -98,7 +98,8 @@ void DiscMarkShapeCalc::MarkShapeCalcOps() {
 // later fusion pass.
 bool withInputFromWhereOp(Operation* op) {
   for (Value operand : op->getOperands()) {
-    if (isa<mhlo_disc::WhereOp>(operand.getDefiningOp())) {
+    auto op = operand.getDefiningOp();
+    if (op != nullptr && isa<mhlo_disc::WhereOp>(op)) {
       return true;
     }
   }


### PR DESCRIPTION
This pr is prepared for `mhlo_disc.where` op's fusion implementation as mentioned in #742 

`mhlo.disc` op will produce 2 outputs, the 2nd output is i64 tensor with single element
represent number of valid elements in the 1st output, this will be used to calc the final output
shape used for `mhlo.real_dynamic_slice`.

 It is indeed a shape calculation, but where op should not be considered as shape calc op, it is more than that.
By marking it as shape calc op will cause `mhlo_disc.where` impossible to fuse in later fusion pass. Evenmore, the element-wise ops produces the input for `mhlo_disc.where` will be marked as shape calc ops, thus they also cannot be fused in later passes.

With changes from current pr, we can generate the following IR(no disc.shape_op attr for where op), which can be properly fused as we expected when we support fusion for  #`mhlo.where`.
```
module {
  func.func @main(%arg0: tensor<?x?x?xi64>) -> tensor<?x3xi64> {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c3 = arith.constant 3 : index
    %0 = mhlo.constant dense<0> : tensor<i64>
    %cst = arith.constant dense<1> : tensor<2xindex>
    %cst_0 = arith.constant dense<0> : tensor<2xindex>
    %dim = tensor.dim %arg0, %c0 : tensor<?x?x?xi64>
    %dim_1 = tensor.dim %arg0, %c1 : tensor<?x?x?xi64>
    %dim_2 = tensor.dim %arg0, %c2 : tensor<?x?x?xi64>
    %from_elements = tensor.from_elements %dim, %dim_1, %dim_2 {disc.shape_op = true} : tensor<3xindex>
    %1 = "mhlo.dynamic_broadcast_in_dim"(%0, %from_elements) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i64>, tensor<3xindex>) -> tensor<?x?x?xi64>
    %2 = mhlo.compare  NE, %arg0, %1 : (tensor<?x?x?xi64>, tensor<?x?x?xi64>) -> tensor<?x?x?xi1>
    %index, %num_output_elements = "mhlo_disc.where"(%2) : (tensor<?x?x?xi1>) -> (tensor<?x3xi64>, tensor<1xi64>)
    %extracted = tensor.extract %num_output_elements[%c0] : tensor<1xi64>
    %3 = arith.index_cast %extracted : i64 to index
    %from_elements_3 = tensor.from_elements %3, %c3 {disc.shape_op = true} : tensor<2xindex>
    %4 = mhlo.real_dynamic_slice %index, %cst_0, %from_elements_3, %cst : (tensor<?x3xi64>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x3xi64>
    return %4 : tensor<?x3xi64>
  }
}
```