### PR TITLE
[pdll] support more attribute types and add an e2e tf qgemm demo

### DIFF
--- a/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
@@ -87,7 +87,7 @@ def LHLO_CustomCallOp : LHLODISC_Op<"custom_call", [AttrSizedOperandSegments]> {
 
 // Models the behavior of the second version BladeDISC custom call.
 // TODO(wyzero): Merge with the old version once the refactor is done.
-def LHLODISC_CustomCallV2Op: LHLODISC_Op<"custom_call_v2", []> {
+def LHLODISC_CustomCallV2Op: Op<LHLODISC_Dialect, "custom_call_v2", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "CustomCallV2 operator";
   let description = [{
     A custom call invokes code external to BladeDISC. The `args` are passed to the

--- a/tao_compiler/mlir/disc/disc_util.cc
+++ b/tao_compiler/mlir/disc/disc_util.cc
@@ -218,6 +218,16 @@ bool useHorizontalFusion() {
   return enabled;
 }
 
+bool lowerFakeQuantToQuantAndDequant() {
+  static bool enabled = []() {
+    bool enabled = false;
+    tensorflow::ReadBoolFromEnvVar("DISC_FAKE_QUANT_TO_QUANT_AND_DEQUANT",
+                                   enabled, &enabled);
+    return enabled;
+  }();
+  return enabled;
+}
+
 bool isMemIntensiveOptExperimentalEnabled() {
   static bool enabled = []() {
     bool enabled = false;

--- a/tao_compiler/mlir/disc/disc_util.h
+++ b/tao_compiler/mlir/disc/disc_util.h
@@ -112,6 +112,9 @@ bool useShapeConstraintIR();
 // Returns true if `DISC_ENABLE_HORIZONTAL_FUSION` is true.
 bool useHorizontalFusion();
 
+// Returns true if `DISC_FAKE_QUANT_TO_QUANT_AND_DEQUANT` is true
+bool lowerFakeQuantToQuantAndDequant();
+
 // Returns true if `DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL` is true.
 bool isMemIntensiveOptExperimentalEnabled();
 

--- a/tao_compiler/mlir/disc/tests/pdll/data/qgemm_i8_per_channel.mlir
+++ b/tao_compiler/mlir/disc/tests/pdll/data/qgemm_i8_per_channel.mlir
@@ -1,0 +1,33 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%input: tensor<?x?xf32>) -> (tensor<?x71xf32>) attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %input_scale:2 = tf_executor.island wraps "tf.Const"() {value = dense<8.333333e-3> : tensor<f32>} : () -> tensor<f32>
+      %input_zero_point:2 = tf_executor.island wraps "tf.Const"() {value = dense<0> : tensor<i32>} : () -> tensor<i32>
+      %quantized_input:2 = tf_executor.island wraps "tf.DiscFakeQuant"(%input, %input_scale, %input_zero_point) {
+          axis = [], use_dynamic = false, use_signed = true, use_symmetric = true, num_bits = 8 : i64, quant_max = 127 : i64, quant_min = -128 : i64} :
+      (tensor<?x?xf32>, tensor<f32>, tensor<i32>) -> tensor<?x?xf32>
+
+      %weight:2 = tf_executor.island wraps "tf.Const"() {value = dense<-0.8> : tensor<25x71xf32>} : () -> tensor<25x71xf32>
+      %weight_scale:2 = tf_executor.island wraps "tf.Const"() {value = dense<1.568627e-2> : tensor<71xf32>} : () -> tensor<71xf32>
+      %weight_zero_point:2 = tf_executor.island wraps "tf.Const"() {value = dense<0> : tensor<71xi32>} : () -> tensor<71xi32>
+      %quantized_weight:2 = tf_executor.island wraps "tf.DiscFakeQuant"(%weight, %weight_scale, %weight_zero_point) {
+          axis = [1], use_dynamic = false, use_signed = true, use_symmetric = true, num_bits = 8 : i64, quant_max = 127 : i64, quant_min = -128 : i64} :
+      (tensor<25x71xf32>, tensor<71xf32>, tensor<71xi32>) -> tensor<25x71xf32>
+
+      %result:2 = tf_executor.island wraps "tf.MatMul"(%quantized_input, %quantized_weight)
+      {
+        transpose_a = false,
+        transpose_b = false
+      } : (tensor<?x?xf32>, tensor<25x71xf32>) -> tensor<?x71xf32>
+
+      %result_scale:2 = tf_executor.island wraps "tf.Const"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+      %result_zero_point:2 = tf_executor.island wraps "tf.Const"() {value = dense<0> : tensor<i32>} : () -> tensor<i32>
+      %quantized_result:2 = tf_executor.island wraps "tf.DiscFakeQuant"(%result, %result_scale, %result_zero_point) {
+          axis = [], use_dynamic = false, use_signed = true, use_symmetric = true, num_bits = 8 : i64, quant_max = 127 : i64, quant_min = -128 : i64} :
+      (tensor<?x71xf32>, tensor<f32>, tensor<i32>) -> tensor<?x71xf32>
+
+      tf_executor.fetch %quantized_result : tensor<?x71xf32>
+    }
+    return %graph : tensor<?x71xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/pdll/data/qgemm_i8_per_channel.pdll
+++ b/tao_compiler/mlir/disc/tests/pdll/data/qgemm_i8_per_channel.pdll
@@ -1,0 +1,45 @@
+Pattern TFFusedAddMul {
+  /// match phase: define the pattern
+  let inputQuant = op<mhlo_disc.quantize>(input : Value, inputScale : Value, inputZeroPoint : Value);
+  let inputDequant = op<mhlo_disc.dequantize>(inputQuant.0, inputScale, inputZeroPoint);
+
+  let weightQuant = op<mhlo_disc.quantize>(weight : Value, weightScale : Value, weightZeroPoint : Value);
+  let weightDequant = op<mhlo_disc.dequantize>(weightQuant.0, weightScale, weightZeroPoint);
+
+  let transpose_a_attr : Attr;
+  let transpose_b_attr : Attr;
+  let matmul = op<tf.MatMul>(inputDequant.0, weightDequant.0) {
+      transpose_a = transpose_a_attr,
+      transpose_b = transpose_b_attr
+  };
+
+  let resultQuant = op<mhlo_disc.quantize>(matmul.0, resultScale : Value, resultZeroPoint : Value);
+
+  /// rewrite phase
+  rewrite resultQuant with {
+    /// 1. create custom call op
+    let inputs = PackValue_8(
+        attr<"\"in\"">,
+        inputQuant.0, weightQuant.0,
+        inputScale, inputZeroPoint,
+        weightScale, weightZeroPoint,
+        resultScale, resultZeroPoint
+    );
+    let outputs = PackValue_1(attr<"\"out\"">, resultQuant.0);
+    let infos = CreateCustomCall(attr<"\"op\"">, inputs, outputs);
+
+    /// 2. set attrs that are used by bladedisc.
+    SetAttr(infos.op, attr<"\"call_target_name\"">, attr<"\"ral_pdll_qgemm\"">);
+    SetAttr(infos.op, attr<"\"device\"">, attr<"\"h\"">);
+    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"h,h,s,s,s,s,s,s\"">);
+    SetAttr(infos.op, attr<"\"output_placements\"">, attr<"\"h\"">);
+
+    /// 3. set attrs that are directly passed to the custom call kernel.
+    SetCustomAttr(infos.op, attr<"\"transpose_a\"">, transpose_a_attr);
+    SetCustomAttr(infos.op, attr<"\"transpose_b\"">, transpose_b_attr);
+    SetCustomAttr(infos.op, attr<"\"weight_is_const\"">, IsConstantTensor(weight));
+
+    let rs = UnpackValue_1(infos.new_outputs);
+    replace resultQuant with rs;
+  };
+}

--- a/tao_compiler/mlir/disc/tests/pdll/data/simple_fused_add_mul.pdll
+++ b/tao_compiler/mlir/disc/tests/pdll/data/simple_fused_add_mul.pdll
@@ -18,6 +18,15 @@ Pattern TFFusedAddMul {
 
     /// 3. set attrs that are directly passed to the custom call kernel.
     SetCustomAttr(infos.op, attr<"\"name\"">, attr<"\"disc.custom_call.test.tf_fused_add_mul\"">);
+    SetCustomAttr(infos.op, attr<"\"trueBoolAttr\"">, attr<"true">);
+    SetCustomAttr(infos.op, attr<"\"falseBoolAttr\"">, attr<"false">);
+    SetCustomAttr(infos.op, attr<"\"int127\"">, attr<"127">);
+    SetCustomAttr(infos.op, attr<"\"intNegative123456\"">, attr<"-123456">);
+    SetCustomAttr(infos.op, attr<"\"float0_001\"">, attr<"0.001">);
+    SetCustomAttr(infos.op, attr<"\"rank0I64DenseAttr\"">, attr<"dense<1> : tensor<i64>">);
+    SetCustomAttr(infos.op, attr<"\"rank1UI8DenseAttr\"">, attr<"dense<[1]> : tensor<1xui8>">);
+    SetCustomAttr(infos.op, attr<"\"rank2Shape2x3SplatBoolDenseAttr\"">, attr<"dense<1> : tensor<2x3xi1>">);
+    SetCustomAttr(infos.op, attr<"\"rank2Shape2x3SplatFloatDenseAttr\"">, attr<"dense<-0.01> : tensor<2x3xf32>">);
 
     let rs = UnpackValue_1(infos.new_outputs);
     replace mul with rs;

--- a/tao_compiler/mlir/disc/tests/pdll/qgemm.cc
+++ b/tao_compiler/mlir/disc/tests/pdll/qgemm.cc
@@ -1,0 +1,44 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/disc/tests/mlir_feature_test.h"
+#include "tensorflow/compiler/mlir/disc/tests/mlir_test.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace mlir_test {
+
+const std::string c_ft_path = "tensorflow/compiler/mlir/disc/tests/pdll/data/";
+
+TEST(SimpleTest, FusedAddMul) {
+  EnvSetting setting = {
+      {"DISC_TF_PDLL_FILES", {c_ft_path + "qgemm_i8_per_channel.pdll", false}},
+      {"DISC_FAKE_QUANT_TO_QUANT_AND_DEQUANT", {"true", false}}};
+  EnvSettingContext ctx(setting);
+  std::vector<float> inputs(4 * 25, -0.6);
+  tensorflow::Tensor output(tensorflow::DataType::DT_FLOAT, {4, 71});
+  auto datas = output.flat<float>();
+  for (int i = 0; i < output.NumElements(); ++i) datas(i) = 12.0;
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "qgemm_i8_per_channel.mlir",
+      /*backend_types*/ {BackendType::kAArch64},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"4x25xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {inputs},
+      /*expect_output_vals*/ {output}));
+}
+
+}  // namespace mlir_test

--- a/tao_compiler/mlir/xla/ral/BUILD
+++ b/tao_compiler/mlir/xla/ral/BUILD
@@ -152,7 +152,10 @@ cc_library(
     name = "pdll_util",
     srcs = ["context/pdll_util.cc"],
     hdrs = ["context/pdll_util.h"],
-    deps = [":ral_logging"],
+    deps = [
+        ":ral_context",
+        ":ral_logging",
+    ],
     alwayslink = 1,
 )
 

--- a/tao_compiler/mlir/xla/ral/context/common_context_impl_quantization.cc
+++ b/tao_compiler/mlir/xla/ral/context/common_context_impl_quantization.cc
@@ -11,10 +11,11 @@
 
 #if defined(TAO_CPU_ONLY)
 
-#include <sstream>
 #include <thread>
 
 #include "tensorflow/compiler/mlir/xla/ral/context/common_context_impl_mkldnn.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/pdll_util.h"
+#include "tensorflow/compiler/mlir/xla/ral/device/cpu/cpu_driver.h"
 
 // aarch64 related
 #if defined(TAO_AARCH64)
@@ -362,7 +363,7 @@ void ral_qgemm_acl_s8_s8_s8_per_channel(
     MemRefType<int8_t, 2> result, bool tp_a, bool tp_b, bool weight_is_const) {
   CpuTimer timer("ral_cpu_qgemm");
   if (isEmptyMemref(input) || isEmptyMemref(weight) || isEmptyMemref(result)) {
-    TAO_VLOG(1) << "ral_cpu_batch_gemm: early return for empty tensor";
+    TAO_VLOG(1) << "ral_cpu_qgemm: early return for empty tensor";
     return;
   }
 
@@ -490,6 +491,163 @@ void ral_qgemm_acl_s8_s8_s8_per_channel(
                 << "\n";
   }
 }
+
+MemRefType<int8_t, 2> ral_pdll_qgemm_acl_s8_s8_s8_per_channel(
+    ExecutionContext* ctx, opaque_t /*stream_handle*/,
+    MemRefType<int8_t, 2> input, MemRefType<int8_t, 2> weight,
+    MemRefType<float, 0> inputScales, MemRefType<int32_t, 0> inputZeroPoints,
+    MemRefType<float, 1> weightScales, MemRefType<int32_t, 1> weightZeroPoints,
+    MemRefType<float, 0> resultScales, MemRefType<int32_t, 0> resultZeroPoints,
+    void* customAttrs) {
+  CpuTimer timer("ral_cpu_qgemm");
+  int64_t resultSizes[2] = {0, 0};
+  if (isEmptyMemref(input) || isEmptyMemref(weight)) {
+    TAO_VLOG(1) << "ral_cpu_qgemm: early return for empty tensor";
+    return assignMemRef<int8_t, 2>(nullptr, resultSizes);
+  }
+
+  auto attr = getOrParsePDLAttr(ctx, customAttrs,
+                                "ral_pdll_qgemm_acl_s8_s8_s8_per_channel");
+  if (!attr) {
+    ctx->signalError(Context::FAILURE, "fail to parse custom_attrs\n");
+  }
+
+  // ACL GEMM kernel does not support transpose.
+  // TODO(wyzero): use standalone ACL transpose kernel to imitate.
+  auto& dictAttr = attr->as<DictPDLAttr>();
+  bool tp_a = dictAttr.get("transpose_a").as<BoolPDLAttr>().getValue();
+  bool tp_b = dictAttr.get("transpose_b").as<BoolPDLAttr>().getValue();
+  bool weight_is_const =
+      dictAttr.get("weight_is_const").as<BoolPDLAttr>().getValue();
+  if (tp_a || tp_b) {
+    ctx->signalError(Context::FAILURE,
+                     "not supported ral_qgemm with transpose");
+  }
+
+  // Make sure thread pool configuration is set.
+  applyACLThreadPoolConfigIfNotSet();
+
+  int64_t m = tp_a ? input.sizes[1] : input.sizes[0];
+  int64_t k = tp_a ? input.sizes[0] : input.sizes[1];
+  if (k != (tp_b ? weight.sizes[1] : weight.sizes[0])) {
+    ctx->signalError(Context::FAILURE, "mismatch contraction dim for gemm");
+  }
+  int64_t n = (tp_b ? weight.sizes[0] : weight.sizes[1]);
+
+  auto driver = ctx->getDriver<cpu::CPUDriver>(cpu::CPUDriver::name());
+  auto data = static_cast<int8_t*>(driver->alloc(ctx, m * n * sizeof(int8_t)));
+  resultSizes[0] = m;
+  resultSizes[1] = n;
+  auto result = assignMemRef<int8_t, 2>(data, resultSizes);
+
+  auto AclQGemmCreator = [&](const arm_compute::ITensorPack* pack) {
+    std::shared_ptr<AclQGemmInfo> info(new AclQGemmInfo);
+    auto src_shape = TensorShape(k, m);
+    auto weights_shape = TensorShape(n, k);
+    auto dst_shape = TensorShape(n, m);
+
+    DataType data_type = DataType::QASYMM8_SIGNED;
+    TensorInfo src_info = TensorInfo(src_shape, 1, data_type);
+    TensorInfo weights_info =
+        TensorInfo(weights_shape, 1, DataType::QSYMM8_PER_CHANNEL);
+    TensorInfo dst_info = TensorInfo(dst_shape, 1, data_type);
+
+    src_info.set_quantization_info(
+        QuantizationInfo(*inputScales.data, *inputZeroPoints.data));
+    std::vector<float> scales(weightScales.data,
+                              weightScales.data + weightScales.sizes[0]);
+    std::vector<int32_t> zero_points(
+        weightZeroPoints.data,
+        weightZeroPoints.data + weightZeroPoints.sizes[0]);
+    weights_info.set_quantization_info(
+        QuantizationInfo(std::move(scales), std::move(zero_points)));
+    dst_info.set_quantization_info(
+        QuantizationInfo(*resultScales.data, *resultZeroPoints.data));
+
+    info->src.allocator()->init(src_info);
+    info->weights.allocator()->init(weights_info);
+    info->dst.allocator()->init(dst_info);
+    info->src.allocator()->import_memory(input.data);
+    info->weights.allocator()->import_memory(weight.data);
+    info->dst.allocator()->import_memory(result.data);
+
+    arm_compute::GEMMLowpOutputStageInfo osInfo;
+    osInfo.type =
+        arm_compute::GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
+    osInfo.gemmlowp_offset = *resultZeroPoints.data;
+    osInfo.output_data_type = data_type;
+    osInfo.is_quantized_per_channel = true;
+    arm_compute::quantization::calculate_quantized_multipliers(
+        src_info.quantization_info(), weights_info.quantization_info(),
+        dst_info.quantization_info(), osInfo);
+    arm_compute::GEMMInfo gemmInfo;
+    gemmInfo.set_gemmlowp_output_stage(osInfo);
+
+    auto status = info->op.validate(&src_info, &weights_info, nullptr,
+                                    &dst_info, gemmInfo);
+    if (!status) {
+      ctx->signalError(
+          Context::FAILURE,
+          "fail to validate ral_qgemm_acl_s8_s8_s8_per_channel conv: " +
+              status.error_description());
+    } else {
+      info->op.configure(&info->src, &info->weights, nullptr, &info->dst,
+                         gemmInfo);
+    }
+    if (pack) info->op.reuse_packed_weight(*pack);
+    info->op.prepare(&info->src, &info->weights, nullptr, &info->dst);
+    return info;
+  };
+
+  std::shared_ptr<AclQGemmInfo> info;
+  std::shared_ptr<AclQGemmThreadSafeInfo> thread_safe_info;
+  if (isWeightPrePackingForMatMulEnabled() && weight_is_const) {
+    std::string unique_name = "disc.ral_qgemm_acl_s8_s8_s8_per_channel";
+    auto state = ctx->getOrCreateResource<AclQGemmState>(
+        unique_name, []() { return new AclQGemmState; });
+    auto key = makeGEMMParamsKey(input, weight, result, tp_a, tp_b,
+                                 weight_is_const, kDiscCpuDefaultThreadId);
+    auto dynamicKey =
+        makeDynamicShapeGEMMParamsKey(input, weight, result, tp_a, tp_b,
+                                      weight_is_const, kDiscCpuDefaultThreadId);
+    thread_safe_info = state->getOrCreate(dynamicKey);
+    info = thread_safe_info->getOrCreate(key, AclQGemmCreator);
+  } else {
+    info = AclQGemmCreator(nullptr);
+  }
+
+  // TOOD(disc): re-import quantization info when online-quantization is
+  // supported.
+  info->src.allocator()->import_memory(input.data);
+  info->dst.allocator()->import_memory(result.data);
+  info->op.run(&info->src, &info->weights, nullptr, &info->dst);
+
+  timer.Stop();
+
+  if (isProfilingEnabled()) {
+    int64_t bytes = sizeof(int8_t) * m * k + sizeof(int8_t) * k * n +
+                    sizeof(int8_t) * m * n;
+    TAO_VLOG(0) << "ral_cpu_gemm:\n"
+                << "\tpa = " << input.data << "\n"
+                << "\tpb = " << weight.data << "\n"
+                << "\tpc = " << result.data << "\n"
+                << "\tm = " << m << "\n"
+                << "\tn = " << n << "\n"
+                << "\tk = " << k << "\n"
+                << "\ttp_a = " << tp_a << "\n"
+                << "\ttp_b = " << tp_b << "\n"
+                << "\tweight_is_const = " << weight_is_const << "\n"
+                << "\tMath Ops = " << 2 * m * n * k << "\n"
+                << "\tBytes = " << bytes << "\n"
+                << "\tBandwidth = "
+                << double(bytes) / double(timer.GetNanoSeconds()) << " GB\n"
+                << "\tGFLOPS = "
+                << double(2 * m * n * k) / double(timer.GetNanoSeconds())
+                << "\n";
+  }
+  return result;
+}
+
 #endif  // TAO_AARCH64
 
 #if defined(TAO_X86)
@@ -580,6 +738,8 @@ TAO_RAL_API("ral_qconv_s8_s8_s8", "cpu", ral_qconv_s8_s8_s8<4>);
 TAO_RAL_API("ral_qconv", "cpu", ral_qconv_acl_s8_s8_s8_per_channel<4>);
 
 TAO_RAL_API("ral_qgemm", "cpu", ral_qgemm_acl_s8_s8_s8_per_channel);
+
+TAO_RAL_API("ral_pdll_qgemm", "cpu", ral_pdll_qgemm_acl_s8_s8_s8_per_channel);
 #endif  // TAO_AARCH64
 
 #if defined(TAO_X86)

--- a/tao_compiler/mlir/xla/ral/ral_context.cc
+++ b/tao_compiler/mlir/xla/ral/ral_context.cc
@@ -186,7 +186,7 @@ void Context::signalErrorLocked(status_t errcode, const std::string& err_msg) {
   Impl::Status st;
   st.errcode = errcode;
   st.err_msg = err_msg;
-  TAO_VLOG(0) << "[[ERROR]] Context catch an exception: " << err_msg;
+  TAO_LOG(FATAL) << "[[ERROR]] Context catch an exception: " << err_msg;
   impl_->global_status.merge(st);
 }
 

--- a/tao_compiler/mlir/xla/ral/ral_logging.h
+++ b/tao_compiler/mlir/xla/ral/ral_logging.h
@@ -121,6 +121,9 @@ class LogMessageNull : public std::basic_ostringstream<char> {
           ::tao::ral::internal::LogMessage(__FILE__, __LINE__, \
                                            ::tao::ral::INFO)
 
+#define TAO_CHECK(expr) \
+  while (!(expr)) TAO_LOG(FATAL) << "TAO_CHECK failed: "
+
 }  // namespace ral
 }  // namespace tao
 


### PR DESCRIPTION
1, support BoolAttr/IntegerAttr/FloatAttr/DenseElementsAttr. Add UTs for these attribute types as well.

2, add an E2E TF QGEMM UT based on PDLL. Currently it's disable by default. We'll eventually change to PDLL based method by default after we do more evalutations.