### PR TITLE
Explict type casting to avoid compilation error

### DIFF
--- a/tao_compiler/mlir/xla/ral/context/custom_library/transpose_gpu.cu.cc
+++ b/tao_compiler/mlir/xla/ral/context/custom_library/transpose_gpu.cu.cc
@@ -37,11 +37,13 @@ void LaunchTransposeKernel(cudaStream_t stream, T* input,
   static constexpr int64_t tile_size = 32;
   static constexpr int64_t num_threads = 256;
   Dimension<3> input_dims_in_tiles = {
-      input_dims[0],
-      CeilOfRatio(input_dims[1], tile_size),
-      CeilOfRatio(input_dims[2], tile_size),
+      static_cast<int>(input_dims[0]),
+      static_cast<int>(CeilOfRatio(input_dims[1], tile_size)),
+      static_cast<int>(CeilOfRatio(input_dims[2], tile_size)),
   };
-  Dimension<3> dims = {input_dims[0], input_dims[1], input_dims[2]};
+  Dimension<3> dims = {static_cast<int>(input_dims[0]),
+                       static_cast<int>(input_dims[1]),
+                       static_cast<int>(input_dims[2])};
 
   int total_tiles_count =
       input_dims_in_tiles[0] * input_dims_in_tiles[1] * input_dims_in_tiles[2];


### PR DESCRIPTION
narrowing convertion in array initializer list is not allowed by c++11, make the casting explicitly to avoid compiliation error.