### PR TITLE
[transform] legalize a lmhlo fusion op to linalg

### DIFF
--- a/scripts/python/tao_build.py
+++ b/scripts/python/tao_build.py
@@ -403,6 +403,9 @@ def test_tao_compiler(root, args):
     TARGET_DISC_CUDA_SOURCE_TESTS = [
         "//tensorflow/compiler/mlir/disc/tools/disc-source-emitter/tests/..."
     ]
+    TARGET_DISC_TRANSFORM_DIALECT_TESTS = [
+        "//tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/tests/..."
+    ]
 
     TARGET_DISC_REPLAY_TEST = "//tensorflow/compiler/mlir/disc/tools/disc-replay:disc-replay-test"
 
@@ -439,7 +442,8 @@ def test_tao_compiler(root, args):
                 TARGET_DISC_TRANSFORMS_TEST,
                 TARGET_DISC_E2E_TEST,
             ] + TARGET_DISC_RAL_TESTS \
-              + TARGET_DISC_PDLL_TESTS
+              + TARGET_DISC_PDLL_TESTS \
+              + TARGET_DISC_TRANSFORM_DIALECT_TESTS
             MLIR_TESTS = " ".join(mlir_test_list)
             bazel_test(MLIR_TESTS, flag=flag)
         else:
@@ -465,7 +469,8 @@ def test_tao_compiler(root, args):
                 TARGET_DISC_REPLAY_TEST,
             ] + TARGET_DISC_RAL_TESTS \
               + TARGET_DISC_PDLL_TESTS \
-              + TARGET_DISC_CUDA_SOURCE_TESTS
+              + TARGET_DISC_CUDA_SOURCE_TESTS \
+              + TARGET_DISC_TRANSFORM_DIALECT_TESTS
             MLIR_TESTS = " ".join(mlir_tests_list)
             bazel_test(MLIR_TESTS, flag=flag)
             flag += " --action_env=BRIDGE_ENABLE_TAO=true "

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -2019,6 +2019,7 @@ cc_library(
         ":disc_function_dead_argument_elimination",
         ":disc_side_effect_loop_invariant_code_motion",
         ":disc_unhandled_atomic_rmw_converter",
+        "//tensorflow/compiler/mlir/disc/tools/disc-transform:all_passes",
         "@llvm-project//mlir:Pass",
     ],
     alwayslink = 1,

--- a/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
+++ b/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/disc/IR/disc_shape_ops.h"
 #include "tensorflow/compiler/mlir/disc/IR/hlo_disc_ops.h"
 #include "tensorflow/compiler/mlir/disc/IR/lhlo_disc_ops.h"
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/register_passes.h"
 #include "tensorflow/compiler/mlir/disc/transforms/register_passes.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
 
@@ -34,6 +35,7 @@ int main(int argc, char** argv) {
   mlir::mhlo::registerAllMhloPasses();
   mlir::lmhlo::registerAllLmhloPasses();
   mlir::disc_ral::registerAllDiscPasses();
+  mlir::disc_ral::registerAllDiscTransformPasses();
   mlir::mhlo_disc::registerAllMhloDiscPasses();
 
   mlir::DialectRegistry registry;

--- a/tao_compiler/mlir/disc/tools/disc-transform/BUILD
+++ b/tao_compiler/mlir/disc/tools/disc-transform/BUILD
@@ -1,0 +1,90 @@
+load(
+    "@org_tensorflow//tensorflow:tensorflow.bzl",
+    "get_compatible_with_cloud",
+)
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
+
+package(
+    default_visibility = [":friends"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+package_group(
+    name = "friends",
+    packages = [
+        "//tensorflow/compiler/mlir/...",
+        "//tensorflow/compiler/tf2xla/...",
+        "//tensorflow/compiler/xla/...",
+        "//tensorflow/compiler/...",
+    ],
+)
+
+gentbl_cc_library(
+    name = "TransformPassIncGen",
+    compatible_with = get_compatible_with_cloud(),
+    strip_include_prefix = "",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=DISCTransform",
+            ],
+            "transforms/transform_passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "transforms/transform_passes.td",
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "pass_details",
+    hdrs = [
+        "transforms/PassDetail.h",
+    ],
+    visibility = [
+        "//visibility:private",  # This target is a private detail of pass implementations
+    ],
+    deps = [
+        ":TransformPassIncGen",
+        "@llvm-project//mlir:Pass",
+    ],
+)
+
+cc_library(
+    name = "legalize_lmhlo_fusion_to_linalg",
+    srcs = ["transforms/legalize_lmhlo_fusion_to_linalg.cc"],
+    deps = [
+        ":pass_details",
+        "//tensorflow/compiler/xla/mlir_hlo:lhlo",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "all_passes",
+    hdrs = [
+        "transforms/passes.h",
+        "transforms/register_passes.h",
+    ],
+    visibility = [
+        ":friends",
+    ],
+    deps = [
+        ":legalize_lmhlo_fusion_to_linalg",
+        "@llvm-project//mlir:Pass",
+    ],
+    alwayslink = 1,
+)

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/PassDetail.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/PassDetail.h
@@ -1,0 +1,65 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSDETAIL_H_
+#define DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSDETAIL_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+class AffineDialect;
+
+namespace NVVM {
+class NVVMDialect;
+}
+
+namespace ROCDL {
+class ROCDLDialect;
+}
+
+namespace math {
+class MathDialect;
+}
+
+namespace memref {
+class MemRefDialect;
+}
+
+namespace scf {
+class SCFDialect;
+}
+
+namespace shape {
+class ShapeDialect;
+}
+
+namespace mhlo {
+class MhloDialect;
+}
+
+namespace arith {
+class ArithDialect;
+}
+
+namespace disc_ral {
+
+#define GEN_PASS_CLASSES
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.h.inc"
+
+}  // namespace disc_ral
+}  // namespace mlir
+
+#endif  // DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSDETAIL_H_

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/legalize_lmhlo_fusion_to_linalg.cc
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/legalize_lmhlo_fusion_to_linalg.cc
@@ -1,0 +1,180 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/Support/Debug.h"
+#include "mlir-hlo/Dialect/lhlo/IR/lhlo_ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/PassDetail.h"
+
+#define DEBUG_TYPE "disc-legalize-lmhlo-fusion-to-linalg"
+
+// This file implements the logic to convert a lmhlo fusion op in side a
+// function to its linalg on tensor equivalent.
+//
+// Assume: Each candidate function should only have one lhlo fusion + one return
+// ops. Example convert from:
+// ```
+//  func.func @name(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C:
+//  memref<?x?xf32>) {
+//    "lmhlo.fusion"() ({
+//      "lmhlo.dot_general"(%A, %B, %C) {...}
+//      "lmhlo.terminator"() : () -> ()
+//    })
+//    return %arg3 : memref<?x?xf32>
+//  }
+// to:
+//  func.func @name(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C:
+//  tensor<?x?xf32>) {
+//    %0 = linalg.matmul(%A, %B, ...)
+//    return %0 : tensor<?x?xf32>
+//  }
+
+namespace mlir {
+namespace disc_ral {
+namespace {
+
+using func::FuncOp;
+
+struct DiscLegalizeLmhloFusionToLinalgPass
+    : public DiscLegalizeLmhloFusionToLinalgPassBase<
+          DiscLegalizeLmhloFusionToLinalgPass> {
+  void runOnOperation() override;
+};
+
+Type convertMemRefToTensorType(Type type) {
+  auto memrefTy = type.cast<MemRefType>();
+  return RankedTensorType::get(memrefTy.getShape(), memrefTy.getElementType());
+}
+
+SmallVector<Type> convertMemRefToTensorType(TypeRange range) {
+  SmallVector<Type> newTypes;
+  for (Type type : range) newTypes.push_back(convertMemRefToTensorType(type));
+  return newTypes;
+}
+
+// forward decalration.
+LogicalResult emitOp(Operation* op, OpBuilder& b,
+                     BlockAndValueMapping& mapping);
+
+LogicalResult emitReturnOp(func::ReturnOp op, OpBuilder& b,
+                           BlockAndValueMapping& mapping) {
+  SmallVector<Value> newOperands;
+  for (Value v : op->getOperands()) newOperands.push_back(mapping.lookup(v));
+  b.create<func::ReturnOp>(op.getLoc(), newOperands);
+  return success();
+}
+
+LogicalResult emitDotGeneralOp(lmhlo::DotGeneralOp op, OpBuilder& b,
+                               BlockAndValueMapping& mapping) {
+  Value A = op->getOperand(0);
+  Value B = op->getOperand(1);
+  Value C = op->getOperand(2);
+
+  Value newA = mapping.lookup(A);
+  Value newB = mapping.lookup(B);
+  Value newC = mapping.lookup(C);
+
+  // firstly fill the output buffer using zero.
+  auto ty = newC.getType().cast<ShapedType>();
+  auto zeroAttr = b.getZeroAttr(ty.getElementType());
+  Location loc = op->getLoc();
+  Value zero = b.create<arith::ConstantOp>(loc, zeroAttr);
+  Value t0 = b.create<linalg::FillOp>(loc, zero, newC).result();
+  Value t1 =
+      b.create<linalg::MatmulOp>(loc, ValueRange{newA, newB}, ValueRange{t0})
+          .getResult(0);
+  mapping.erase(C);
+  mapping.map(C, t1);
+
+  return success();
+}
+
+LogicalResult emitLmhloOp(Operation* op, OpBuilder& b,
+                          BlockAndValueMapping& mapping) {
+  if (auto dotGeneralOp = dyn_cast<lmhlo::DotGeneralOp>(op)) {
+    return emitDotGeneralOp(dotGeneralOp, b, mapping);
+  }
+  // TODO(wyzero): support other lmhlo ops.
+  return failure();
+}
+
+LogicalResult emitLmhloFusionOp(lmhlo::FusionOp op, OpBuilder& b,
+                                BlockAndValueMapping& mapping) {
+  for (Operation& op : op.getRegion().getBlocks().front()) {
+    if (isa<lmhlo::TerminatorOp>(&op)) continue;
+    if (failed(emitLmhloOp(&op, b, mapping))) return failure();
+  }
+  return success();
+}
+
+LogicalResult emitOp(Operation* op, OpBuilder& b,
+                     BlockAndValueMapping& mapping) {
+  if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
+    return emitReturnOp(returnOp, b, mapping);
+  } else if (auto fusionOp = dyn_cast<lmhlo::FusionOp>(op)) {
+    return emitLmhloFusionOp(fusionOp, b, mapping);
+  }
+  return failure();
+}
+
+LogicalResult rewriteFuncOp(FuncOp func, FuncOp& newFunc) {
+  if (func.getBody().getBlocks().size() != 1) return failure();
+  if (func.getBody().front().getOperations().size() != 2) return failure();
+  auto fusionOp = dyn_cast<lmhlo::FusionOp>(
+      &func.getBody().front().getOperations().front());
+  if (!fusionOp) return failure();
+
+  OpBuilder b(func.getContext());
+  auto newArgumentTypes = convertMemRefToTensorType(func.getArgumentTypes());
+  auto newResultTypes = convertMemRefToTensorType(func.getResultTypes());
+  auto newFuncType =
+      FunctionType::get(func->getContext(), newArgumentTypes, newResultTypes);
+  newFunc = b.create<FuncOp>(func.getLoc(), func.getName(), newFuncType);
+  Block* entryBlock = newFunc.addEntryBlock();
+  BlockAndValueMapping mapping;
+  for (const auto& z :
+       llvm::zip(func.getArguments(), entryBlock->getArguments()))
+    mapping.map(std::get<0>(z), std::get<1>(z));
+  b.setInsertionPoint(entryBlock, entryBlock->begin());
+  for (Operation& op : func.getBody().front().getOperations())
+    if (failed(emitOp(&op, b, mapping))) return failure();
+  return success();
+}
+
+void DiscLegalizeLmhloFusionToLinalgPass::runOnOperation() {
+  for (FuncOp funcOp :
+       llvm::to_vector<4>(getOperation().getOps<func::FuncOp>())) {
+    FuncOp newFuncOp;
+    if (failed(rewriteFuncOp(funcOp, newFuncOp))) {
+      signalPassFailure();
+      return;
+    }
+    funcOp->erase();
+    getOperation().push_back(newFuncOp);
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createDiscLegalizeLmhloFusionToLinalgPass() {
+  return std::make_unique<DiscLegalizeLmhloFusionToLinalgPass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/passes.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/passes.h
@@ -1,0 +1,42 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSES_H_
+#define DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSES_H_
+
+#include <memory>
+
+namespace mlir {
+
+class FuncOp;
+class FunctionPass;
+class ModuleOp;
+class Operation;
+class Pass;
+
+template <typename T>
+class OperationPass;
+
+namespace disc_ral {
+
+// Converts a lmhlo fusion op in side a function to its linalg on tensor
+// equivalent.
+std::unique_ptr<OperationPass<ModuleOp>>
+createDiscLegalizeLmhloFusionToLinalgPass();
+
+}  // namespace disc_ral
+}  // namespace mlir
+
+#endif  // DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_PASSES_H_

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/register_passes.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/register_passes.h
@@ -1,0 +1,33 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_REGISTER_PASSES_H_
+#define DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_REGISTER_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/passes.h"
+
+namespace mlir {
+namespace disc_ral {
+
+#define GEN_PASS_REGISTRATION
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.h.inc"
+
+inline void registerAllDiscTransformPasses() { registerDISCTransformPasses(); }
+
+}  // namespace disc_ral
+}  // namespace mlir
+
+#endif  // DISC_TOOLS_DISC_TRANSFORM_TRANSFORMS_REGISTER_PASSES_H_

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/BUILD
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/BUILD
@@ -1,0 +1,20 @@
+load("//tensorflow:tensorflow.bzl", "filegroup")
+load("//tensorflow/compiler/mlir/disc:glob_lit_test.bzl", "glob_lit_tests")
+
+package(licenses = ["notice"])
+
+glob_lit_tests(
+    data = [":test_utilities"],
+    driver = "@llvm-project//mlir:run_lit.sh",
+    test_file_exts = ["mlir"],
+)
+
+# Bundle together all of the test utilities that are used by tests.
+filegroup(
+    name = "test_utilities",
+    testonly = True,
+    data = [
+        "//tensorflow/compiler/mlir/disc:disc-opt",
+        "@llvm-project//llvm:FileCheck",
+    ],
+)

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/legalize-lmhlo-fusion-to-linalg.mlir
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/legalize-lmhlo-fusion-to-linalg.mlir
@@ -1,0 +1,15 @@
+// RUN: disc-opt --disc-legalize-lmhlo-fusion-to-linalg -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @matmul_nn
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>, %[[ARG2:.*]]: tensor<?x?xf32>)
+func.func @matmul_nn(%arg1: memref<?x?xf32, "cpu">, %arg2: memref<?x?xf32, "cpu">, %arg3: memref<?x?xf32, "cpu">) -> memref<?x?xf32, "cpu"> {
+  // CHECK: %[[T0:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[T1:.*]] = linalg.fill ins(%[[T0]] : f32) outs(%[[ARG2]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[T2:.*]] = linalg.matmul ins(%[[ARG0]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[T1]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: return %[[T2]]
+  "lmhlo.fusion"() ({
+    "lmhlo.dot_general"(%arg1, %arg2, %arg3) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x?xf32, "cpu">, memref<?x?xf32, "cpu">, memref<?x?xf32, "cpu">) -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) {disc.device = "cpu", disc.fusion.name = "matmul_nn_kTransform_dot_general__1_1_0", disc.fusion_type = "kTransform"} : () -> ()
+  return %arg3 : memref<?x?xf32, "cpu">
+}

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.td
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.td
@@ -1,0 +1,21 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+include "mlir/Pass/PassBase.td"
+
+def DiscLegalizeLmhloFusionToLinalgPass : Pass<"disc-legalize-lmhlo-fusion-to-linalg", "ModuleOp"> {
+  let summary = "Pass to convert a lmhlo fusion op to linalg on tensor.";
+  let constructor = "createDiscLegalizeLmhloFusionToLinalgPass()";
+}


### PR DESCRIPTION
An example is shown as following. Convert from:
```
 func.func @name(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C:
 memref<?x?xf32>) {
   "lmhlo.fusion"() ({
     "lmhlo.dot_general"(%A, %B, %C) {...}
     "lmhlo.terminator"() : () -> ()
   })
   return %arg3 : memref<?x?xf32>
 }
```

to:

```
 func.func @name(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>, %C:
 tensor<?x?xf32>) {
   %0 = linalg.fill(...)
   %1 = linalg.matmul(%A, %B, ...)
   return %1 : tensor<?x?xf32>
 }
```