### PR TITLE
Fix Bert amp example type promotion fail

### DIFF
--- a/examples/PyTorch/Inference/CUDA/BERT/main.py
+++ b/examples/PyTorch/Inference/CUDA/BERT/main.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import argparse
 import os
 
 # Enable stitch fusion optimization.
@@ -248,6 +248,11 @@ def blade_trt_optimize(model, inputs, fp16: bool, is_static: bool,
 
 
 def run():
+    parser = argparse.ArgumentParser(prog = 'BladeDISC Bert example')
+    parser.add_argument('--disc-only', help = "Run BladeDISC only",
+                    action='store_true')  # on/off flag
+    args = parser.parse_args()
+
     batch = 1
     seq = 64
     bert_large = get_torch_bert_large_model(amp=False)
@@ -264,6 +269,9 @@ def run():
     disc_optimize(bert_large_amp, inputs, 'bert_large_amp.disc.pt')
     model = torch.jit.load('bert_large_amp.disc.pt').cuda().eval()
     evaluate_torch(model, inputs)
+
+    if args.disc_only:
+        return
 
     # Run TensorRT with `trtexec`. Static shape optimization.
     print("Official TensorRT Static Optimization.")

--- a/examples/PyTorch/Inference/CUDA/BERT/requirements.txt
+++ b/examples/PyTorch/Inference/CUDA/BERT/requirements.txt
@@ -1,2 +1,1 @@
 transformers
-git+https://github.com/Media-Smart/volksdep.git

--- a/examples/PyTorch/Inference/CUDA/BERT/test.sh
+++ b/examples/PyTorch/Inference/CUDA/BERT/test.sh
@@ -14,7 +14,9 @@ script_dir=$(cd $(dirname "$0"); pwd)
 pushd $script_dir
 echo DIR: $(pwd)
 
+export PYTORCH_JIT_LOG_LEVEL=">>>mhlo_conversion.cpp"
+export TENSORRT_INSTALL_PATH=${TENSORRT_INSTALL_PATH:-/usr/local/TensorRT/}
+export LD_LIBRARY_PATH=${TENSORRT_INSTALL_PATH}/lib/:${TENSORRT_INSTALL_PATH}/lib64/:${CUDA_HOME}/lib64:$LD_LIBRARY_PATH
 pip3 install -r requirements.txt
-python3 main.py
-
+python3 main.py --disc-only
 popd

--- a/pytorch_blade/pytorch_blade/BUILD
+++ b/pytorch_blade/pytorch_blade/BUILD
@@ -24,6 +24,7 @@ cc_library(
     deps = [
         "//pytorch_blade/common_utils:torch_blade_common",
         "//pytorch_blade/compiler/backends:torch_blade_backends",
+        "//pytorch_blade/compiler/jit:aten_custom_ops",
         "//pytorch_blade/compiler/jit:torch_blade_jit",
         "//pytorch_blade/compiler/mlir:torch_blade_mlir",
         "@local_org_torch//:libtorch",

--- a/pytorch_blade/pytorch_blade/compiler/jit/BUILD
+++ b/pytorch_blade/pytorch_blade/compiler/jit/BUILD
@@ -31,6 +31,15 @@ cc_library(
 )
 
 cc_library(
+    name = "aten_custom_ops",
+    srcs = ["aten_custom_ops.cpp"],
+    deps = [
+        "@local_org_torch//:libtorch",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
     name = "tool_funcs",
     srcs = ["tool_funcs.cpp"],
     hdrs = ["tool_funcs.h"],
@@ -72,6 +81,7 @@ cc_test(
     ],
     linkstatic = True,
     deps = [
+        ":aten_custom_ops",
         ":tool_funcs",
         ":torch_blade_jit",
         "//pytorch_blade/common_utils:torch_blade_common",

--- a/pytorch_blade/pytorch_blade/compiler/jit/aten_custom_ops.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/aten_custom_ops.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/script.h>
+namespace torch {
+namespace blade {
+namespace {
+#define WRAPPER_ADDSUB_TENSOR(func) \
+  at::Tensor wrapper_##func(        \
+      const at::Tensor& self,       \
+      const at::Tensor& other,      \
+      const at::Scalar& alpha) {    \
+    return self.func(other, alpha); \
+  }
+
+#define WRAPPER_MULDIV_TENSOR(func)                                            \
+  at::Tensor wrapper_##func(const at::Tensor& self, const at::Tensor& other) { \
+    return self.func(other);                                                   \
+  }
+
+WRAPPER_ADDSUB_TENSOR(add);
+WRAPPER_ADDSUB_TENSOR(add_);
+WRAPPER_ADDSUB_TENSOR(sub);
+WRAPPER_ADDSUB_TENSOR(sub_);
+WRAPPER_MULDIV_TENSOR(mul);
+WRAPPER_MULDIV_TENSOR(mul_);
+WRAPPER_MULDIV_TENSOR(div);
+WRAPPER_MULDIV_TENSOR(div_);
+
+#undef WRAPPER_MULDIV_TENSOR
+#undef WRAPPER_ADDSUB_TENSOR
+} // namespace
+
+namespace {
+#define C10_REGISTER_OP(func, schema)                   \
+  static auto reg_##func = c10::RegisterOperators().op( \
+      schema,                                           \
+      torch::RegisterOperators::options()               \
+          .catchAllKernel(&wrapper_##func)              \
+          .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA))
+
+C10_REGISTER_OP(
+    add_,
+    "aten::add_inplace_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)");
+C10_REGISTER_OP(
+    add,
+    "aten::add_inplace.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor");
+
+C10_REGISTER_OP(
+    sub_,
+    "aten::sub_inplace_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)");
+C10_REGISTER_OP(
+    sub,
+    "aten::sub_inplace.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor");
+
+C10_REGISTER_OP(
+    mul_,
+    "aten::mul_inplace_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+C10_REGISTER_OP(
+    mul,
+    "aten::mul_inplace.Tensor(Tensor self, Tensor other) -> Tensor");
+
+C10_REGISTER_OP(
+    div_,
+    "aten::div_inplace_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+C10_REGISTER_OP(
+    div,
+    "aten::div_inplace.Tensor(Tensor self, Tensor other) -> Tensor");
+
+#undef C10_REGISTER_OP
+} // namespace
+
+} // namespace blade
+} // namespace torch

--- a/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
@@ -116,6 +116,7 @@ void initToolsBindings(py::module& m) {
   tools.def("is_concrete_shape_tensor_type", is_concrete_shape_tensor_type);
   tools.def("set_value_type", set_value_type);
   tools.def("node_schema_str", node_schema_str);
+  tools.def("node_overload_name", node_overload_name);
   tools.def("cast_to_tensor_type", cast_to_tensor_type);
   tools.def("cast_to_i32_tensor_type", cast_to_i32_tensor_type);
 

--- a/pytorch_blade/pytorch_blade/compiler/jit/tool_funcs.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/tool_funcs.cpp
@@ -131,7 +131,21 @@ std::string node_schema_str(const torch::jit::Node& node) {
   if (schema) {
     return c10::toString(*schema);
   } else {
-    return "";
+    return node.kind().toQualString();
+  }
+}
+
+std::string node_overload_name(const torch::jit::Node& node) {
+  auto schema = node.maybeSchema();
+  if (schema) {
+    auto overload_name = schema->overload_name();
+    if (overload_name.empty()) {
+      return schema->name();
+    } else {
+      return schema->name() + "." + overload_name;
+    }
+  } else {
+    return node.kind().toQualString();
   }
 }
 
@@ -192,6 +206,5 @@ torch::jit::Node* create_prim_constant_with_val(
   constant_node->output()->setType(c10::BoolType::get());
   return constant_node;
 }
-
 } // namespace blade
 } // namespace torch

--- a/pytorch_blade/pytorch_blade/compiler/jit/tool_funcs.h
+++ b/pytorch_blade/pytorch_blade/compiler/jit/tool_funcs.h
@@ -80,6 +80,7 @@ void set_value_type(
     bool is_contiguous);
 
 std::string node_schema_str(const torch::jit::Node& node);
+std::string node_overload_name(const torch::jit::Node& node);
 bool cast_to_i32_tensor_type(torch::jit::Value& value);
 bool cast_to_tensor_type(torch::jit::Value& value);
 } // namespace blade

--- a/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
@@ -128,6 +128,10 @@ const std::unordered_set<std::string> &GetTorchMlirWhiteList() {
       "prim::ListConstruct",
       "prim::ListUnpack",
       // Torch Blade custom ops follows:
+      "aten::add_inplace", // use aten namespace to work with PyTorch mutation pass
+      "aten::sub_inplace", // use aten namespace to work with PyTorch mutation pass
+      "aten::mul_inplace", // use aten namespace to work with PyTorch mutation pass
+      "aten::div_inplace", // use aten namespace to work with PyTorch mutation pass
       "torch_blade::fake_quant"
     };
 

--- a/pytorch_blade/tests/test_tools.py
+++ b/pytorch_blade/tests/test_tools.py
@@ -86,7 +86,7 @@ class TestTools(TestCase):
 
         FileCheck().run(expect_gstr, shape.graph)
         schemas = [tools.node_schema_str(n) for n in shape.graph.nodes()]
-        self.assertEqual(schemas[0], "")
+        self.assertEqual(schemas[0], "prim::Constant")
 
         if utils.torch_version_number() < utils.parse_version("1.14.0"):
             self.assertEqual(schemas[1], "aten::size(Tensor self) -> (int[])")
@@ -94,6 +94,56 @@ class TestTools(TestCase):
         else:
             self.assertEqual(schemas[1], "aten::size(Tensor self) -> int[]")
             self.assertEqual(schemas[2], "aten::__getitem__.t(t[](a) list, int idx) -> t(*)")
+
+    def test_node_overload_name(self):
+        @torch.jit.script
+        def shape(x):
+            return x.size()[1]
+
+        expect_gstr = '''
+        graph(%x.1 : Tensor):
+          # CHECK: prim::Constant
+          %3 : int = prim::Constant[value=1]() # tests/test_tools.py:49:28
+          # CHECK: aten::size
+          %2 : int[] = aten::size(%x.1) # tests/test_tools.py:49:19
+          # CHECK: aten::__getitem__
+          %4 : int = aten::__getitem__(%2, %3) # tests/test_tools.py:49:19
+          return (%4)'''
+
+        FileCheck().run(expect_gstr, shape.graph)
+        names = [tools.node_overload_name(n) for n in shape.graph.nodes()]
+        self.assertEqual(names[0], "prim::Constant")
+        self.assertEqual(names[1], "aten::size")
+        self.assertEqual(names[2], "aten::__getitem__.t")
+
+        @torch.jit.script
+        def arith_func(x: torch.Tensor, y: torch.Tensor):
+            z = x + y
+            w = z.mul_(x)
+            return w.add_(y, alpha=2.0)
+
+        expect_gstr = '''
+        graph(%x.1 : Tensor,
+              %y.1 : Tensor):
+          # CHECK: prim::Constant
+          %4 : int = prim::Constant[value=1]()
+          # CHECK: prim::Constant
+          %11 : float = prim::Constant[value=2.]() # test.py:7:27
+          # CHECK: aten::add
+          %z.1 : Tensor = aten::add(%x.1, %y.1, %4) # test.py:5:8
+          # CHECK: aten::mul
+          %w.1 : Tensor = aten::mul_(%z.1, %x.1) # test.py:6:8
+          # CHECK: aten::add
+          %12 : Tensor = aten::add_(%w.1, %y.1, %11) # test.py:7:11
+          return (%12)'''
+        FileCheck().run(expect_gstr, arith_func.graph)
+        overload_name = [tools.node_overload_name(n) for n in arith_func.graph.nodes()]
+        names = [tools.node_overload_name(n) for n in arith_func.graph.nodes()]
+        self.assertEqual(names[0], "prim::Constant")
+        self.assertEqual(names[1], "prim::Constant")
+        self.assertEqual(names[2], "aten::add.Tensor")
+        self.assertEqual(names[3], "aten::mul_.Tensor")
+        self.assertEqual(names[4], "aten::add_.Tensor")
 
     def test_from_number_type(self):
 

--- a/pytorch_blade/tests/torchscript/BUILD
+++ b/pytorch_blade/tests/torchscript/BUILD
@@ -16,6 +16,7 @@ cc_binary(
         "-lm",
     ],
     deps = [
+        "//pytorch_blade/compiler/jit:aten_custom_ops",
 	"//pytorch_blade/compiler/jit/torch:shape_analysis",
     ] + if_quantization_enabled([
         "//pytorch_blade/quantization:quantization_op",


### PR DESCRIPTION
Related to https://github.com/alibaba/BladeDISC/issues/785

1. Fix Bert amp example type promotion fail
2. fix amp in place op type promotion after removing the mutations

Before the mutation remover pass removes in-place-mutation information:
```
graph(%x.1 : Tensor,
      %y.1 : Tensor):
  %7 : float = prim::Constant[value=2.]() # test.py:9:24
  %z.1 : Tensor = aten::mul(%x.1, %y.1) # test.py:6:8
  %a.1 : Tensor = aten::add_(%z.1, %y.1, %7) # test.py:9:8
  %c.1 : Tensor = aten::add_(%a.1, %y.1, %7) # test.py:10:8
  return (%c.1)

=== after mutation remover ====>
graph(%x.1 : Tensor,
      %y.1 : Tensor):
  %7 : float = prim::Constant[value=2.]() # test.py:9:24
  %z.1 : Tensor = aten::mul(%x.1, %y.1) # test.py:6:8
  %22 : Tensor = aten::add(%z.1, %y.1, %7) # test.py:9:8
  %23 : Tensor = aten::add(%22, %y.1, %7) # test.py:10:8
  return (%23)
```

The pull request renames the in-place-mutation ops and do the correct type promotion on in-place ops and lowering:
```
=== after renaming ====>
graph(%x.1 : Tensor,
      %y.1 : Tensor):
  %7 : float = prim::Constant[value=2.]() # test.py:9:24
  %z.1 : Tensor = aten::mul(%x.1, %y.1) # test.py:6:8
  %22 : Tensor = aten::add_inplace_(%z.1, %y.1, %7)
  %23 : Tensor = aten::add_inplace_(%22, %y.1, %7)
  return (%23)

=== after mutation remover ====>
graph(%x.1 : Tensor,
      %y.1 : Tensor):
  %7 : float = prim::Constant[value=2.]() # test.py:9:24
  %z.1 : Tensor = aten::mul(%x.1, %y.1) # test.py:6:8
  %24 : Tensor = aten::add_inplace(%z.1, %y.1, %7)
  %25 : Tensor = aten::add_inplace(%24, %y.1, %7)
  return (%25)
``` 