### PR TITLE
[Quantization] Enable quantization on gpu without bladnn

### DIFF
--- a/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant.pdll
+++ b/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant.pdll
@@ -84,7 +84,7 @@ Pattern TorchDequantGemmQuantOp {
 
     /// 2. set attrs that are used by bladedisc.
     SetAttr(infos.op, attr<"\"call_target_name\"">, attr<"\"ral_pdll_qgemm\"">);
-    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"d,d,d,s,s,s,s,s,s\"">);
+    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"d,d,d,d,s,d,s,d,s\"">);
     SetAttr(infos.op, attr<"\"output_placements\"">, attr<"\"d\"">);
     SetAttr(infos.op, attr<"\"device\"">, attr<"\"d\"">);
     SetAttr(infos.op, attr<"\"input_layouts\"">, attr<"\"*,*,*,*,*,*,*,*,*\"">);

--- a/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant_bias_f32_quant.pdll
+++ b/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant_bias_f32_quant.pdll
@@ -1,0 +1,96 @@
+/// Pre-defined custom call prototypes
+///
+/// const std::string kDefaultHelperFunctionDeclarations = R"pdll(
+///   Rewrite PackValue_1(tag : Attr, v0 : Value) -> ValueRange;
+///   Rewrite PackValue_2(tag : Attr, v0 : Value, v1 : Value) -> ValueRange;
+///   Rewrite UnpackValue_1(v : ValueRange) -> (Value);
+///   Rewrite UnpackValue_2(v : ValueRange) -> (Value, Value);
+///   Rewrite CreateTorchCustomCall(tag : Attr, inputs : ValueRange, outputs : ValueRange) -> (op: Op, new_outputs : ValueRange);
+///   Rewrite SetAttr(op : Op, key : Attr, value : Attr);
+///   Rewrite SetCustomAttr(op : Op, key : Attr, value : Attr);
+/// )pdll";
+
+//     bias \                 bias + quant \
+// Dequant + gemm + quant ->                 qgemm
+
+// Need to attention that rewrited graph is not strictly equal to original graph.
+// It adds extra quantize node between bias and gemm to be meet the requirement
+// with gpu kernel implementation that source addition should be same type with
+// output.
+Pattern TorchDequantGemmQuantOp {
+  /// match phase: define the pattern
+  let input_dequantize_op = op<torch.operator>(
+    input: Value,
+    input_scale: Value,
+    input_zero_point: Value,
+    input_quant_min: Value,
+    input_quant_max: Value,
+    input_num_bits: Value,
+    input_axis: Value,
+    input_signed: Value,
+    input_symmetric: Value,
+    input_dynamic: Value,
+    input_per_channel: Value
+  ){ name = attr<"\"torch_blade.dequantize\"">};
+
+  let weight_dequantize_op = op<torch.operator>(
+    weight: Value,
+    weight_scale: Value,
+    weight_zero_point: Value,
+    weight_quant_min: Value,
+    weight_quant_max: Value,
+    weight_num_bits: Value,
+    weight_axis: Value,
+    weight_signed: Value,
+    weight_symmetric: Value,
+    weight_dynamic: Value,
+    weight_per_channel: Value
+  ){ name = attr<"\"torch_blade.dequantize\"">};
+
+  let gemm = op<torch.aten.linear>(
+      input_dequantize_op.0,
+      weight_dequantize_op.0,
+      bias: Value
+  );
+
+  let output_quantize_op = op<torch.operator>(
+      gemm.0,
+      output_scale: Value,
+      output_zero_point: Value,
+      output_quant_min: Value,
+      output_quant_max: Value,
+      output_num_bits: Value,
+      output_axis: Value,
+      output_signed: Value,
+      output_symmetric: Value,
+      output_dynamic: Value,
+      output_per_channel: Value
+   ){ name = attr<"\"torch_blade.quantize\"">};
+
+  /// rewrite phase
+  rewrite output_quantize_op with {
+    let bias_type = GetTorchTensorType(bias);
+    let bias_quantize_op = op<torch.aten.div.Tensor>(
+      bias,
+      output_scale
+    ) -> (bias_type);
+
+    /// 1. create custom call op
+    let inputs = PackValue_9(attr<"\"in\"">, input, weight, bias_quantize_op.0, input_scale, input_zero_point, weight_scale, weight_zero_point, output_scale, output_zero_point);
+    let outputs = PackValue_1(attr<"\"out\"">, output_quantize_op.0);
+    let infos = CreateTorchCustomCall(attr<"\"op\"">, inputs, outputs);
+
+    /// 2. set attrs that are used by bladedisc.
+    SetAttr(infos.op, attr<"\"call_target_name\"">, attr<"\"ral_pdll_qgemm\"">);
+    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"d,d,d,d,s,d,s,d,s\"">);
+    SetAttr(infos.op, attr<"\"output_placements\"">, attr<"\"d\"">);
+    SetAttr(infos.op, attr<"\"device\"">, attr<"\"d\"">);
+    SetAttr(infos.op, attr<"\"input_layouts\"">, attr<"\"*,*,*,*,*,*,*,*,*\"">);
+    SetAttr(infos.op, attr<"\"output_layouts\"">, attr<"\"*\"">);
+    SetAttr(infos.op, attr<"\"expected_input_layouts\"">, attr<"\"*,*,*,*,*,*,*,*,*\"">);
+    SetAttr(infos.op, attr<"\"expected_output_layouts\"">, attr<"\"*\"">);
+
+    let rs = UnpackValue_1(infos.new_outputs);
+    replace output_quantize_op with rs;
+  };
+}

--- a/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant_bias_quant.pdll
+++ b/pytorch_blade/tests/disc/pdl/pdll_files/gpu/dequant_gemm_quant_bias_quant.pdll
@@ -92,7 +92,7 @@ Pattern TorchDequantGemmQuantOp {
 
     /// 2. set attrs that are used by bladedisc.
     SetAttr(infos.op, attr<"\"call_target_name\"">, attr<"\"ral_pdll_qgemm\"">);
-    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"d,d,d,s,s,s,s,s,s\"">);
+    SetAttr(infos.op, attr<"\"input_placements\"">, attr<"\"d,d,d,d,s,d,s,d,s\"">);
     SetAttr(infos.op, attr<"\"output_placements\"">, attr<"\"d\"">);
     SetAttr(infos.op, attr<"\"device\"">, attr<"\"d\"">);
     SetAttr(infos.op, attr<"\"input_layouts\"">, attr<"\"*,*,*,*,*,*,*,*,*\"">);

--- a/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
+++ b/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
@@ -158,60 +158,6 @@ class TestCPULiner(CPUDiscPdlQuantizationE2ETestCase):
                  "The patterns corresponding to pytorch before version "
                  "1.9.0 has not yet been implemented ")
 class TestGPULiner(GPUDiscPdlQuantizationE2ETestCase):
-    #  weight -> fake-quant  \
-    #  input  -> fake-quant -> linear -> fake-quant -> output
-    def test_s8s8s8_s8bias_per_tensor_verify(self):
-        class Model(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.input_scale = 0.1
-                self.input_zero_point = 0
-                self.output_scale = 0.2
-                self.output_zero_point = 0
-                self.weight_scale = 0.3
-                self.weight_zero_point = 0
-                self.weight_quant_min = -128
-                self.weight_quant_max = 127
-                self.activation_quant_min = -128
-                self.activation_quant_max = 127
-                self.register_buffer("weight", torch.randn(512, 512))
-                self.register_buffer("bias", torch.randn(512))
-                self.bias_scale = 0.2
-                self.bias_zero_point = 0
-                # bias i8 quantization
-                self.bias_quant_min = -128
-                self.bias_quant_max = 127
-                self.ch_axis = 0
-
-            def forward(self, x):
-                x = torch.fake_quantize_per_tensor_affine(
-                    x, self.input_scale, self.input_zero_point,
-                    self.activation_quant_min, self.activation_quant_max
-                )
-                weight = torch.fake_quantize_per_tensor_affine(
-                    self.weight, self.weight_scale, self.weight_zero_point,
-                    self.weight_quant_min, self.weight_quant_max
-                )
-                bias = torch.fake_quantize_per_tensor_affine(
-                    self.bias, self.bias_scale, self.bias_zero_point,
-                    self.bias_quant_min, self.bias_quant_max
-                )
-                x = F.linear(x, weight, bias=bias)
-                x = torch.fake_quantize_per_tensor_affine(
-                    x, self.output_scale, self.output_zero_point,
-                    self.activation_quant_min, self.activation_quant_max
-                )
-                return x
-        model = Model().eval().to(self.device)
-        inp = torch.randn(512, 512).to(self.device)
-        traced_model = torch.jit.trace(model, inp)
-        pdll_files = [
-            os.path.join(self.common_pdll_dir, "fake_quant.pdll"),
-            os.path.join(self.device_pdll_dir, "dequant_gemm_quant.pdll")
-        ]
-        pdll_files = ",".join(pdll_files)
-        self._test_e2e(model, inp, pdll_files=pdll_files, enable_int8=True, diff_scale=model.output_scale)
-
     def test_s8s8s8_f32bias_per_tensor_verify(self):
         class Model(nn.Module):
             def __init__(self):
@@ -253,9 +199,13 @@ class TestGPULiner(GPUDiscPdlQuantizationE2ETestCase):
         model = Model().eval().to(self.device)
         inp = torch.randn(512, 512).to(self.device)
         traced_model = torch.jit.trace(model, inp)
+        if torch.version.cuda=='11.3':
+            qgemm_pdl_file = "dequant_gemm_quant_bias_quant.pdll"
+        else:
+            qgemm_pdl_file = "dequant_gemm_quant_bias_f32_quant.pdll"
         pdll_files = [
             os.path.join(self.common_pdll_dir, "fake_quant.pdll"),
-            os.path.join(self.device_pdll_dir, "dequant_gemm_quant_bias_quant.pdll")
+            os.path.join(self.device_pdll_dir, qgemm_pdl_file)
         ]
         pdll_files = ",".join(pdll_files)
         self._test_e2e(model, inp, pdll_files=pdll_files, enable_int8=True, diff_scale=model.output_scale)
@@ -301,9 +251,13 @@ class TestGPULiner(GPUDiscPdlQuantizationE2ETestCase):
         model = Model().eval().to(self.device)
         inp = torch.randn(8, 512, 512).to(self.device)
         traced_model = torch.jit.trace(model, inp)
+        if torch.version.cuda == '11.3':
+            qgemm_pdl_file = "dequant_gemm_quant_bias_quant.pdll"
+        else:
+            qgemm_pdl_file = "dequant_gemm_quant_bias_f32_quant.pdll"
         pdll_files = [
             os.path.join(self.common_pdll_dir, "fake_quant.pdll"),
-            os.path.join(self.device_pdll_dir, "dequant_gemm_quant_bias_quant.pdll")
+            os.path.join(self.device_pdll_dir, qgemm_pdl_file)
         ]
         pdll_files = ",".join(pdll_files)
         self._test_e2e(model, inp, pdll_files=pdll_files, enable_int8=True, diff_scale=model.output_scale)

--- a/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
+++ b/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
@@ -38,9 +38,11 @@ class CPUDiscPdlQuantizationE2ETestCase(CPUDiscPdlQuantizationTestCase):
 class GPUDiscPdlQuantizationE2ETestCase(GPUDiscPdlQuantizationTestCase):
     def setUp(self):
         super().setUp()
-        if float(torch.version.cuda) <= 11.1:
-            self.skipTest("Quantization gpu test case only works on cuda"
-                          " version > 11.1")
+        support_cuda_version = ['11.3', '11.7']
+        if torch.version.cuda not in support_cuda_version:
+            self.skipTest("Currently, the correctness can be ensured on cuda"
+                          " version 11.3/11.7. Using other versions may cause"
+                          " correctness problem ")
 
 
 @unittest.skipIf(TORCH_VERSION < (1, 9),
@@ -202,7 +204,8 @@ class TestGPULiner(GPUDiscPdlQuantizationE2ETestCase):
         model = Model().eval().to(self.device)
         inp = torch.randn(512, 512).to(self.device)
         traced_model = torch.jit.trace(model, inp)
-        if torch.version.cuda=='11.3':
+        # only cuda version 11.3/11.7 can be ensured correctness
+        if torch.version.cuda == '11.3':
             qgemm_pdl_file = "dequant_gemm_quant_bias_quant.pdll"
         else:
             qgemm_pdl_file = "dequant_gemm_quant_bias_f32_quant.pdll"
@@ -254,6 +257,7 @@ class TestGPULiner(GPUDiscPdlQuantizationE2ETestCase):
         model = Model().eval().to(self.device)
         inp = torch.randn(8, 512, 512).to(self.device)
         traced_model = torch.jit.trace(model, inp)
+        # only cuda version 11.3/11.7 can be ensured correctness
         if torch.version.cuda == '11.3':
             qgemm_pdl_file = "dequant_gemm_quant_bias_quant.pdll"
         else:

--- a/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
+++ b/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
@@ -38,6 +38,9 @@ class CPUDiscPdlQuantizationE2ETestCase(CPUDiscPdlQuantizationTestCase):
 class GPUDiscPdlQuantizationE2ETestCase(GPUDiscPdlQuantizationTestCase):
     def setUp(self):
         super().setUp()
+        if float(torch.version.cuda) <= 11.1:
+            self.skipTest("Quantization gpu test case only works on cuda"
+                          " version > 11.1")
 
 
 @unittest.skipIf(TORCH_VERSION < (1, 9),

--- a/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
+++ b/pytorch_blade/tests/disc/pdl/test_e2e/test_quantization.py
@@ -38,11 +38,6 @@ class CPUDiscPdlQuantizationE2ETestCase(CPUDiscPdlQuantizationTestCase):
 class GPUDiscPdlQuantizationE2ETestCase(GPUDiscPdlQuantizationTestCase):
     def setUp(self):
         super().setUp()
-        import os
-        bladnn_on = os.getenv('BLADE_GEMM_TUNE_JIT')
-        if bladnn_on != 'true' and bladnn_on != '1':
-            self.skipTest("Quantization cuda test case only works on gpu"
-                          " with bladnn library")
 
 
 @unittest.skipIf(TORCH_VERSION < (1, 9),

--- a/pytorch_blade/tests/disc/testing_base.py
+++ b/pytorch_blade/tests/disc/testing_base.py
@@ -229,4 +229,4 @@ class GPUDiscPdlQuantizationTestCase(DiscPdlQuantizationTestCase):
         with set_env(**env_var), cfg:
             opt_model = optimize(model, True, inp)
         now_output = opt_model(inp)
-        self.assertTrue(torch.allclose(now_output, origin_output, atol=(1.0 + 1e-4) * diff_scale))
+        self.assertTrue(torch.allclose(now_output, origin_output, atol=1.0 * diff_scale))

--- a/pytorch_blade/tests/disc/testing_base.py
+++ b/pytorch_blade/tests/disc/testing_base.py
@@ -229,4 +229,4 @@ class GPUDiscPdlQuantizationTestCase(DiscPdlQuantizationTestCase):
         with set_env(**env_var), cfg:
             opt_model = optimize(model, True, inp)
         now_output = opt_model(inp)
-        self.assertTrue(torch.allclose(now_output, origin_output, atol=1.0 * diff_scale))
+        self.assertTrue(torch.allclose(now_output, origin_output, atol=(1.0 + 1e-4) * diff_scale))

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -227,8 +227,6 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   // quantization related passes.
   pm.addNestedPass<FuncOp>(disc_ral::createDiscCustomCallRewriterPass());
   pm.addNestedPass<FuncOp>(disc_ral::createDiscConvertFakeQuantOpPass());
-  pm.addNestedPass<FuncOp>(
-      disc_ral::createDiscLowerQuantizeAndDequantizePass());
 
   if (gpu_enabled) {
     pm.addNestedPass<FuncOp>(

--- a/tao_compiler/mlir/xla/ral/BUILD
+++ b/tao_compiler/mlir/xla/ral/BUILD
@@ -301,6 +301,7 @@ cc_library(
         "context/stream_executor_based_impl.cc",
     ]) + if_cuda([
         "context/cuda_impl_sparse.cc",
+        "context/quantized_gpu_kernel_impl.cc",
     ]) + if_patine([
         "context/common_context_impl_patine.cc",
     ]) + if_mkldnn([
@@ -657,6 +658,7 @@ cc_library(
         "context/stream_executor_based_impl.cc",
     ]) + if_cuda([
         "context/cuda_impl_sparse.cc",
+        "context/quantized_gpu_kernel_impl.cc",
     ]) + if_patine([
         "context/common_context_impl_patine.cc",
     ]) + if_mkldnn([

--- a/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
@@ -1,3 +1,14 @@
+// Copyright 2022 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <cublasLt.h>
 #include <cuda_runtime.h>
 #include <dlfcn.h>

--- a/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
@@ -183,6 +183,11 @@ struct GemmScaleState : public Context::Resource {
   std::unordered_map<GemmScaleKey, float, GemmScaleKeyHasher> cache;
 };
 
+// Layout requirement:
+// input: m x k, row major
+// weight: n x k, col major
+// output: m x n, row major
+// bias: 1 x n
 template <int N, typename T>
 MemRefType<int8_t, N> ral_pdll_qgemm(
     ExecutionContext* ctx, void* stream_handle, MemRefType<int8_t, N>& input,

--- a/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/quantized_gpu_kernel_impl.cc
@@ -1,0 +1,280 @@
+#include <cublasLt.h>
+#include <cuda_runtime.h>
+#include <dlfcn.h>
+
+#include <functional>
+#include <iostream>
+
+#include "absl/types/optional.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/common_context_impl.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/context_util.h"
+#include "tensorflow/compiler/mlir/xla/ral/context/stream_executor_based_impl.h"
+#include "tensorflow/compiler/mlir/xla/ral/device/gpu/gpu_driver.h"
+
+#if defined(PLATFORM_ALIBABA) and defined(ENABLE_BLADE_GEMM)
+#include "bladnn/bladnn.h"
+#endif
+
+namespace tao {
+namespace ral {
+
+namespace gpu {
+
+namespace se = ::stream_executor;
+
+namespace se_impl {
+
+struct CublasLtBiasParamsKey {
+  int m;
+  int k;
+  int n;
+  int lda;
+  int ldb;
+  int ldc;
+  bool transa;
+  bool transb;
+
+  int8_t* bias;
+
+  bool operator==(const CublasLtBiasParamsKey& rhs) const {
+    return m == rhs.m && k == rhs.k && n == rhs.n && lda == rhs.lda &&
+           ldb == rhs.ldb && ldc == rhs.ldc && transa == rhs.transa &&
+           transb == rhs.transb && bias == rhs.bias;
+  }
+};
+
+struct CublasLtBiasParams {
+  cublasLtHandle_t ltHandle;
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t Adesc;
+  cublasLtMatrixLayout_t Bdesc;
+  cublasLtMatrixLayout_t Cdesc;
+
+  CublasLtBiasParams(CublasLtBiasParamsKey& key) {
+    cublasLtCreate(&ltHandle);
+    cublasLtMatmulDescCreate(&matmulDesc, CUBLAS_COMPUTE_32I, CUDA_R_32F);
+
+    int m = key.m, k = key.k, n = key.n;
+
+    auto transa_cublas = key.transa ? CUBLAS_OP_T : CUBLAS_OP_N;
+    auto transb_cublas = key.transb ? CUBLAS_OP_T : CUBLAS_OP_N;
+
+    cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                   &transa_cublas, sizeof(transa_cublas));
+    cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                   &transb_cublas, sizeof(transb_cublas));
+
+    // bias add epilogue
+    auto epi = CUBLASLT_EPILOGUE_BIAS;
+    cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_EPILOGUE,
+                                   &epi, sizeof(epi));
+    cublasLtMatmulDescSetAttribute(matmulDesc,
+                                   CUBLASLT_MATMUL_DESC_BIAS_POINTER, &key.bias,
+                                   sizeof(key.bias));
+    cublasLtMatrixLayoutCreate(&Adesc, CUDA_R_8I,
+                               transa_cublas == CUBLAS_OP_N ? m : k,
+                               transa_cublas == CUBLAS_OP_N ? k : m, key.lda);
+    cublasLtMatrixLayoutCreate(&Bdesc, CUDA_R_8I,
+                               transb_cublas == CUBLAS_OP_N ? k : n,
+                               transb_cublas == CUBLAS_OP_N ? n : k, key.ldb);
+    cublasLtMatrixLayoutCreate(&Cdesc, CUDA_R_8I, m, n, key.ldc);
+  }
+
+  ~CublasLtBiasParams() {
+    if (Cdesc) cublasLtMatrixLayoutDestroy(Cdesc);
+    if (Bdesc) cublasLtMatrixLayoutDestroy(Bdesc);
+    if (Adesc) cublasLtMatrixLayoutDestroy(Adesc);
+    if (matmulDesc) cublasLtMatmulDescDestroy(matmulDesc);
+  }
+};
+
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v) {
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+struct CublasLtBiasKeyHasher {
+  std::size_t operator()(const CublasLtBiasParamsKey& key) const {
+    std::size_t seed = std::hash<int>()(key.m);
+    hash_combine(seed, key.k);
+    hash_combine(seed, key.n);
+    hash_combine(seed, key.lda);
+    hash_combine(seed, key.ldb);
+    hash_combine(seed, key.ldc);
+    hash_combine(seed, key.transa);
+    hash_combine(seed, key.transb);
+    hash_combine(seed, key.bias);
+    return seed;
+  }
+};
+
+struct CublasLtBiasState : public Context::Resource {
+  std::mutex mu;
+  std::unordered_map<CublasLtBiasParamsKey, CublasLtBiasParams*,
+                     CublasLtBiasKeyHasher>
+      cache;
+};
+
+void runCublasLtBiasForward(ExecutionContext* ctx, bool transa, bool transb,
+                            int m, int n, int k, void const* A, int lda,
+                            void const* B, int ldb, void* C, int ldc,
+                            void const* alpha, void const* beta,
+                            void const* bias) {
+  std::string unique_name = "tao_ral.gpu.cublasLt_bias_" +
+                            tao::ral::TaoTypeNameHelper<int8_t>::Invoke();
+  auto state = ctx->getOrCreateResource<CublasLtBiasState>(
+      unique_name, []() { return new CublasLtBiasState; });
+  CublasLtBiasParamsKey key{m,   k,      n,      lda,          ldb,
+                            ldc, transa, transb, (int8_t*)bias};
+  {
+    std::lock_guard<std::mutex> l(state->mu);
+
+    auto& cache = state->cache;
+    auto it = cache.find(key);
+    if (it == cache.end()) {
+      auto params_tmp = new CublasLtBiasParams(key);
+      cache.insert(std::make_pair(key, params_tmp));
+    }
+  }
+  auto params = state->cache[key];
+
+  auto status =
+      cublasLtMatmul(params->ltHandle, params->matmulDesc, alpha, A,
+                     params->Adesc, B, params->Bdesc, beta, C, params->Cdesc, C,
+                     params->Cdesc, NULL, NULL, 0, 0);
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    ctx->signalError(Context::FAILURE, "Error to execute cublasLt.");
+  }
+}
+
+struct GemmScaleKey {
+  opaque_t input_scale = nullptr;
+  opaque_t weight_scale = nullptr;
+  opaque_t output_scale = nullptr;
+
+  bool operator==(const GemmScaleKey& rhs) const {
+    return input_scale == rhs.input_scale && weight_scale == rhs.weight_scale &&
+           output_scale == rhs.output_scale;
+  }
+};
+
+struct GemmScaleKeyHasher {
+  std::size_t operator()(const GemmScaleKey& key) const {
+    std::size_t seed = std::hash<intptr_t>()((intptr_t)key.input_scale);
+    hash_combine(seed, key.weight_scale);
+    hash_combine(seed, key.output_scale);
+    return seed;
+  }
+};
+
+struct GemmScaleState : public Context::Resource {
+  std::mutex mu;
+  std::unordered_map<GemmScaleKey, float, GemmScaleKeyHasher> cache;
+};
+
+template <int N>
+MemRefType<int8_t, N> ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor(
+    ExecutionContext* ctx, void* stream_handle, MemRefType<int8_t, N> input,
+    MemRefType<int8_t, 2> weight, MemRefType<int8_t, 1> bias,
+    MemRefType<float, 0> inputScales, MemRefType<int32_t, 0> inputZeroPoints,
+    MemRefType<float, 0> weightScales, MemRefType<int32_t, 0> weightZeroPoints,
+    MemRefType<float, 0> resultScales, MemRefType<int32_t, 0> resultZeroPoints,
+    void* customAttrs) {
+  int64_t m = 1;
+  int64_t k = weight.sizes[1];
+  int64_t n = weight.sizes[0];
+  int64_t resultSizes[N];
+  for (int i = 0; i < N - 1; i += 1) {
+    m *= input.sizes[i];
+    resultSizes[i] = input.sizes[i];
+  }
+  resultSizes[N - 1] = n;
+
+  if (isEmptyMemref(input) || isEmptyMemref(weight)) {
+    TAO_VLOG(1) << "ral_qgemm: early return for empty tensor";
+    return assignMemRef<int8_t, N>(nullptr, resultSizes);
+    ;
+  }
+
+  float kernel_scale;
+  float beta = 0.0f;
+
+  {
+    // Kernel internal scale is calculated by input_scale, weight_scale and
+    // result_scale in ral call function. Since these three tensors are stored
+    // in device, we have to load them from device to host which will break
+    // kernel launch and influence the overall latency. Here we choose to
+    // cache the calculated scale to avoid extra h2d overhead.
+    GemmScaleKey key{inputScales.data, weightScales.data, resultScales.data};
+    std::string unique_name = "tao_ral.gpu.qgemm_scale" +
+                              tao::ral::TaoTypeNameHelper<int8_t>::Invoke();
+    auto state = ctx->getOrCreateResource<GemmScaleState>(
+        unique_name, []() { return new GemmScaleState; });
+    std::lock_guard<std::mutex> l(state->mu);
+    auto& cache = state->cache;
+    auto it = cache.find(key);
+    if (it == cache.end()) {
+      auto gpu_driver = ctx->getDriver<GPUDriver>(GPUDriver::name());
+      float input_scale, weight_scale, result_scale;
+      gpu_driver->d2h(ctx, stream_handle, &inputScales.data[0], &input_scale,
+                      sizeof(float));
+      gpu_driver->d2h(ctx, stream_handle, &weightScales.data[0], &weight_scale,
+                      sizeof(float));
+      gpu_driver->d2h(ctx, stream_handle, &resultScales.data[0], &result_scale,
+                      sizeof(float));
+
+      gpu_driver->syncOnStream(ctx, stream_handle);
+
+      float kernel_scale_tmp = input_scale * weight_scale / result_scale;
+      it = cache.insert(std::make_pair(key, kernel_scale_tmp)).first;
+    }
+    kernel_scale = (float)(it->second);
+  }
+
+  // For int8 gemm kernel, matrix a is always row major and matrix b is always
+  // column major.
+  bool transa = false;
+  bool transb = true;
+
+  auto gpu_driver = ctx->getDriver<GPUDriver>(GPUDriver::name());
+  auto data =
+      static_cast<int8_t*>(gpu_driver->alloc(ctx, m * n * sizeof(int8_t)));
+  auto result = assignMemRef<int8_t, N>(data, resultSizes);
+
+#if defined(PLATFORM_ALIBABA) and defined(ENABLE_BLADE_GEMM)
+  {
+    beta = 1.0f;
+    void* s = gpu_driver->asCUStream(ctx, stream_handle);
+    bladnn::Context bladnn_ctx{s};
+    bladnn::Dtype in_dtype = bladnn::Dtype::kS8;
+    ;
+    bladnn::Dtype out_dtype = bladnn::Dtype::kS8;
+    ;
+    bool ret =
+        bladnn::gemm(&bladnn_ctx, in_dtype, 0, input.data, m, k, in_dtype, 1,
+                     weight.data, n, k, out_dtype, result.data, m, n, 1, false,
+                     false, &kernel_scale, &beta, bias.data);
+    if (ret) {
+      return result;
+    }
+  }
+#endif
+  beta = 0.0f;
+
+  runCublasLtBiasForward(ctx, transb, transa, n, m, k, weight.data, k,
+                         input.data, k, result.data, n, &kernel_scale, &beta,
+                         bias.data);
+  return result;
+}
+
+}  // namespace se_impl
+}  // namespace gpu
+
+TAO_RAL_API("ral_pdll_qgemm", "gpu",
+            gpu::se_impl::ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor<2>);
+TAO_RAL_API("ral_pdll_qgemm", "gpu",
+            gpu::se_impl::ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor<3>);
+
+}  // namespace ral
+}  // namespace tao

--- a/tao_compiler/mlir/xla/ral/context/stream_executor_based_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/stream_executor_based_impl.cc
@@ -470,62 +470,6 @@ void ral_qgemm(
   ctx->signalError(Context::FAILURE, "Should turn on bladnn first.");
 }
 
-template <int N>
-MemRefType<int8_t, N> ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor(
-    ExecutionContext* ctx, void* stream_handle, MemRefType<int8_t, N> input,
-    MemRefType<int8_t, 2> weight, MemRefType<int8_t, 1> bias,
-    MemRefType<float, 0> inputScales, MemRefType<int32_t, 0> inputZeroPoints,
-    MemRefType<float, 0> weightScales, MemRefType<int32_t, 0> weightZeroPoints,
-    MemRefType<float, 0> resultScales, MemRefType<int32_t, 0> resultZeroPoints,
-    void* customAttrs) {
-  int64_t m = 1;
-  int64_t k = weight.sizes[1];
-  int64_t n = weight.sizes[0];
-  int64_t resultSizes[N];
-  for (int i = 0; i < N - 1; i += 1) {
-    m *= input.sizes[i];
-    resultSizes[i] = input.sizes[i];
-  }
-  resultSizes[N - 1] = n;
-
-  if (isEmptyMemref(input) || isEmptyMemref(weight)) {
-    TAO_VLOG(1) << "ral_qgemm: early return for empty tensor";
-    return assignMemRef<int8_t, N>(nullptr, resultSizes);
-  }
-
-  float input_scale, weight_scale, result_scale;
-
-  input_scale = inputScales.data[0];
-  weight_scale = weightScales.data[0];
-  result_scale = resultScales.data[0];
-
-  float kernel_scale = input_scale * weight_scale / result_scale;
-  float beta = 1.0f;
-
-#if defined(PLATFORM_ALIBABA) and defined(ENABLE_BLADE_GEMM)
-  {
-    auto gpu_driver = ctx->getDriver<GPUDriver>(GPUDriver::name());
-    auto data =
-        static_cast<int8_t*>(gpu_driver->alloc(ctx, m * n * sizeof(int8_t)));
-    auto result = assignMemRef<int8_t, N>(data, resultSizes);
-    void* s = gpu_driver->asCUStream(ctx, stream_handle);
-    bladnn::Context bladnn_ctx{s};
-    bladnn::Dtype in_dtype = toBlaDNNDtype<int8_t>();
-    bladnn::Dtype out_dtype = toBlaDNNDtype<int8_t>();
-    bool ret =
-        bladnn::gemm(&bladnn_ctx, in_dtype, 0, input.data, m, k, in_dtype, 1,
-                     weight.data, n, k, out_dtype, result.data, m, n, 1, false,
-                     false, &kernel_scale, &beta, bias.data);
-    if (ret) {
-      return result;
-    } else {
-      ctx->signalError(Context::FAILURE, "Bladnn gemm run fail.");
-    }
-  }
-#endif
-  ctx->signalError(Context::FAILURE, "Should turn on bladnn first.");
-}
-
 void ral_comp_intens_fusion(
     ExecutionContext* ctx,
     const char* kernel_name,  /* function name to call on host side */
@@ -1925,10 +1869,6 @@ TAO_RAL_API("ral_conv", "gpu",
             gpu::se_impl::gpu_conv_impl::ral_conv<Eigen::half, 3>);
 TAO_RAL_API("ral_qconv", "gpu",
             gpu::se_impl::gpu_conv_impl::ral_qconv<int8_t, 4>);
-TAO_RAL_API("ral_pdll_qgemm", "gpu",
-            gpu::se_impl::ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor<2>);
-TAO_RAL_API("ral_pdll_qgemm", "gpu",
-            gpu::se_impl::ral_pdll_qgemm_nt_s8s8s8_biasadd_quant_per_tensor<3>);
 
 // compute-intensive fusion
 TAO_RAL_API("ral_comp_intens_fusion", "gpu",


### PR DESCRIPTION
About this pr:
1. Use cublasLt int8 gemm bias fusion kernel when bladnn is off. Cache the cublasLt setting for each kernel. 
2. Choose the faster kernel between bladnn and cublasLt when bladnn is on.
3. Add new pdl for cublasLt on cuda 11.7 whose bias should be float32.The logics of cublasLt int8 gemm bias fusion vary with cuda version. For example, fused bias on cuda 11.3 should be int8 while it should be float on cuda 11.7.
4. Cache kernel internal scale to avoid host/device memory transaction.