### PR TITLE
add env to control torch-blade cluster iteration

### DIFF
--- a/pytorch_blade/torch_blade/clustering/support_fusion_algorithm.py
+++ b/pytorch_blade/torch_blade/clustering/support_fusion_algorithm.py
@@ -12,7 +12,7 @@
 import torch
 from torch_blade.logging import logger
 from torch_blade.algorithm import UnionSet, NxGraph
-import os
+from torch_blade.config import Config
 
 
 class NoCycleFusedGraphBuilder(object):
@@ -190,9 +190,10 @@ def _cluster_by_union_find(graph_builder, support_info):
         return True
 
     graph_topolist = graph_builder.group_topolist()
-    # some graph unions may not converge in 10 iterations, provide customize setting from env
+    # some graph unions may not converge in 10 iterations, provide customize setting from config
     # TODO: refine cluster policy
-    max_iter_count = int(os.getenv('TORCH_CLUSTER_MAX_ITER_COUNT', 10))
+    cfg = Config.get_current_context_or_new()
+    max_iter_count = cfg.disc_cluster_max_iter_count
     while max_iter_count > 0:
         max_iter_count -= 1
         # TODO: merge brother group nodes that not construct a cycle

--- a/pytorch_blade/torch_blade/clustering/support_fusion_algorithm.py
+++ b/pytorch_blade/torch_blade/clustering/support_fusion_algorithm.py
@@ -12,6 +12,7 @@
 import torch
 from torch_blade.logging import logger
 from torch_blade.algorithm import UnionSet, NxGraph
+import os
 
 
 class NoCycleFusedGraphBuilder(object):
@@ -189,7 +190,9 @@ def _cluster_by_union_find(graph_builder, support_info):
         return True
 
     graph_topolist = graph_builder.group_topolist()
-    max_iter_count = 10
+    # some graph unions may not converge in 10 iterations, provide customize setting from env
+    # TODO: refine cluster policy
+    max_iter_count = int(os.getenv('TORCH_CLUSTER_MAX_ITER_COUNT', 10))
     while max_iter_count > 0:
         max_iter_count -= 1
         # TODO: merge brother group nodes that not construct a cycle

--- a/pytorch_blade/torch_blade/config.py
+++ b/pytorch_blade/torch_blade/config.py
@@ -151,6 +151,10 @@ class Config(ConfigContext):
         #   Level 3: Level 2 + NoNaNs + NoSignedZeros
         #   Level 4: Level 3 + fully llvm fast math
         self._disc_cpu_fast_math_level = 4
+        # Note that default cluster max_iter_count number has risk of early stopping before 
+        # cluster final convergence. If this phenomenon happens and it drastically influence 
+        # the latency, user can try to enlarge this number.
+        self._disc_cluster_max_iter_count = 10
         # min/max/opt settings for tuning trt engines with dynamic input shapes
         # looks like:
         # {
@@ -320,6 +324,20 @@ class Config(ConfigContext):
     def disc_cpu_fast_math_level(self, val):
         assert isinstance(val, int), "disc_cpu_fast_math_level should be int, got {}".format(type(val))
         self._disc_cpu_fast_math_level = val
+
+    @property
+    def disc_cluster_max_iter_count(self):
+        """The flag to set number of max_iter_count.
+
+        :type: int
+        :default: 10
+        """
+        return self._disc_cluster_max_iter_count
+
+    @disc_cluster_max_iter_count.setter
+    def disc_cluster_max_iter_count(self, val):
+        assert isinstance(val, int), "disc_cluster_max_iter_count should be int, got {}".format(type(val))
+        self._disc_cluster_max_iter_count = val
 
     @property
     def dynamic_tuning_shapes(self):


### PR DESCRIPTION
Current torch_blade cluster setting(`max_iter_count=10`) has risk of early stopping before cluster final convergence. In the case of bert-base with fakequant node, the number of fusion block is 62 when `max_iter_count=10` while the number is 7 when `max_iter_count=40`. This phenomenon drastically influence the latency.
This PR aims to prevent performance drop in some cases by adding env to set specific `max_iter_count` value. Clustering policy refinement is in TODO list.