### PR TITLE
[transform] not allow const as the final output of fusion

### DIFF
--- a/tao_compiler/mlir/disc/transforms/fusion_utils_transform_based.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils_transform_based.cc
@@ -76,10 +76,13 @@ bool TransformBasedCpuFusionStrategy::initFusionPattern(
   // Only support one gemm a.t.m.
   if (supportedDotOps.size() != 1) return true;
 
-  // Only support fuse const ops that are used as weights for some dot ops.
+  // Only support fuse const ops that are used as weights for some dot ops and
+  // not consumed by ops outside the fusion pattern.
   for (Operation* op : fusionPattern.getOpList()) {
     if (!isa<lmhlo::ConstantOp>(op)) continue;
-    if (llvm::find(dotWeights, op->getOperand(0)) == dotWeights.end())
+    if (llvm::find(dotWeights, op->getOperand(0)) == dotWeights.end() ||
+        llvm::find(fusionPattern.getRootOps(), op) !=
+            fusionPattern.getRootOps().end())
       return true;
   }
 

--- a/tao_compiler/mlir/disc/transforms/tests/cpu-only-lmhlo-fusion.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/cpu-only-lmhlo-fusion.mlir
@@ -1,5 +1,5 @@
 // RUN: disc-opt -pass-pipeline='func.func(disc-fusion{gpu-enabled=false fusion-strategy=base})' -split-input-file %s -o - | FileCheck %s --check-prefix=BASE
-// RUN: DISC_ENABLE_TRANSFORM_SCHEDULE=1 disc-opt -pass-pipeline='func.func(disc-fusion{gpu-enabled=false fusion-strategy=stitch})' -split-input-file %s -o - | FileCheck %s --check-prefix=TRANSFORM
+// RUN: DISC_ENABLE_TRANSFORM_SCHEDULE=1 disc-opt -split-input-file -pass-pipeline='func.func(disc-fusion{gpu-enabled=false fusion-strategy=stitch})' %s -o - | FileCheck %s --check-prefix=TRANSFORM
 
 // BASE-LABEL: @custom_call_op
 // BASE-SAME: (%[[ARG0:.*]]: memref<?x?xf32, "cpu">, %[[ARG1:.*]]: memref<?x?xf32, "cpu">, %[[ARG2:.*]]: memref<?x?xf32, "cpu">, %[[ARG3:.*]]: memref<?x?xf32, "cpu">) -> memref<?x?xf32, "cpu">
@@ -29,7 +29,7 @@ func.func @matmul_nn(%arg0: memref<?x?xf32, "cpu">, %arg1: memref<?x?xf32, "cpu"
 
 // -----
 
-// TRANSFORM-LABEL: @matmul_nn
+// TRANSFORM-LABEL: @matmul_nn_const_weight
 func.func @matmul_nn_const_weight(%arg0: memref<1024x1024xf32, "cpu">, %arg1: memref<1024x1024xf32, "cpu">,
                                   %arg2: memref<?x1024xf32, "cpu">, %arg3: memref<?x1024xf32, "cpu">) -> memref<?x1024xf32, "cpu"> {
   // TRANSFORM: lmhlo.constant
@@ -43,4 +43,21 @@ func.func @matmul_nn_const_weight(%arg0: memref<1024x1024xf32, "cpu">, %arg1: me
   "lmhlo.constant"(%arg1) {disc.device = "cpu", value = dense<-1.0> : tensor<1024x1024xf32>} : (memref<1024x1024xf32, "cpu">) -> ()
   "lmhlo.dot_general"(%arg2, %arg1, %arg3) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x1024xf32, "cpu">, memref<1024x1024xf32, "cpu">, memref<?x1024xf32, "cpu">) -> ()
   return %arg3 : memref<?x1024xf32, "cpu">
+}
+
+// -----
+
+// TRANSFORM-LABEL: @matmul_nn_const_weight_with_external_user
+func.func @matmul_nn_const_weight_with_external_user(%arg1: memref<1024x1024xf32, "cpu">,
+                                                     %arg2: memref<?x1024xf32, "cpu">, %arg3: memref<?x1024xf32, "cpu">) -> (memref<1024x1024xf32, "cpu">, memref<?x1024xf32, "cpu">) {
+  // TRANSFORM: lmhlo.constant
+  // TRANSFORM-NEXT: "lmhlo.fusion"() ({
+  // TRANSFORM-NEXT: lmhlo.dot_general
+  // TRANSFORM-NEXT: lmhlo.terminator
+  // TRANSFORM-NEXT: })
+  // TRANSFORM-SAME: disc.fusion_type = "kTransform"
+  // TRANSFORM-NEXT: return
+  "lmhlo.constant"(%arg1) {disc.device = "cpu", value = dense<-1.0> : tensor<1024x1024xf32>} : (memref<1024x1024xf32, "cpu">) -> ()
+  "lmhlo.dot_general"(%arg2, %arg1, %arg3) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x1024xf32, "cpu">, memref<1024x1024xf32, "cpu">, memref<?x1024xf32, "cpu">) -> ()
+  return %arg1, %arg3 : memref<1024x1024xf32, "cpu">, memref<?x1024xf32, "cpu">
 }

--- a/tao_compiler/mlir/disc/transforms/tests/disc-duplicate-computation-for-fusion.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-duplicate-computation-for-fusion.mlir
@@ -1,10 +1,11 @@
-// RUN: disc-opt --disc-duplicate-computation-for-fusion -split-input-file %s | FileCheck %s
+// RUN: disc-opt -split-input-file --disc-duplicate-computation-for-fusion %s | FileCheck %s --check-prefix=BASE
+// RUN: DISC_ENABLE_TRANSFORM_SCHEDULE=1 disc-opt -split-input-file --disc-duplicate-computation-for-fusion=gpu-enabled=false %s -o - | FileCheck %s --check-prefix=TRANSFORM
 
-// CHECK-LABEL: @main
+// BASE-LABEL: @main
 func.func @main(%arg0 : memref<?x?xf32, "gpu">, %arg1 : memref<f32, "gpu">, %arg2 : memref<2xi32, "cpu">) -> memref<?x?xf32, "gpu"> {
   // make sure dynamic_broadcast_in_dim is duplicated
-  // CHECK: lmhlo.dynamic_broadcast_in_dim
-  // CHECK: lmhlo.dynamic_broadcast_in_dim
+  // BASE: lmhlo.dynamic_broadcast_in_dim
+  // BASE: lmhlo.dynamic_broadcast_in_dim
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %0 = memref.dim %arg0, %c0 : memref<?x?xf32, "gpu">
@@ -24,11 +25,11 @@ func.func @main(%arg0 : memref<?x?xf32, "gpu">, %arg1 : memref<f32, "gpu">, %arg
 
 // -----
 
-// CHECK-LABEL: @main
+// BASE-LABEL: @main
 func.func @main(%arg0 : memref<?x128xf32, "gpu">, %arg1 : memref<128xf32, "gpu">, %arg2 : memref<1xi32, "cpu">) -> memref<?x128xf32, "gpu"> {
   // make sure dynamic_broadcast_in_dim is duplicated
-  // CHECK: lmhlo.dynamic_broadcast_in_dim
-  // CHECK: lmhlo.dynamic_broadcast_in_dim
+  // BASE: lmhlo.dynamic_broadcast_in_dim
+  // BASE: lmhlo.dynamic_broadcast_in_dim
   %c0 = arith.constant 0 : index
   "lmhlo.constant"(%arg1) {value = dense<0.1> : tensor<128xf32>} : (memref<128xf32, "gpu">) -> ()
   %0 = memref.dim %arg0, %c0 : memref<?x128xf32, "gpu">
@@ -43,4 +44,20 @@ func.func @main(%arg0 : memref<?x128xf32, "gpu">, %arg1 : memref<128xf32, "gpu">
   %6 = memref.alloc(%0) : memref<?x128xf32, "gpu">
   "lmhlo.add"(%2, %5, %6) : (memref<?x128xf32, "gpu">, memref<?x128xf32, "gpu">, memref<?x128xf32, "gpu">) -> ()
   return %6 :  memref<?x128xf32, "gpu">
+}
+
+// -----
+
+// TRANSFORM-LABEL: @duplicate_dot_weight
+func.func @duplicate_dot_weight(%arg0 : memref<128x128xf32, "cpu">, %arg1 : memref<?x128xf32, "cpu">,
+                                %arg2 : memref<?x128xf32, "cpu">, %arg3 : memref<?x128xf32, "cpu">, %arg4 : memref<?x128xf32, "cpu">) -> (memref<?x128xf32, "cpu">, memref<?x128xf32, "cpu">) {
+  // TRANSFORM: lmhlo.constant
+  // TRANSFORM-NEXT: memref.alloc
+  // TRANSFORM-NEXT: lmhlo.constant
+  // TRANSFORM-NEXT: lmhlo.dot_general
+  // TRANSFORM-NEXT: lmhlo.dot_general
+  "lmhlo.constant"(%arg0) {value = dense<0.1> : tensor<128x128xf32>} : (memref<128x128xf32, "cpu">) -> ()
+  "lmhlo.dot_general"(%arg1, %arg0, %arg2) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x128xf32, "cpu">, memref<128x128xf32, "cpu">, memref<?x128xf32, "cpu">) -> ()
+  "lmhlo.dot_general"(%arg3, %arg0, %arg4) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x128xf32, "cpu">, memref<128x128xf32, "cpu">, memref<?x128xf32, "cpu">) -> ()
+  return %arg2, %arg4 :  memref<?x128xf32, "cpu">, memref<?x128xf32, "cpu">
 }


### PR DESCRIPTION
1, not fuse a const op if there are external consumers.

2, add a pattern to duplicate const ops for dot ops to reduce the case where multiple dot ops share the same weight op while requiring different layout.

to #787 