### PR TITLE
[transform] name each op and transfrom based on name instead of type

### DIFF
--- a/tao_compiler/mlir/disc/tools/disc-transform/BUILD
+++ b/tao_compiler/mlir/disc/tools/disc-transform/BUILD
@@ -283,6 +283,7 @@ cc_library(
     srcs = ["transforms/legalize_lmhlo_fusion_to_linalg.cc"],
     deps = [
         ":DISCLinalgExtDialect",
+        ":disc_transform_utils",
         ":pass_details",
         "//tensorflow/compiler/xla/mlir_hlo:lhlo",
         "@llvm-project//llvm:Support",

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/legalize-lmhlo-fusion-to-linalg.mlir
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/legalize-lmhlo-fusion-to-linalg.mlir
@@ -4,8 +4,8 @@
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>, %[[ARG2:.*]]: tensor<?x?xf32>)
 func.func @matmul_nn(%arg1: memref<?x?xf32, "cpu">, %arg2: memref<?x?xf32, "cpu">, %arg3: memref<?x?xf32, "cpu">) -> memref<?x?xf32, "cpu"> {
   // CHECK: %[[T0:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[T1:.*]] = linalg.fill ins(%[[T0]] : f32) outs(%[[ARG2]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-  // CHECK: %[[T2:.*]] = linalg.matmul ins(%[[ARG0]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[T1]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[T1:.*]] = linalg.fill {disc.transform.name = "dot_general"} ins(%[[T0]] : f32) outs(%[[ARG2]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[T2:.*]] = linalg.matmul {disc.transform.name = "dot_general"} ins(%[[ARG0]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[T1]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   // CHECK: return %[[T2]]
   "lmhlo.fusion"() ({
     "lmhlo.dot_general"(%arg1, %arg2, %arg3) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<?x?xf32, "cpu">, memref<?x?xf32, "cpu">, memref<?x?xf32, "cpu">) -> ()
@@ -19,10 +19,10 @@ func.func @matmul_nn(%arg1: memref<?x?xf32, "cpu">, %arg2: memref<?x?xf32, "cpu"
 // CHECK-LABEL: @packed_matmul_nn
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<?x512xf32>, %[[ARG1:.*]]: tensor<512x1024xf32>, %[[ARG2:.*]]: tensor<?x1024xf32>)
 func.func @packed_matmul_nn(%arg1: memref<?x512xf32, "cpu">, %arg2: memref<512x1024xf32, "cpu">, %arg3: memref<?x1024xf32, "cpu">) -> memref<?x1024xf32, "cpu"> {
-  // CHECK: %[[T0:.*]] = disc_linalg_ext.constant_wrapper dense<-8.000000e-01> : tensor<512x1024xf32>
+  // CHECK: %[[T0:.*]] = disc_linalg_ext.constant_wrapper {disc.transform.name = "constant"} dense<-8.000000e-01> : tensor<512x1024xf32>
   // CHECK: %[[T1:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[T2:.*]] = linalg.fill ins(%[[T1]] : f32) outs(%[[ARG2]] : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-  // CHECK: %[[T3:.*]] = linalg.matmul ins(%[[ARG0]], %[[T0]] : tensor<?x512xf32>, tensor<512x1024xf32>) outs(%[[T2]] : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+  // CHECK: %[[T2:.*]] = linalg.fill {disc.transform.name = "dot_general"} ins(%[[T1]] : f32) outs(%[[ARG2]] : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+  // CHECK: %[[T3:.*]] = linalg.matmul {disc.transform.name = "dot_general"} ins(%[[ARG0]], %[[T0]] : tensor<?x512xf32>, tensor<512x1024xf32>) outs(%[[T2]] : tensor<?x1024xf32>) -> tensor<?x1024xf32>
   // CHECK: return %[[T3]]
   "lmhlo.fusion"() ({
     "lmhlo.constant"(%arg2) {disc.device = "cpu", value = dense<-8.000000e-01> : tensor<512x1024xf32>} : (memref<512x1024xf32, "cpu">) -> ()

--- a/tao_compiler/mlir/disc/tools/disc-transform/utils.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/utils.h
@@ -16,10 +16,37 @@ limitations under the License.
 #ifndef DISC_TOOLS_DISC_TRANSFORM_UTILS_H_
 #define DISC_TOOLS_DISC_TRANSFORM_UTILS_H_
 
+#include <string>
+#include <unordered_map>
+
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 
 namespace mlir {
 namespace disc_ral {
+
+// An attribute name used to represent the unique name assigned to each linalg
+// ops. This tag can be used to distinguish different linalg ops when using
+// transform IR.
+extern const char* kDISCLinalgTransformName;
+
+class TransformNameAssigner {
+ public:
+  TransformNameAssigner() = default;
+  TransformNameAssigner(ArrayRef<Operation*> ops);
+
+  // Returns the name assigned to the new `op`. The `op` must not be assigned
+  // name by this assigner before.
+  std::string nameNewOperation(Operation* op);
+
+  // Returns the <op,name> map. The map records the names for all the ops that
+  // have been passed to `nameNewOperation`.
+  const std::unordered_map<Operation*, std::string>& getNameMap();
+
+ private:
+  // Assigned a unique id for the ops having the same op name.
+  std::unordered_map<std::string, int> nameCounterMap_;
+  std::unordered_map<Operation*, std::string> nameMap_;
+};
 
 /// Create a linalg::GenericOp version of an n-D copy that can further tile,
 /// lower to loops or vectorize, unlike the current implementation of


### PR DESCRIPTION
op type is not reliable in case there are multiple ops having the same type. This CL assigns a unique name for each op being transformed and build transform IR based on the name instead of op type. This will help to enable more complicated fusion pattern.

to #787 