### PR TITLE
Using shared memory to cache element-wise results in stitch fusion.

### DIFF
--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -516,7 +516,8 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   // TODO: move to aicompiler repo and add more schedules/op coverage
   pm.addNestedPass<FuncOp>(
       disc_ral::createDiscLhloLegalizeRootsToParallelLoopsPass(
-          options.gpu_info.sm_count));
+          options.gpu_info.sm_count, options.gpu_info.cc_major,
+          options.gpu_info.cc_minor));
   // Converts `atomic_rmw` to `generic_atomic_rmw` when necessary to use CAS.
   pm.addNestedPass<FuncOp>(memref::createExpandOpsPass());
   // Converts `atomic_rmw` to `generic_atomic_rmw` that is unhandled in

--- a/tao_compiler/mlir/disc/disc_util.cc
+++ b/tao_compiler/mlir/disc/disc_util.cc
@@ -355,6 +355,19 @@ int getNumResultOperands(Operation* op) {
                         [&](Value v) { return IsOpWriteValue(op, v); });
 }
 
+int getShmemSizeBytesNotAffectOccupancy(int cc_major, int cc_minor) {
+  return 8192;
+}
+
+Type getLhloOpsElementType(Operation* op) {
+  unsigned int num_operands = op->getNumOperands();
+  Type result_type = op->getOperand(num_operands - 1)
+                         .getType()
+                         .cast<MemRefType>()
+                         .getElementType();
+  return result_type;
+}
+
 // Returns 1D 64-bit dense elements attribute with the given values.
 }  // namespace disc_ral
 }  // namespace mlir

--- a/tao_compiler/mlir/disc/disc_util.h
+++ b/tao_compiler/mlir/disc/disc_util.h
@@ -154,6 +154,13 @@ int getShmemSizeBytesNotAffectOccupancy(int cc_major, int cc_minor);
 // Return the element type of the result of given lmhlo op.
 Type getLhloOpsElementType(Operation* op);
 
+Value CastMemRefTo(OpBuilder& b, Location loc, Value from, Type toType,
+                   ValueRange toShape);
+
+Value createViewLike(OpBuilder& b, Location loc, Value from, Value to);
+
+SmallVector<Value> getShapeValues(OpBuilder* b, Value memref);
+
 }  // namespace disc_ral
 }  // namespace mlir
 

--- a/tao_compiler/mlir/disc/disc_util.h
+++ b/tao_compiler/mlir/disc/disc_util.h
@@ -146,6 +146,14 @@ DenseIntElementsAttr GetI64ElementsAttrForSeq(int start, int end,
 // Thus these operands are supposed to be updated.
 int getNumResultOperands(Operation* op);
 
+// Return size in bytes of shared memory per thread-block that does not hurt
+// occupancy. It varies in different architectures. Currently, return 8192 for
+// simplification.
+int getShmemSizeBytesNotAffectOccupancy(int cc_major, int cc_minor);
+
+// Return the element type of the result of given lmhlo op.
+Type getLhloOpsElementType(Operation* op);
+
 }  // namespace disc_ral
 }  // namespace mlir
 

--- a/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_large.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_large.mlir
@@ -1,10 +1,8 @@
 module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
   func.func @main(%arg0: tensor<96x512x512xf16>, %arg1: tensor<8x12x512x512xf16>, %arg2: tensor<8x12x512x512xf32>)
-        // -> (tensor<96x512x512xf16>)
         -> (tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>)
         attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
     %graph:4 = tf_executor.graph {
-    // %graph = tf_executor.graph {
       %2:2 = tf_executor.island wraps "tf.Const"() {value = dense<[96, 512, 512]> : tensor<3xi32>} : () -> tensor<3xi32>
       %3:2 = tf_executor.island wraps "tf.Const"() {value = dense<[8, 12, 512, 512]> : tensor<4xi32>} : () -> tensor<4xi32>
       %4:2 = tf_executor.island wraps "tf.Reshape"(%arg0, %3) : (tensor<96x512x512xf16>, tensor<4xi32>) -> tensor<8x12x512x512xf16>
@@ -25,10 +23,8 @@ module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, pr
       %19:2 = tf_executor.island wraps "tf.Div"(%15, %18) : (tensor<8x12x512x512xf32>, tensor<8x12x512x512xf32>) -> tensor<8x12x512x512xf32>
       %20:2 = tf_executor.island wraps "tf.Cast"(%19) : (tensor<8x12x512x512xf32>) -> (tensor<8x12x512x512xf16>)
       %21:2 = tf_executor.island wraps "tf.Reshape"(%20, %2) : (tensor<8x12x512x512xf16>, tensor<3xi32>) -> tensor<96x512x512xf16>
-      // tf_executor.fetch %21 : tensor<96x512x512xf16>
       tf_executor.fetch %4, %12, %17, %21 : tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>
     }
     return %graph#0, %graph#1, %graph#2, %graph#3 : tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>
-    // return %graph : tensor<96x512x512xf16>
   }
 }

--- a/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_large.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_large.mlir
@@ -1,0 +1,34 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<96x512x512xf16>, %arg1: tensor<8x12x512x512xf16>, %arg2: tensor<8x12x512x512xf32>)
+        // -> (tensor<96x512x512xf16>)
+        -> (tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>)
+        attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph:4 = tf_executor.graph {
+    // %graph = tf_executor.graph {
+      %2:2 = tf_executor.island wraps "tf.Const"() {value = dense<[96, 512, 512]> : tensor<3xi32>} : () -> tensor<3xi32>
+      %3:2 = tf_executor.island wraps "tf.Const"() {value = dense<[8, 12, 512, 512]> : tensor<4xi32>} : () -> tensor<4xi32>
+      %4:2 = tf_executor.island wraps "tf.Reshape"(%arg0, %3) : (tensor<96x512x512xf16>, tensor<4xi32>) -> tensor<8x12x512x512xf16>
+      %5:2 = tf_executor.island wraps "tf.Div"(%4, %arg1) : (tensor<8x12x512x512xf16>, tensor<8x12x512x512xf16>) -> tensor<8x12x512x512xf16>
+      %6:2 = tf_executor.island wraps "tf.Cast"(%5) : (tensor<8x12x512x512xf16>) -> (tensor<8x12x512x512xf32>)
+      %9:2 = tf_executor.island wraps "tf.Add"(%6, %arg2) : (tensor<8x12x512x512xf32>, tensor<8x12x512x512xf32>) -> tensor<8x12x512x512xf32>
+      %10:2 = tf_executor.island wraps "tf.Const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+      %11:2 = tf_executor.island wraps "tf.Max"(%9, %10) : (tensor<8x12x512x512xf32>, tensor<i32>) -> tensor<8x12x512xf32>
+      // return
+      %12:2 = tf_executor.island wraps "tf.ExpandDims"(%11, %10) : (tensor<8x12x512xf32>, tensor<i32>) -> (tensor<8x12x512x1xf32>)
+      %13:2 = tf_executor.island wraps "tf.BroadcastTo"(%12, %3) : (tensor<8x12x512x1xf32>, tensor<4xi32>) -> tensor<8x12x512x512xf32>
+      %14:2 = tf_executor.island wraps "tf.Sub"(%9, %13) : (tensor<8x12x512x512xf32>, tensor<8x12x512x512xf32>) -> tensor<8x12x512x512xf32>
+      %15:2 = tf_executor.island wraps "tf.Exp"(%14) : (tensor<8x12x512x512xf32>) -> tensor<8x12x512x512xf32>
+      %16:2 = tf_executor.island wraps "tf.Sum"(%15, %10) : (tensor<8x12x512x512xf32>, tensor<i32>) -> tensor<8x12x512xf32>
+      // return
+      %17:2 = tf_executor.island wraps "tf.ExpandDims"(%16, %10) : (tensor<8x12x512xf32>, tensor<i32>) -> (tensor<8x12x512x1xf32>)
+      %18:2 = tf_executor.island wraps "tf.BroadcastTo"(%17, %3) : (tensor<8x12x512x1xf32>, tensor<4xi32>) -> tensor<8x12x512x512xf32>
+      %19:2 = tf_executor.island wraps "tf.Div"(%15, %18) : (tensor<8x12x512x512xf32>, tensor<8x12x512x512xf32>) -> tensor<8x12x512x512xf32>
+      %20:2 = tf_executor.island wraps "tf.Cast"(%19) : (tensor<8x12x512x512xf32>) -> (tensor<8x12x512x512xf16>)
+      %21:2 = tf_executor.island wraps "tf.Reshape"(%20, %2) : (tensor<8x12x512x512xf16>, tensor<3xi32>) -> tensor<96x512x512xf16>
+      // tf_executor.fetch %21 : tensor<96x512x512xf16>
+      tf_executor.fetch %4, %12, %17, %21 : tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>
+    }
+    return %graph#0, %graph#1, %graph#2, %graph#3 : tensor<8x12x512x512xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x512xf16>
+    // return %graph : tensor<96x512x512xf16>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_small.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_small.mlir
@@ -1,0 +1,34 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<96x512x64xf16>, %arg1: tensor<8x12x512x64xf16>, %arg2: tensor<8x12x512x64xf32>)
+        // -> (tensor<96x512x64xf16>)
+        -> (tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>)
+        attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph:4 = tf_executor.graph {
+    // %graph = tf_executor.graph {
+      %2:2 = tf_executor.island wraps "tf.Const"() {value = dense<[96, 512, 64]> : tensor<3xi32>} : () -> tensor<3xi32>
+      %3:2 = tf_executor.island wraps "tf.Const"() {value = dense<[8, 12, 512, 64]> : tensor<4xi32>} : () -> tensor<4xi32>
+      %4:2 = tf_executor.island wraps "tf.Reshape"(%arg0, %3) : (tensor<96x512x64xf16>, tensor<4xi32>) -> tensor<8x12x512x64xf16>
+      %5:2 = tf_executor.island wraps "tf.Div"(%4, %arg1) : (tensor<8x12x512x64xf16>, tensor<8x12x512x64xf16>) -> tensor<8x12x512x64xf16>
+      %6:2 = tf_executor.island wraps "tf.Cast"(%5) : (tensor<8x12x512x64xf16>) -> (tensor<8x12x512x64xf32>)
+      %9:2 = tf_executor.island wraps "tf.Add"(%6, %arg2) : (tensor<8x12x512x64xf32>, tensor<8x12x512x64xf32>) -> tensor<8x12x512x64xf32>
+      %10:2 = tf_executor.island wraps "tf.Const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+      %11:2 = tf_executor.island wraps "tf.Max"(%9, %10) : (tensor<8x12x512x64xf32>, tensor<i32>) -> tensor<8x12x512xf32>
+      // return
+      %12:2 = tf_executor.island wraps "tf.ExpandDims"(%11, %10) : (tensor<8x12x512xf32>, tensor<i32>) -> (tensor<8x12x512x1xf32>)
+      %13:2 = tf_executor.island wraps "tf.BroadcastTo"(%12, %3) : (tensor<8x12x512x1xf32>, tensor<4xi32>) -> tensor<8x12x512x64xf32>
+      %14:2 = tf_executor.island wraps "tf.Sub"(%9, %13) : (tensor<8x12x512x64xf32>, tensor<8x12x512x64xf32>) -> tensor<8x12x512x64xf32>
+      %15:2 = tf_executor.island wraps "tf.Exp"(%14) : (tensor<8x12x512x64xf32>) -> tensor<8x12x512x64xf32>
+      %16:2 = tf_executor.island wraps "tf.Sum"(%15, %10) : (tensor<8x12x512x64xf32>, tensor<i32>) -> tensor<8x12x512xf32>
+      // return
+      %17:2 = tf_executor.island wraps "tf.ExpandDims"(%16, %10) : (tensor<8x12x512xf32>, tensor<i32>) -> (tensor<8x12x512x1xf32>)
+      %18:2 = tf_executor.island wraps "tf.BroadcastTo"(%17, %3) : (tensor<8x12x512x1xf32>, tensor<4xi32>) -> tensor<8x12x512x64xf32>
+      %19:2 = tf_executor.island wraps "tf.Div"(%15, %18) : (tensor<8x12x512x64xf32>, tensor<8x12x512x64xf32>) -> tensor<8x12x512x64xf32>
+      %20:2 = tf_executor.island wraps "tf.Cast"(%19) : (tensor<8x12x512x64xf32>) -> (tensor<8x12x512x64xf16>)
+      %21:2 = tf_executor.island wraps "tf.Reshape"(%20, %2) : (tensor<8x12x512x64xf16>, tensor<3xi32>) -> tensor<96x512x64xf16>
+      // tf_executor.fetch %21 : tensor<96x512x64xf16>
+      tf_executor.fetch %4, %12, %17, %21 : tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>
+    }
+    return %graph#0, %graph#1, %graph#2, %graph#3 : tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>
+    // return %graph : tensor<96x512x64xf16>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_small.mlir
+++ b/tao_compiler/mlir/disc/tests/regression/data/kstitch_fusion_elemwise_shm_cache_small.mlir
@@ -1,10 +1,8 @@
 module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
   func.func @main(%arg0: tensor<96x512x64xf16>, %arg1: tensor<8x12x512x64xf16>, %arg2: tensor<8x12x512x64xf32>)
-        // -> (tensor<96x512x64xf16>)
         -> (tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>)
         attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
     %graph:4 = tf_executor.graph {
-    // %graph = tf_executor.graph {
       %2:2 = tf_executor.island wraps "tf.Const"() {value = dense<[96, 512, 64]> : tensor<3xi32>} : () -> tensor<3xi32>
       %3:2 = tf_executor.island wraps "tf.Const"() {value = dense<[8, 12, 512, 64]> : tensor<4xi32>} : () -> tensor<4xi32>
       %4:2 = tf_executor.island wraps "tf.Reshape"(%arg0, %3) : (tensor<96x512x64xf16>, tensor<4xi32>) -> tensor<8x12x512x64xf16>
@@ -25,10 +23,8 @@ module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, pr
       %19:2 = tf_executor.island wraps "tf.Div"(%15, %18) : (tensor<8x12x512x64xf32>, tensor<8x12x512x64xf32>) -> tensor<8x12x512x64xf32>
       %20:2 = tf_executor.island wraps "tf.Cast"(%19) : (tensor<8x12x512x64xf32>) -> (tensor<8x12x512x64xf16>)
       %21:2 = tf_executor.island wraps "tf.Reshape"(%20, %2) : (tensor<8x12x512x64xf16>, tensor<3xi32>) -> tensor<96x512x64xf16>
-      // tf_executor.fetch %21 : tensor<96x512x64xf16>
       tf_executor.fetch %4, %12, %17, %21 : tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>
     }
     return %graph#0, %graph#1, %graph#2, %graph#3 : tensor<8x12x512x64xf16>, tensor<8x12x512x1xf32>, tensor<8x12x512x1xf32>, tensor<96x512x64xf16>
-    // return %graph : tensor<96x512x64xf16>
   }
 }

--- a/tao_compiler/mlir/disc/tests/regression/kstitch_fusion.cc
+++ b/tao_compiler/mlir/disc/tests/regression/kstitch_fusion.cc
@@ -173,6 +173,52 @@ TEST(KStitchFusionGPUTest, KStitchSimpleWithTransposeF32) {
   unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
 }
 
+// The column size is large to enable block-wise reduction schedule.
+TEST(KStitchFusionGPUTest, KStitchElemwiseShmCacheLarge) {
+  setenv("DISC_ENABLE_SHAPE_CONSTRAINT_IR", "true", 1);
+  setenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL", "true", 1);
+  setenv("DISC_ENABLE_STITCH", "true", 1);
+  setenv("DISC_EXPECTED_KERNELS_IN_UT", "1", 1);
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path +
+          "kstitch_fusion_elemwise_shm_cache_large.mlir",
+      /*backend_types*/ {BackendType::kCuda},
+      /*num_inputs*/ 3,
+      /*num_outputs*/ 4,
+      // /*num_outputs*/ 1,
+      /*input_descriptors*/
+      {"96x512x512xf16_X", "8x12x512x512xf16_X", "8x12x512x512xf32_X"},
+      /*output_descriptors*/ {"f16_X", "f32_X", "f32_X", "f16_X"}));
+  // /*output_descriptors*/ {"f16_X"}));
+  unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
+  unsetenv("DISC_ENABLE_STITCH");
+  unsetenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL");
+  unsetenv("DISC_ENABLE_SHAPE_CONSTRAINT_IR");
+}
+
+// The column size is small to enable warp-wise reduction schedule.
+TEST(KStitchFusionGPUTest, KStitchElemwiseShmCacheSmall) {
+  setenv("DISC_ENABLE_SHAPE_CONSTRAINT_IR", "true", 1);
+  setenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL", "true", 1);
+  setenv("DISC_ENABLE_STITCH", "true", 1);
+  setenv("DISC_EXPECTED_KERNELS_IN_UT", "1", 1);
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path +
+          "kstitch_fusion_elemwise_shm_cache_small.mlir",
+      /*backend_types*/ {BackendType::kCuda},
+      /*num_inputs*/ 3,
+      /*num_outputs*/ 4,
+      // /*num_outputs*/ 1,
+      /*input_descriptors*/
+      {"96x512x64xf16_X", "8x12x512x64xf16_X", "8x12x512x64xf32_X"},
+      /*output_descriptors*/ {"f16_X", "f32_X", "f32_X", "f16_X"}));
+  // /*output_descriptors*/ {"f16_X"}));
+  unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
+  unsetenv("DISC_ENABLE_STITCH");
+  unsetenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL");
+  unsetenv("DISC_ENABLE_SHAPE_CONSTRAINT_IR");
+}
+
 // multi-outputs
 TEST(KStitchFusionCPUTest, MultiOutputs) {
   std::vector<float> input_val;
@@ -191,4 +237,5 @@ TEST(KStitchFusionCPUTest, MultiOutputs) {
   unsetenv("DISC_ENABLE_STITCH");
   unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
 }
+
 }  // namespace mlir_test

--- a/tao_compiler/mlir/disc/tests/regression/kstitch_fusion.cc
+++ b/tao_compiler/mlir/disc/tests/regression/kstitch_fusion.cc
@@ -185,11 +185,9 @@ TEST(KStitchFusionGPUTest, KStitchElemwiseShmCacheLarge) {
       /*backend_types*/ {BackendType::kCuda},
       /*num_inputs*/ 3,
       /*num_outputs*/ 4,
-      // /*num_outputs*/ 1,
       /*input_descriptors*/
       {"96x512x512xf16_X", "8x12x512x512xf16_X", "8x12x512x512xf32_X"},
       /*output_descriptors*/ {"f16_X", "f32_X", "f32_X", "f16_X"}));
-  // /*output_descriptors*/ {"f16_X"}));
   unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
   unsetenv("DISC_ENABLE_STITCH");
   unsetenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL");
@@ -208,11 +206,9 @@ TEST(KStitchFusionGPUTest, KStitchElemwiseShmCacheSmall) {
       /*backend_types*/ {BackendType::kCuda},
       /*num_inputs*/ 3,
       /*num_outputs*/ 4,
-      // /*num_outputs*/ 1,
       /*input_descriptors*/
       {"96x512x64xf16_X", "8x12x512x64xf16_X", "8x12x512x64xf32_X"},
       /*output_descriptors*/ {"f16_X", "f32_X", "f32_X", "f16_X"}));
-  // /*output_descriptors*/ {"f16_X"}));
   unsetenv("DISC_EXPECTED_KERNELS_IN_UT");
   unsetenv("DISC_ENABLE_STITCH");
   unsetenv("DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL");

--- a/tao_compiler/mlir/disc/transforms/disc_passes.td
+++ b/tao_compiler/mlir/disc/transforms/disc_passes.td
@@ -41,6 +41,10 @@ def DiscLhloLegalizeRootsToParallelLoopsPass : Pass<"disc-lhlo-legalize-roots-to
   let options = [
     Option<"core_count_", "core-count", "int",
             /*default=*/"-1", "core count (e.g., SM count on NVIDIA GPU).">,
+    Option<"cc_major_", "gpu-sm-cc-major", "int",
+            /*default=*/"8", "gpu sm cc_major.">,
+    Option<"cc_minor_", "gpu-sm-cc-minor", "int",
+            /*default=*/"0", "gpu sm cc_minor.">,
   ];
   let dependentDialects = [
     "mlir::scf::SCFDialect",

--- a/tao_compiler/mlir/disc/transforms/disc_specialize_fusion_with_speculation.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_specialize_fusion_with_speculation.cc
@@ -84,16 +84,6 @@ bool HasCandidateBroadcastOp(FusionOp fusion_op) {
   return false;
 }
 
-Value createViewLike(OpBuilder& b, Location loc, Value from, Value to) {
-  SmallVector<Value> toShape = getShapeValues(&b, to);
-  auto toType = to.getType().cast<MemRefType>();
-  auto fromType = from.getType().cast<MemRefType>();
-  auto targetType =
-      MemRefType::get(toType.getShape(), fromType.getElementType(),
-                      toType.getLayout(), toType.getMemorySpace());
-  return CastMemRefTo(b, loc, from, targetType, toShape);
-}
-
 struct ShapeConstraintIRCloneContext {
   BlockAndValueMapping valueMapping;
   DenseMap<Value, SmallVector<SymbolicDimOp>> value2Symbols;

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -772,18 +772,6 @@ void FusionPattern::findOpsOfSkeletonGroup(
         auto output = input_op->getOperand(input_op->getNumOperands() - 1);
         int collapsed_tile_dim = getCollapsedTileDim(output);
         auto output_type = output.getType().cast<MemRefType>();
-        // auto output_shape = output_type.getShape();
-        // auto tile_info = tile_plan_[output];
-        // int tiled_dim_size = 1;
-        // for (auto tile : tile_info.tileSizes) {
-        //   int dim = tile.first;
-        //   if (output_shape[dim] == ShapedType::kDynamicSize) {
-        //     tiled_dim_size = ShapedType::kDynamicSize;
-        //     break;
-        //   } else {
-        //     tiled_dim_size *= output_shape[dim];
-        //   }
-        // }
         if (collapsed_tile_dim != ShapedType::kDynamicSize) {
           auto bit_width = row_per_block * collapsed_tile_dim *
                            output_type.getElementType().getIntOrFloatBitWidth();

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -372,7 +372,9 @@ class FusionPattern : public FusionPatternBase {
       SkeletonGroup group, DenseSet<Operation*>& ops,
       DenseSet<Operation*>& shmem_cached_ops,
       const DenseMap<Operation*, SmallVector<Operation*>>& existing_group_ops,
-      int& shmem_usage_bits, const int shmem_limit_bits);
+      int row_per_block, int& shmem_usage_bits, const int shmem_limit_bits);
+
+  int64_t getCollapsedTileDim(Value value);
 
   DenseSet<Operation*>& getRegularXroots() { return regular_xroots_; }
 

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -368,7 +368,11 @@ class FusionPattern : public FusionPatternBase {
     DenseSet<Operation*> irregular_root_member_set;
   };
 
-  void findOpsOfSkeletonGroup(SkeletonGroup group, DenseSet<Operation*>& ops);
+  void findOpsOfSkeletonGroup(
+      SkeletonGroup group, DenseSet<Operation*>& ops,
+      DenseSet<Operation*>& shmem_cached_ops,
+      const DenseMap<Operation*, SmallVector<Operation*>>& existing_group_ops,
+      int& shmem_usage_bits, const int shmem_limit_bits);
 
   DenseSet<Operation*>& getRegularXroots() { return regular_xroots_; }
 

--- a/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.cc
+++ b/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.cc
@@ -182,57 +182,6 @@ LogicalResult InputInlineFusionPattern::processParallelOp(
   return failure();
 }
 
-LogicalResult InputInlineFusionPattern::processParallelOpGreedyly(
-    scf::ParallelOp parallel_op, Block* parent_block, PatternRewriter& rewriter,
-    const DominanceInfo& dominance_info) const {
-  bool has_change = false;
-  bool changed = false;
-  do {
-    changed = false;
-    SmallVector<memref::LoadOp, 4> load_ops;
-    parallel_op->walk(
-        [&](memref::LoadOp load_op) { load_ops.push_back(load_op); });
-    for (auto load_op : load_ops) {
-      auto lhlo_op = getFusibleOperation(load_op);
-      if (!lhlo_op) continue;
-      // 1, in case of:
-      //      A = ...
-      //      B = op(A)
-      //      C = op(A, B)
-      //    C should fuse B first before fusing A.
-      //    This is the same logic as in instruction_fusion pass of XLA
-      //
-      // 2, When multiple loads consume the same result of lhlo_op and
-      //    the load indices are also identical, the ir should be
-      //    emitted only once. Other LoadOps should use cached Value.
-
-      // 'load_ops' that can consume the same cached value
-      SmallVector<memref::LoadOp> same_load_ops;
-      bool can_remove_producer;
-      if (!checkIfFusible(parallel_op, lhlo_op, load_op, can_remove_producer,
-                          same_load_ops, dominance_info))
-        continue;
-      // 'load_op' is always the one that locates in the most
-      // external code block among all the 'same_load_ops', because the walker
-      // is in the post order sequence.
-      if (failed(inlineFuseLhloOp(rewriter, parallel_op, lhlo_op, load_op,
-                                  same_load_ops, lower_config_)))
-        return failure();
-      changed = true;
-      if (can_remove_producer) rewriter.eraseOp(lhlo_op);
-      for (memref::LoadOp to_be_removed : same_load_ops)
-        rewriter.eraseOp(to_be_removed);
-
-      // Clean all the ops that do not have LoadOps inside the nested
-      // ParallelOps and is not the ancestor of any ops that have LoadOps
-      // inside the nested ParallelOps.
-      cleanUnusedLhloOps(parent_block, &rewriter);
-    }
-  } while (changed);
-
-  return has_change ? success() : failure();
-}
-
 Operation* InputInlineFusionPattern::getFusibleOperation(
     memref::LoadOp load_op) const {
   Operation* lhlo_op = nullptr;

--- a/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.h
+++ b/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.h
@@ -100,14 +100,14 @@ class InputInlineFusionPattern : public RewritePattern {
 
     // Returns success if any of parallelOp is processed.
     for (scf::ParallelOp parallelOp : innermostPloops) {
-      // auto func = one_pass_ ? processParallelOpGreedyly : processParallelOp;
       auto status = one_pass_
                         ? processParallelOpGreedyly(parallelOp, &parent_block,
                                                     rewriter, dominance_info)
                         : processParallelOp(parallelOp, &parent_block, rewriter,
                                             dominance_info);
-      // if (!failed(func(parallelOp, &parent_block, rewriter, dominance_info)))
-      if (!failed(status)) return success();
+      if (!failed(status)) {
+        return success();
+      }
     }
     return failure();
   }

--- a/tao_compiler/mlir/disc/transforms/lhlo_elemental_utils.h
+++ b/tao_compiler/mlir/disc/transforms/lhlo_elemental_utils.h
@@ -133,8 +133,7 @@ class LowerConfig {
     specific_stores_[store_for] = store;
   }
 
-  //  private:
- public:
+ private:
   DenseMap<std::pair<Operation*, Value>, SpecificLoader> specific_loaders_;
   DenseMap<std::pair<Operation*, Value>, SpecificStore> specific_stores_;
   DenseSet<Operation*> is_written_back_;

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -472,15 +472,6 @@ Value emitReduceMapOp(OpBuilder& b, Location loc, Operation* map_op, Value lhs,
   return result;
 }
 
-Type getLhloOpsElementType(Operation* op) {
-  unsigned int num_operands = op->getNumOperands();
-  Type result_type = op->getOperand(num_operands - 1)
-                         .getType()
-                         .cast<MemRefType>()
-                         .getElementType();
-  return result_type;
-}
-
 void emitNotToVectorReduction(OpBuilder& b, Location loc, Operation* root_op,
                               ValueRange index) {
   assert(isa<lmhlo::ReduceOp>(root_op));
@@ -1606,10 +1597,12 @@ LogicalResult lowerWithScheduleRowReduction<DISC_BLOCK_WISE_ROW_REDUCE>(
   b.create<scf::YieldOp>(loc, yield_values_for_j);
 
   b.setInsertionPointToEnd(parallel_op.getBody());
-  emitFirstRoundShuffle(
-      b, loc, row_reduction_ops, shared_mem_map_vec,
-      for_op_j.getResults().begin(),  // + i * row_reduction_ops.size(),
-      lane_id_is_zero, warp_id, vector_size);
+  if (failed(emitFirstRoundShuffle(
+          b, loc, row_reduction_ops, shared_mem_map_vec,
+          for_op_j.getResults().begin(),  // + i * row_reduction_ops.size(),
+          lane_id_is_zero, warp_id, vector_size))) {
+    return failure();
+  }
   b.setInsertionPointToEnd(parallel_op.getBody());
   b.create<gpu::BarrierOp>(loc);
 
@@ -1679,8 +1672,11 @@ LogicalResult lowerWithScheduleRowReduction<DISC_BLOCK_WISE_ROW_REDUCE>(
   b.create<scf::YieldOp>(loc, false_yield_values);
   b.setInsertionPointToEnd(parallel_op.getBody());
   auto acc_iter = if_lane_id_inbound.getResults().begin();
-  emitSecondRoundShuffle(b, loc, row_reduction_ops, acc_iter, thread_id_is_zero,
-                         row_ids, vector_size, getThreadPerBlock(dominant_op));
+  if (failed(emitSecondRoundShuffle(b, loc, row_reduction_ops, acc_iter,
+                                    thread_id_is_zero, row_ids, vector_size,
+                                    getThreadPerBlock(dominant_op)))) {
+    return failure();
+  }
 
   b.setInsertionPointToEnd(parallel_op.getBody());
   b.create<scf::YieldOp>(loc, ValueRange({}));
@@ -2677,10 +2673,12 @@ LogicalResult emitRowReduceThreadBlock(
     }
     warp_reduce_result_shm[i] = shared_mem;
   }
-  emitFirstRoundShuffleStitch(
-      b, loc, op, warp_reduce_result_shm, for_op_j.getResults().begin(),
-      warp_id, lane_id_is_zero, row_tile, reduce_threads, result_buffer_shm,
-      row_ids, block_row_offset, external_output_only, is_output);
+  if (failed(emitFirstRoundShuffleStitch(
+          b, loc, op, warp_reduce_result_shm, for_op_j.getResults().begin(),
+          warp_id, lane_id_is_zero, row_tile, reduce_threads, result_buffer_shm,
+          row_ids, block_row_offset, external_output_only, is_output))) {
+    return failure();
+  }
 
   // Finally, for block-wise schedule, emit second round reduction.
   if (reduce_threads == kWarpSize) {
@@ -2703,8 +2701,8 @@ LogicalResult emitRowReduceThreadBlock(
 LogicalResult initSkeletonGrpsAndCloneOps(
     lmhlo::FusionOp& fusion_op, FusionPattern& fusion_pattern,
     SmallVector<FusionPattern::SkeletonGroup>& skeleton_groups,
-    ShapeAnalysis* shape_analysis, LowerConfig& lower_config,
-    bool merge_group) {
+    ShapeAnalysis* shape_analysis, LowerConfig& lower_config, bool merge_group,
+    int shmem_limit_bytes = 8192) {
   if (!getOrderedSkeletonGroups(fusion_pattern, skeleton_groups)) {
     return failure();
   }
@@ -2723,11 +2721,24 @@ LogicalResult initSkeletonGrpsAndCloneOps(
   // Find ops in the group and reorder according to `op_list`.
   // { skeleton, group-ops-inorder }
   DenseMap<Operation*, SmallVector<Operation*>> skeleton_group_ops;
+  DenseSet<Operation*> shmem_cached_ops;
+  int shmem_usage_bits = 0;
+  for (auto& skeleton_group : skeleton_groups) {
+    auto skeletons = skeleton_group.skeletons;
+    for (auto& skeleton : skeletons) {
+      auto output_type = getLhloOpsElementType(skeleton);
+      auto bit_width = output_type.getIntOrFloatBitWidth();
+      shmem_usage_bits += bit_width;
+    }
+  }
+  int shmem_limit_bits = shmem_limit_bytes * 8;
   for (auto& skeleton_group : skeleton_groups) {
     auto skeletons = skeleton_group.skeletons;
     // Find ops in the group and reorder according to `op_list`.
     DenseSet<Operation*> group_ops;
-    fusion_pattern.findOpsOfSkeletonGroup(skeleton_group, group_ops);
+    fusion_pattern.findOpsOfSkeletonGroup(skeleton_group, group_ops,
+                                          shmem_cached_ops, skeleton_group_ops,
+                                          shmem_usage_bits, shmem_limit_bits);
     SmallVector<Operation*>& group_ops_inorder =
         skeleton_group_ops[skeletons[0]];
     for (auto op : op_list) {
@@ -2736,6 +2747,18 @@ LogicalResult initSkeletonGrpsAndCloneOps(
       }
     }
   }
+#if 1
+  llvm::errs() << "[ZZ] shmem cached ops:\n";
+  for (auto op : shmem_cached_ops) {
+    llvm::errs() << "\t[ZZ] " << *op << "\n";
+  }
+  for (auto& skeleton_group_op : skeleton_group_ops) {
+    llvm::errs() << "[ZZ] skeleton: " << *(skeleton_group_op.first) << "\n";
+    for (auto op : skeleton_group_op.second) {
+      llvm::errs() << "\t[ZZ] op: " << *op << "\n";
+    }
+  }
+#endif
 
   // Clone ops in each group and build written flags in `lower_config`.
   // Note that for irregular-xroot occurs in several skeleton-groups, it
@@ -3353,7 +3376,10 @@ LogicalResult emitRowReduceThreadBlockV2(
     for (int64_t i = 0; i < ops.size(); i++) {
       warp_reduces.push_back(for_local_reduce.getResult(i));
     }
-    emitWarpReduce(b, loc, ops, accumFactories, warp_reduces, kWarpSize);
+    if (failed(emitWarpReduce(b, loc, ops, accumFactories, warp_reduces,
+                              kWarpSize))) {
+      return failure();
+    }
 
     // 3. Store warp-reduce result.
     // If it is one-block-one-row reduce, the result will be stored in shm for
@@ -3500,7 +3526,8 @@ LogicalResult lowerWithScheduleStitchV2(lmhlo::FusionOp& fusion_op,
                                         ShapeAnalysis* shape_analysis,
                                         int64_t ilp_factor,
                                         LowerConfig& lower_config,
-                                        int row_reduction_schedule) {
+                                        int row_reduction_schedule,
+                                        int shmem_limit_bytes) {
   auto root_ops = fusion_pattern.getRootOps();
   auto sub_root_ops = fusion_pattern.getSubRootOps();
   auto result_values = fusion_pattern.getResults();
@@ -3531,9 +3558,9 @@ LogicalResult lowerWithScheduleStitchV2(lmhlo::FusionOp& fusion_op,
   }
 
   SmallVector<FusionPattern::SkeletonGroup> skeleton_groups;
-  if (failed(initSkeletonGrpsAndCloneOps(fusion_op, fusion_pattern,
-                                         skeleton_groups, shape_analysis,
-                                         lower_config, true))) {
+  if (failed(initSkeletonGrpsAndCloneOps(
+          fusion_op, fusion_pattern, skeleton_groups, shape_analysis,
+          lower_config, true, shmem_limit_bytes))) {
     LLVM_DEBUG(llvm::dbgs() << "Fail to init skeleton groups or clone.\n");
     return failure();
   }
@@ -3782,7 +3809,8 @@ static void createPrintFusionParams(lmhlo::FusionOp fusion,
 
 LogicalResult HandleGpuFusionOp(OpBuilder& b, Operation* fusion,
                                 ShapeAnalysis* shape_analysis,
-                                LowerConfig& lower_config, int core_count) {
+                                LowerConfig& lower_config, int core_count,
+                                int cc_major, int cc_minor) {
   auto fusion_op = cast<lmhlo::FusionOp>(fusion);
   assert(fusion_op);
   FusionPattern fusion_pattern(fusion_op, shape_analysis);
@@ -3922,9 +3950,11 @@ LogicalResult HandleGpuFusionOp(OpBuilder& b, Operation* fusion,
       const int row_reduction_schedule =
           getRowReductionScheduleHint(dominant_op);
       if (isMemIntensiveOptExperimentalEnabled()) {
+        const int shmem_limit_bytes =
+            getShmemSizeBytesNotAffectOccupancy(cc_major, cc_minor);
         if (failed(lowerWithScheduleStitchV2(
                 fusion_op, fusion_pattern, shape_analysis, tile_size,
-                lower_config, row_reduction_schedule))) {
+                lower_config, row_reduction_schedule, shmem_limit_bytes))) {
           return fusion->emitError() << "failed to lower kStitch fusion V2.";
         }
       } else {
@@ -5150,8 +5180,11 @@ LogicalResult HandleCpuFusionOp(OpBuilder& b, Operation* fusion,
 struct DiscLhloLegalizeRootsToParallelLoops
     : public DiscLhloLegalizeRootsToParallelLoopsPassBase<
           DiscLhloLegalizeRootsToParallelLoops> {
-  DiscLhloLegalizeRootsToParallelLoops(int core_count) {
+  DiscLhloLegalizeRootsToParallelLoops(int core_count, int cc_major,
+                                       int cc_minor) {
     core_count_ = core_count;
+    cc_major_ = cc_major;
+    cc_minor_ = cc_minor;
   }
 
   void getDependentDialects(DialectRegistry& registry) const override {
@@ -5252,7 +5285,7 @@ struct DiscLhloLegalizeRootsToParallelLoops
     for (Operation* fusion : gpu_fusion_worklist) {
       // Error message should be emitted inside the function.
       if (failed(HandleGpuFusionOp(b, fusion, &shape_analysis, lower_config,
-                                   core_count_))) {
+                                   core_count_, cc_major_, cc_minor_))) {
         signalPassFailure();
         return;
       }
@@ -5321,8 +5354,10 @@ struct DiscLhloLegalizeRootsToParallelLoops
 };
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createDiscLhloLegalizeRootsToParallelLoopsPass(int core_count) {
-  return std::make_unique<DiscLhloLegalizeRootsToParallelLoops>(core_count);
+createDiscLhloLegalizeRootsToParallelLoopsPass(int core_count, int cc_major,
+                                               int cc_minor) {
+  return std::make_unique<DiscLhloLegalizeRootsToParallelLoops>(
+      core_count, cc_major, cc_minor);
 }
 
 }  // namespace disc_ral

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -5379,7 +5379,7 @@ struct DiscLhloLegalizeRootsToParallelLoops
     {
       auto* context = &this->getContext();
       RewritePatternSet patterns(context);
-      patterns.insert<InputInlineFusionPattern>(context, &lower_config, true);
+      patterns.insert<InputInlineFusionPattern>(context, &lower_config);
 
       // Just apply the patterns greedily.
       // There should always be one scf.ParallelOp in the fusion.

--- a/tao_compiler/mlir/disc/transforms/passes.h
+++ b/tao_compiler/mlir/disc/transforms/passes.h
@@ -50,7 +50,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createReviseArgsForStaticRankPass();
 
 // Lowers the roots of lmhlo.fusion to parallel loops
 std::unique_ptr<OperationPass<FuncOp>>
-createDiscLhloLegalizeRootsToParallelLoopsPass(int sm_count = -1);
+createDiscLhloLegalizeRootsToParallelLoopsPass(int sm_count = -1,
+                                               int cc_major = 8,
+                                               int cc_minor = 0);
 
 // Canonicalize conv ops to be suitable for lowering to cudnn lib calls.
 std::unique_ptr<OperationPass<FuncOp>> createDiscConvRewriter(int cc_major = 8,


### PR DESCRIPTION
This PR uses shared memory to cached intermediate data of element-wise ops that could be reused across different stitch groups. It helps to reduce redundant computation and off-chip memory traffic. It requires that `DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL=true`.