### PR TITLE
Support decoder-only generation in hf transformers adapter.

### DIFF
--- a/examples/PyTorch/Inference/hf_transformers/tests/test_optimize.py
+++ b/examples/PyTorch/Inference/hf_transformers/tests/test_optimize.py
@@ -13,7 +13,7 @@ import os
 import unittest
 
 import torch
-from blade_adapter import BladeModel, optimize
+from blade_adapter import WrapperModel, optimize
 from transformers import AutoModelForMaskedLM, PreTrainedModel
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -24,7 +24,7 @@ class OptimizeTest(unittest.TestCase):
     def test_no_task_no_model(self):
         self.assertRaises(ValueError, optimize)
 
-    def _eval_models(self, blade_model: BladeModel, eager_model: PreTrainedModel) -> None:
+    def _eval_models(self, blade_model: WrapperModel, eager_model: PreTrainedModel) -> None:
         inputs = blade_model.info.dummy_inputs
         blade_outputs = blade_model(**inputs)
         eager_outputs = eager_model(**inputs)

--- a/examples/PyTorch/Inference/hf_transformers/tests/test_trace_model.py
+++ b/examples/PyTorch/Inference/hf_transformers/tests/test_trace_model.py
@@ -1,0 +1,36 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from blade_adapter import _kwargs_to_args, create_model, trace_model
+from parameterized import parameterized
+
+
+class TraceModelTest(unittest.TestCase):
+    @parameterized.expand([
+        'bert-base-uncased',
+        'gpt2',
+    ])
+    def test_trace_converage(self, id_or_path: str) -> None:
+        model, info = create_model(id_or_path=id_or_path, torchscript=True)
+        traced = trace_model(model, info)
+        golden_outputs = model(**info.dummy_inputs)
+        inputs = _kwargs_to_args(info.input_order, **info.dummy_inputs)
+        traced_outputs = traced(*inputs)
+        self.assertEqual(len(golden_outputs), len(traced_outputs))
+        for a, b in zip(golden_outputs, traced_outputs):
+            torch.testing.assert_close(a, b, rtol=0.01, atol=0.01)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/PyTorch/Inference/hf_transformers/tests/test_wrapper_model.py
+++ b/examples/PyTorch/Inference/hf_transformers/tests/test_wrapper_model.py
@@ -1,0 +1,29 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from blade_adapter import WrapperModel, create_model, trace_model
+from transformers import GPT2LMHeadModel
+
+
+class WrapperModelTest(unittest.TestCase):
+    def test_create_wrapper_model(self):
+        model, info = create_model(id_or_path='gpt2', torchscript=True)
+        traced = trace_model(model, info)
+        wrapper_model = WrapperModel.create_wrapper_model(traced, info)
+        self.assertEqual(type(wrapper_model).__name__,
+                         'GPT2LMHeadModelBladeWrapper')
+        self.assertIsInstance(wrapper_model, GPT2LMHeadModel)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactor huggingface transformer adapter to support decoder-only generation pipeline (e.g. text-generation with gpt2):
- programmatically create wrapper class (inherited from original hf transfromers model class) to keep generation related methods (e.g. prepare_inputs_for_generation).
- specify default forward kwargs (e.g. use_cache) so we can torch.jit.trace model correctly.
- add some unit tests.

Some TODOs (will be implemented in future PRs):
- support use_cache=True for decoder-only model
- support encoder-decoder generation model (e.g. bart, t5)