### PR TITLE
[transform] convert foreach thread op to parallel right before outline cpu kernel

### DIFF
--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -63,6 +63,7 @@ limitations under the License.
 #include "mlir/Target/LLVMIR/Export.h"  // from @llvm-project
 #include "mlir/Transforms/Passes.h"
 #include "tensorflow/compiler/mlir/disc/disc_util.h"
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/passes.h"
 #include "tensorflow/compiler/mlir/disc/transforms/codegen_utils.h"
 #include "tensorflow/compiler/mlir/disc/transforms/fusion_utils.h"
 #include "tensorflow/compiler/mlir/disc/transforms/passes.h"
@@ -586,6 +587,8 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
     pm.addPass(createGpuKernelOutliningPass());
     pm.addPass(disc_ral::createDiscAssignKernelNamePass());
   } else {
+    pm.addNestedPass<FuncOp>(
+        disc_ral::createDiscConvertForeachThreadOpToParallelOpPass());
     if (options.cpu_options.target_multi_threading) {
       pm.addNestedPass<FuncOp>(disc_ral::createDiscCpuMapParallelLoopPass());
       pm.addPass(disc_ral::createDiscOutlineCpuKernelPass());

--- a/tao_compiler/mlir/disc/tools/disc-transform/BUILD
+++ b/tao_compiler/mlir/disc/tools/disc-transform/BUILD
@@ -372,6 +372,23 @@ cc_library(
 )
 
 cc_library(
+    name = "convert-foreach-thread-op-to-parallel-op",
+    srcs = ["transforms/convert_foreach_thread_op_to_parallel_op.cc"],
+    deps = [
+        ":pass_details",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "all_passes",
     hdrs = [
         "transforms/passes.h",
@@ -381,6 +398,7 @@ cc_library(
         ":friends",
     ],
     deps = [
+        ":convert-foreach-thread-op-to-parallel-op",
         ":legalize_lmhlo_fusion_to_linalg",
         ":memref_copy_to_linalg",
         ":rewrite-payload-ir-for-ral",

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/convert_foreach_thread_op_to_parallel_op.cc
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/convert_foreach_thread_op_to_parallel_op.cc
@@ -1,0 +1,88 @@
+// Copyright 2023 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "tensorflow/compiler/mlir/disc/tools/disc-transform/transforms/PassDetail.h"
+
+#define DEBUG_TYPE "disc-convert-foreach-thread-op-to-parallel-op"
+
+// This file implements the logic to convert scf.foreach_thread to scf.parallel
+
+namespace mlir {
+namespace disc_ral {
+namespace {
+
+using func::FuncOp;
+using scf::ForeachThreadOp;
+using scf::ParallelOp;
+
+struct ForeachThreadToParallel : public OpRewritePattern<ForeachThreadOp> {
+  using OpRewritePattern<ForeachThreadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ForeachThreadOp foreachThreadOp,
+                                PatternRewriter& rewriter) const override {
+    if (foreachThreadOp->getNumResults() != 0) return failure();
+    Location loc = foreachThreadOp.getLoc();
+    int64_t rank = foreachThreadOp.getRank();
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    SmallVector<Value> lowerBounds(rank, zero);
+    SmallVector<Value> upperBounds = foreachThreadOp.getNumThreads();
+    SmallVector<Value> steps(rank, one);
+
+    auto parallelOp =
+        rewriter.create<scf::ParallelOp>(loc, lowerBounds, upperBounds, steps);
+    BlockAndValueMapping mapping;
+    for (const auto& z : llvm::zip(foreachThreadOp.getThreadIndices(),
+                                   parallelOp.getInductionVars()))
+      mapping.map(std::get<0>(z), std::get<1>(z));
+    rewriter.setInsertionPointToStart(parallelOp.getBody());
+    for (auto& nestedOp : foreachThreadOp.getBody()->without_terminator()) {
+      rewriter.clone(nestedOp, mapping);
+    }
+    rewriter.replaceOp(foreachThreadOp, parallelOp->getResults());
+    return success();
+  }
+};
+
+struct DiscConvertForeachThreadOpToParallelOpPass
+    : public DiscConvertForeachThreadOpToParallelOpPassBase<
+          DiscConvertForeachThreadOpToParallelOpPass> {
+  void runOnOperation() override;
+};
+
+void DiscConvertForeachThreadOpToParallelOpPass::runOnOperation() {
+  MLIRContext* context = &getContext();
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<ForeachThreadToParallel>(context);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscConvertForeachThreadOpToParallelOpPass() {
+  return std::make_unique<DiscConvertForeachThreadOpToParallelOpPass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/passes.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/passes.h
@@ -60,6 +60,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createDiscRewritePayloadIRForRALPass(
 // Converts a memref.copy op to its linalg equivalent
 std::unique_ptr<OperationPass<func::FuncOp>> createDiscMemrefCopyToLinalgPass();
 
+// Converts scf.foreach_thread to scf.parallel
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscConvertForeachThreadOpToParallelOpPass();
+
 }  // namespace disc_ral
 }  // namespace mlir
 

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/rewrite_payload_ir_for_ral.cc
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/rewrite_payload_ir_for_ral.cc
@@ -46,60 +46,11 @@ struct DiscRewritePayloadIRForRALPass
   }
   void runOnOperation() override;
 
-  // replace scf::foreach_thread op with scf::parallel op
-  LogicalResult convertForeachThreadToParallelOp();
-  LogicalResult funcLevelConvertForeachThreadToParallelOp(FuncOp funcOp);
-
   // assign placement info for each memref value, e.g. memref<f32> ->
   // memref<f32, "cpu">
   LogicalResult assignPlacement();
   LogicalResult assignPlacementForFuncOp(FuncOp funcOp);
 };
-
-LogicalResult
-DiscRewritePayloadIRForRALPass::funcLevelConvertForeachThreadToParallelOp(
-    FuncOp funcOp) {
-  SmallVector<ForeachThreadOp> forOps;
-  funcOp.walk([&](ForeachThreadOp op) { forOps.push_back(op); });
-
-  OpBuilder b(funcOp);
-  for (ForeachThreadOp foreachThreadOp : forOps) {
-    if (foreachThreadOp.getOutputs().size() != 0)
-      return foreachThreadOp->emitError()
-             << "Not support ForeachThreadOp with outputs a.t.m.\n";
-
-    b.setInsertionPoint(foreachThreadOp);
-    Location loc = foreachThreadOp.getLoc();
-    int64_t rank = foreachThreadOp.getRank();
-    Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
-    Value one = b.create<arith::ConstantIndexOp>(loc, 1);
-    SmallVector<Value> lowerBounds(rank, zero);
-    SmallVector<Value> upperBounds = foreachThreadOp.getNumThreads();
-    SmallVector<Value> steps(rank, one);
-
-    auto parallelOp =
-        b.create<ParallelOp>(loc, lowerBounds, upperBounds, steps);
-    BlockAndValueMapping mapping;
-    for (const auto& z : llvm::zip(foreachThreadOp.getThreadIndices(),
-                                   parallelOp.getInductionVars()))
-      mapping.map(std::get<0>(z), std::get<1>(z));
-    b.setInsertionPointToStart(parallelOp.getBody());
-    for (auto& nestedOp : foreachThreadOp.getBody()->without_terminator()) {
-      Operation* cloned = b.clone(nestedOp, mapping);
-    }
-    foreachThreadOp->erase();
-  }
-  return success();
-}
-
-LogicalResult
-DiscRewritePayloadIRForRALPass::convertForeachThreadToParallelOp() {
-  for (auto funcOp : getOperation().getOps<FuncOp>()) {
-    if (failed(funcLevelConvertForeachThreadToParallelOp(funcOp)))
-      return failure();
-  }
-  return success();
-}
 
 LogicalResult DiscRewritePayloadIRForRALPass::assignPlacementForFuncOp(
     FuncOp funcOp) {
@@ -170,14 +121,7 @@ LogicalResult DiscRewritePayloadIRForRALPass::assignPlacement() {
 }
 
 void DiscRewritePayloadIRForRALPass::runOnOperation() {
-  // 1, rewrite scf.foreach_thread to scf.parallel
-  if (failed(convertForeachThreadToParallelOp())) {
-    return signalPassFailure();
-  }
-  LLVM_DEBUG(llvm::dbgs() << "After ForeachThreadOp -> ParallelOp:\n"
-                          << getOperation() << "\n");
-
-  // 2, assign placement info for each memref value.
+  // assign placement info for each memref value.
   if (failed(assignPlacement())) {
     return signalPassFailure();
   }

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.td
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_passes.td
@@ -55,3 +55,8 @@ def DiscMemrefCopyToLinalgPass : Pass<"disc-memref-copy-to-linalg", "func::FuncO
       "linalg::LinalgDialect",
   ];
 }
+
+def DiscConvertForeachThreadOpToParallelOpPass : Pass<"disc-convert-foreach-thread-op-to-parallel-op", "func::FuncOp"> {
+  let summary = "Pass to convert memref.copy to linalg.";
+  let constructor = "createDiscConvertForeachThreadOpToParallelOpPass()";
+}

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -311,6 +311,34 @@ std::string generateSignatureForFusion(FusionPattern& fusionPattern) {
     sig.push_back('_');
   }
 
+  if (fusionPattern.isTransformBasedFusion()) {
+    if (auto dotOp = dyn_cast_or_null<lmhlo::DotGeneralOp>(
+            fusionPattern.getDominantOp())) {
+      auto lhsTy = dotOp->getOperand(0).getType().cast<MemRefType>();
+      auto rhsTy = dotOp->getOperand(1).getType().cast<MemRefType>();
+      auto appendShapeToStr = [&](ArrayRef<int64_t> shape) {
+        for (const auto& en : llvm::enumerate(shape)) {
+          if (en.index() > 0) sig.append("x");
+          if (en.value() == ShapedType::kDynamicSize) {
+            sig.append("u");
+          } else {
+            sig.append(Twine(en.value()).str());
+          }
+        }
+      };
+      sig.append("_LS_");
+      appendShapeToStr(lhsTy.getShape());
+      sig.append("_RS_");
+      appendShapeToStr(rhsTy.getShape());
+      auto dimNumbers = dotOp.getDotDimensionNumbers();
+      sig.append("_LC_");
+      appendShapeToStr(dimNumbers.getLhsContractingDimensions());
+      sig.append("_RC_");
+      appendShapeToStr(dimNumbers.getRhsContractingDimensions());
+      sig.append("_");
+    }
+  }
+
   sig.append(
       ("_" + Twine(num_ops) + "_" + Twine(fusionPattern.getResults().size()))
           .str());


### PR DESCRIPTION
single iteration `scf.parallel` op will be removed, making the outline cpu kernel pass failed to outline transform based codegen kernel (we only support single thread a.t.m.). This PR convert foreach thread op to parallel op right before output cpu kernel pass to avoid it's being removed.

to #787 