### PR TITLE
Add config option to force multiple cuda devices into a single one

### DIFF
--- a/pytorch_blade/torch_blade/config.py
+++ b/pytorch_blade/torch_blade/config.py
@@ -189,6 +189,7 @@ class Config(ConfigContext):
         # TODO(tanyo): merge dynamic_tuning_shapes and annotate_args
         self._annotate_args: List[Optional[ArgAnnotation]] = []
         self._experimental_subgraph_conversion_parallelism = 1
+        self._force_gpu_constants_to_device = ''
 
     @property
     def optimization_pipeline(self):
@@ -601,3 +602,15 @@ class Config(ConfigContext):
         assert isinstance(val, int), \
             "experimental_subgraph_conversion_parallelism should be int, got {}".format(type(val))
         self._experimental_subgraph_conversion_parallelism = val
+
+    @property
+    def force_gpu_constants_to_device(self):
+        """Force to move all prim::Constant on multiple CUDA devices in the model to this device.
+        """
+        return self._force_gpu_constants_to_device
+
+    @force_gpu_constants_to_device.setter
+    def force_gpu_constants_to_device(self, val):
+        assert isinstance(val, str), "device should be str, got {}".format(type(val))
+        assert val.startswith('cuda:') or val == "cuda", "device should be cuda device, got {}".format(val)
+        self._force_gpu_constants_to_device = val

--- a/pytorch_blade/torch_blade/exporter.py
+++ b/pytorch_blade/torch_blade/exporter.py
@@ -41,6 +41,7 @@ def _script_module_preprocess(s_module, inputs, input_dims=[]):
     graph = s_module._c.forward.graph
     torch._C._jit_pass_inline(graph)
     pm._jit_pass_hack_cpu_device(graph)
+    pm._jit_pass_hack_gpu_device(graph)
 
     cfg = Config.get_current_context_or_new()
     for jit_pass in cfg.customize_jit_passes:


### PR DESCRIPTION
In some case, a model may be exported with multiple devices. While for inference, only a single device is required. This option is to force all constant on all CUDA devices to the specified one.
It is potentially unsafe, just like `enable_force_to_cuda`, and should be used with care.