### PR TITLE
refactor: add sparse_segment_reduction to support both sparse_segment_mean/sum

### DIFF
--- a/tao/tao_bridge/passes/tao_mark_for_compilation_pass.cc
+++ b/tao/tao_bridge/passes/tao_mark_for_compilation_pass.cc
@@ -2683,6 +2683,7 @@ std::vector<string> GetDiscSupportedOps() {
       "SparseReshape",
       "SparseFillEmptyRows",
       "SparseSegmentMean",
+      "SparseSegmentSum",
       "Where",
     });
   }

--- a/tao/tao_bridge/tf/xla_op_registry.cc
+++ b/tao/tao_bridge/tf/xla_op_registry.cc
@@ -1248,6 +1248,7 @@ REGISTER_XLA_OP_FOR_TAO(Name("QuantizedConv2DWithBiasAndRequantize"));
 REGISTER_XLA_OP_FOR_TAO(Name("SparseReshape"));
 REGISTER_XLA_OP_FOR_TAO(Name("SparseFillEmptyRows"));
 REGISTER_XLA_OP_FOR_TAO(Name("SparseSegmentMean"));
+REGISTER_XLA_OP_FOR_TAO(Name("SparseSegmentSum"));
 REGISTER_XLA_OP_FOR_TAO(Name("Where"));
 #endif // TF_VERSION
 #endif // TAO_CPU_ONLY

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -2453,6 +2453,26 @@ cc_library(
 )
 
 gentbl_cc_library(
+    name = "lmhlo_disc_enums_inc_gen",
+    compatible_with = get_compatible_with_cloud(),
+    tbl_outs = [
+        (
+            ["-gen-enum-decls"],
+            "IR/lhlo_disc_enums.h.inc",
+        ),
+        (
+            ["-gen-enum-defs"],
+            "IR/lhlo_disc_enums.cc.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "IR/lhlo_disc_enums.td",
+    deps = [
+        "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:hlo_ops_td_files",
+    ],
+)
+
+gentbl_cc_library(
     name = "lmhlo_disc_ops_inc_gen",
     compatible_with = get_compatible_with_cloud(),
     strip_include_prefix = "",
@@ -2469,8 +2489,12 @@ gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "IR/lhlo_disc_ops.td",
     deps = [
-        "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:hlo_ops_td_files",
-    ],
+        ":lmhlo_disc_enums_inc_gen",
+    ] + if_torch_disc(
+        ["@mlir-hlo//:hlo_ops_td_files"],
+        ["@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:hlo_ops_td_files"]
+    )
+
 )
 
 cc_library(
@@ -2484,6 +2508,7 @@ cc_library(
         "IR/lhlo_disc_ops.h",
     ],
     deps = [
+        ":lmhlo_disc_enums_inc_gen",
         ":lmhlo_disc_ops_inc_gen",
         "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:lhlo",
         "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:lhlo_ops_structs_inc_gen",

--- a/tao_compiler/mlir/disc/IR/hlo_disc_enums.td
+++ b/tao_compiler/mlir/disc/IR/hlo_disc_enums.td
@@ -34,5 +34,19 @@ def HLO_RoundModeEnum: I64EnumAttr<"RoundModeEnum",
   let cppNamespace = "::mlir::mhlo_disc";
 }
 
+// The reduction mode enum used for HLO_DISC_SparseSegmentReduction
+def HLO_ReductionModeMean : I64EnumAttrCase<"Mean", 0>;
+def HLO_ReductionModeSum : I64EnumAttrCase<"Sum", 1>;
+def HLO_ReductionModeSqrtn : I64EnumAttrCase<"Sqrtn", 2>;
+def HLO_ReductionModeEnum: I64EnumAttr<"ReductionModeEnum",
+    "Reduction model enum used for sparse reduction now",
+    [
+        HLO_ReductionModeMean,
+        HLO_ReductionModeSum,
+        HLO_ReductionModeSqrtn
+    ]> {
+  let summary = "Reduction mode in sparse segment redcution ops";
+  let cppNamespace = "::mlir::mhlo_disc";
+}
 
 #endif // MHLO_DISC_ENUMS

--- a/tao_compiler/mlir/disc/IR/hlo_disc_ops.cc
+++ b/tao_compiler/mlir/disc/IR/hlo_disc_ops.cc
@@ -837,13 +837,13 @@ LogicalResult SparseFillEmptyRowsOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SparseSegmentMeanOp
+// SparseSegmentReductionOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult SparseSegmentMeanOp::reifyReturnTypeShapes(
+LogicalResult SparseSegmentReductionOp::reifyReturnTypeShapes(
     OpBuilder& builder, ValueRange operands,
     SmallVectorImpl<Value>& reifiedReturnShapes) {
-  SparseSegmentMeanOp::Adaptor adaptor(operands);
+  SparseSegmentReductionOp::Adaptor adaptor(operands);
   Location loc = this->getLoc();
   auto data_type = adaptor.getData().getType().cast<RankedTensorType>();
   auto indices_type = adaptor.getIndices().getType().cast<RankedTensorType>();
@@ -873,7 +873,7 @@ LogicalResult SparseSegmentMeanOp::reifyReturnTypeShapes(
   return success();
 }
 
-LogicalResult SparseSegmentMeanOp::verify() {
+LogicalResult SparseSegmentReductionOp::verify() {
   auto data_type = this->getData().getType().dyn_cast<RankedTensorType>();
   auto indices_type = this->getIndices().getType().dyn_cast<RankedTensorType>();
   auto segment_ids_type =

--- a/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
@@ -339,15 +339,16 @@ def HLO_SparseFillEmptyRowsOp : HLODISC_ShapedInterfaceOp<"sparse_fill_empty_row
   );
 }
 
-def HLO_SparseSegmentMeanOp : HLODISC_ShapedInterfaceOp<"sparse_segment_mean", [Pure]> {
-  let summary = "One-to-one mapping of TF_SparseSegmentMeanOp";
+def HLO_SparseSegmentReductionOp: HLODISC_ShapedInterfaceOp<"sparse_segment_reduction", [Pure]> {
+  let summary = "One-to-one mapping of TF_SparseSegmentMeanOp or TF_SparseSegmentSumOp";
   let description = [{
-    See tf's sparse_segment_mean operator.
+    See tf's sparse_segment_mean or sparse_segment_sum operator.
   }];
   let arguments = (ins
     HLO_FpTensor:$data,
     HLO_I32OrI64Tensor:$indices,
-    HLO_I32OrI64Tensor:$segment_ids
+    HLO_I32OrI64Tensor:$segment_ids,
+    DefaultValuedAttr<BoolAttr, "true">:$is_mean
   );
 
   let results = (outs

--- a/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
@@ -23,7 +23,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir-hlo/Dialect/mhlo/IR/hlo_ops_common.td"
 include "mlir-hlo/Dialect/mhlo/IR/hlo_utils.td"
-include "external/org_tensorflow/tensorflow/compiler/mlir/disc/IR/hlo_disc_enums.td"
+include "mlir/disc/IR/hlo_disc_enums.td"
 
 def HLODISC_Dialect : Dialect {
   let name = "mhlo_disc";
@@ -348,7 +348,7 @@ def HLO_SparseSegmentReductionOp: HLODISC_ShapedInterfaceOp<"sparse_segment_redu
     HLO_FpTensor:$data,
     HLO_I32OrI64Tensor:$indices,
     HLO_I32OrI64Tensor:$segment_ids,
-    DefaultValuedAttr<BoolAttr, "true">:$is_mean
+    DefaultValuedAttr<HLO_ReductionModeEnum, "ReductionModeEnum::Mean">:$reduction_mode
   );
 
   let results = (outs

--- a/tao_compiler/mlir/disc/IR/lhlo_disc_enums.td
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_enums.td
@@ -1,0 +1,39 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This is the operation definition file for LMHLO DISC ops.
+
+#ifndef LMHLO_DISC_ENUMS
+#define LMHLO_DISC_ENUMS
+
+include "mlir/IR/EnumAttr.td"
+
+
+// The reduction mode enum used for LHLO_DISC_SparseSegmentReduction
+def LHLO_ReductionModeMean : I64EnumAttrCase<"Mean", 0>;
+def LHLO_ReductionModeSum : I64EnumAttrCase<"Sum", 1>;
+def LHLO_ReductionModeSqrtn : I64EnumAttrCase<"Sqrtn", 2>;
+def LHLO_ReductionModeEnum: I64EnumAttr<"ReductionModeEnum",
+    "Reduction model enum used for sparse reduction now",
+    [
+        LHLO_ReductionModeMean,
+        LHLO_ReductionModeSum,
+        LHLO_ReductionModeSqrtn
+    ]> {
+  let summary = "Reduction mode in sparse segment redcution ops";
+  let cppNamespace = "::mlir::lmhlo_disc";
+}
+
+#endif // MHLO_DISC_ENUMS

--- a/tao_compiler/mlir/disc/IR/lhlo_disc_ops.cc
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_ops.cc
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include <unordered_set>
 
+#include "mlir/disc/IR/lhlo_disc_enums.cc.inc"
+
 namespace mlir {
 namespace lmhlo_disc {
 

--- a/tao_compiler/mlir/disc/IR/lhlo_disc_ops.h
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_ops.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/disc/IR/lhlo_disc_enums.h.inc"
 
 namespace mlir {
 

--- a/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
@@ -24,6 +24,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir-hlo/Dialect/lhlo/IR/lhlo_ops_base.td"
 include "mlir-hlo/Dialect/lhlo/IR/lhlo_ops_structs.td"
 include "mlir-hlo/Dialect/lhlo/IR/lhlo_structured_interface.td"
+include "mlir/disc/IR/lhlo_disc_enums.td"
 
 def LHLODISC_Dialect : Dialect {
   let name = "lmhlo_disc";
@@ -220,7 +221,7 @@ def LHLO_SparseSegmentReductionOp : LHLODISC_Op<"sparse_segment_reduction", []> 
     Arg<LHLO_FpBuffer, "", [MemRead]>:$data,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$indices,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$segment_ids,
-    DefaultValuedAttr<BoolAttr, "false">:$is_mean,
+    DefaultValuedAttr<LHLO_ReductionModeEnum, "ReductionModeEnum::Mean">:$reduction_mode,
     Arg<LHLO_FpBuffer, "", [MemWrite]>:$output
   );
 }

--- a/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/lhlo_disc_ops.td
@@ -211,15 +211,16 @@ def LHLO_SparseFillEmptyRowsOp : LHLODISC_Op<"sparse_fill_empty_rows", []> {
   );
 }
 
-def LHLO_SparseSegmentMeanOp : LHLODISC_Op<"sparse_segment_mean", []> {
-  let summary = "One-to-one mapping of TF_SparseSegmentMeanOp";
+def LHLO_SparseSegmentReductionOp : LHLODISC_Op<"sparse_segment_reduction", []> {
+  let summary = "One-to-one mapping of TF_SparseSegmentMeanOp or TF_SparseSegmentSumOp";
   let description = [{
-    See tf's sparse_segment_mean operator.
+    See tf's sparse_segment_mean or sparse_segment_sum operator.
   }];
   let arguments = (ins
     Arg<LHLO_FpBuffer, "", [MemRead]>:$data,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$indices,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$segment_ids,
+    DefaultValuedAttr<BoolAttr, "false">:$is_mean,
     Arg<LHLO_FpBuffer, "", [MemWrite]>:$output
   );
 }

--- a/tao_compiler/mlir/disc/IR/tests/invalid_hlo_disc.mlir
+++ b/tao_compiler/mlir/disc/IR/tests/invalid_hlo_disc.mlir
@@ -330,7 +330,7 @@ func.func @sparse_fill_empty_rows_basic(%indices: tensor<?xi64>, %values: tensor
 // CHECK-LABEL: func.func @sparse_segment_mean_matrix_indices
 func.func @sparse_segment_mean_matrix_indices(%data: tensor<?x?xf32>, %indices: tensor<?x?xi32>, %segment_ids: tensor<?xi32>) -> (tensor<?x?xf32>) {
   // expected-error@+1 {{indices should be a vector}}
-  %output = "mhlo_disc.sparse_segment_mean"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 
@@ -339,7 +339,7 @@ func.func @sparse_segment_mean_matrix_indices(%data: tensor<?x?xf32>, %indices: 
 // CHECK-LABEL: func.func @sparse_segment_mean_matrix_segment_ids
 func.func @sparse_segment_mean_matrix_segment_ids(%data: tensor<?x?xf32>, %indices: tensor<?xi32>, %segment_ids: tensor<?x?xi32>) -> (tensor<?x?xf32>) {
   // expected-error@+1 {{segment_ids should be a vector}}
-  %output = "mhlo_disc.sparse_segment_mean"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?xi32>, tensor<?x?xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?xi32>, tensor<?x?xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 
@@ -348,7 +348,7 @@ func.func @sparse_segment_mean_matrix_segment_ids(%data: tensor<?x?xf32>, %indic
 // CHECK-LABEL: func.func @sparse_segment_mean_no_match_indices_segment_ids
 func.func @sparse_segment_mean_no_match_indices_segment_ids(%data: tensor<?x?xf32>, %indices: tensor<6xi32>, %segment_ids: tensor<4xi32>) -> (tensor<?x?xf32>) {
   // expected-error@+1 {{segment_ids and indices should have same size}}
-  %output = "mhlo_disc.sparse_segment_mean"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<6xi32>, tensor<4xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<6xi32>, tensor<4xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 

--- a/tao_compiler/mlir/disc/IR/tests/invalid_hlo_disc.mlir
+++ b/tao_compiler/mlir/disc/IR/tests/invalid_hlo_disc.mlir
@@ -330,7 +330,7 @@ func.func @sparse_fill_empty_rows_basic(%indices: tensor<?xi64>, %values: tensor
 // CHECK-LABEL: func.func @sparse_segment_mean_matrix_indices
 func.func @sparse_segment_mean_matrix_indices(%data: tensor<?x?xf32>, %indices: tensor<?x?xi32>, %segment_ids: tensor<?xi32>) -> (tensor<?x?xf32>) {
   // expected-error@+1 {{indices should be a vector}}
-  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) { reduction_mode = 0 } : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 

--- a/tao_compiler/mlir/disc/IR/tests/ops_hlo_disc.mlir
+++ b/tao_compiler/mlir/disc/IR/tests/ops_hlo_disc.mlir
@@ -224,7 +224,7 @@ func.func @sparse_fill_empty_rows_basic(%indices: tensor<?x?xi64>, %values: tens
 
 // CHECK-LABEL: func.func @sparse_segment_mean_basic
 func.func @sparse_segment_mean_basic(%data: tensor<?x?xf32>, %indices: tensor<?xi32>, %segment_ids: tensor<?xi32>) -> (tensor<?x?xf32>) {
-  %output = "mhlo_disc.sparse_segment_mean"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 

--- a/tao_compiler/mlir/disc/IR/tests/ops_hlo_disc.mlir
+++ b/tao_compiler/mlir/disc/IR/tests/ops_hlo_disc.mlir
@@ -224,7 +224,7 @@ func.func @sparse_fill_empty_rows_basic(%indices: tensor<?x?xi64>, %values: tens
 
 // CHECK-LABEL: func.func @sparse_segment_mean_basic
 func.func @sparse_segment_mean_basic(%data: tensor<?x?xf32>, %indices: tensor<?xi32>, %segment_ids: tensor<?xi32>) -> (tensor<?x?xf32>) {
-  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) {} : (tensor<?x?xf32>, tensor<?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
+  %output = "mhlo_disc.sparse_segment_reduction"(%data, %indices, %segment_ids) { reduction_mode = 1 } : (tensor<?x?xf32>, tensor<?xi32>, tensor<?xi32>) -> (tensor<?x?xf32>)
   return %output : tensor<?x?xf32>
 }
 

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_d_f32_2d.mlir
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_d_f32_2d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<?x?xf32>, %arg1: tensor<?xi32>, %arg2: tensor<?xi32>) -> tensor<?x?xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.SparseSegmentSum"(%arg0, %arg1, %arg2) : (tensor<?x?xf32>, tensor<?xi32>, tensor<?xi32>) -> tensor<?x?xf32>
+      tf_executor.fetch %0#0 : tensor<?x?xf32>
+    }
+    return %graph : tensor<?x?xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_p_f64_2d.mlir
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_p_f64_2d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<?x?xf64>, %arg1: tensor<6xi32>, %arg2: tensor<6xi32>) -> tensor<?x?xf64> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.SparseSegmentSum"(%arg0, %arg1, %arg2) : (tensor<?x?xf64>, tensor<6xi32>, tensor<6xi32>) -> tensor<?x?xf64>
+      tf_executor.fetch %0#0 : tensor<?x?xf64>
+    }
+    return %graph : tensor<?x?xf64>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_s_f32_2d.mlir
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/data/sparse_segment_sum_s_f32_2d.mlir
@@ -1,0 +1,9 @@
+module attributes {tf.versions = {bad_consumers = [], min_consumer = 0 : i32, producer = 0 : i32}} {
+  func.func @main(%arg0: tensor<4x4xf32>, %arg1: tensor<6xi32>, %arg2: tensor<6xi32>) -> tensor<?x4xf32> attributes {tf.entry_function = {inputs = "{{INPUTS}}", outputs = "{{OUTPUTS}}", input_placements="{{INPUT_PLACEMENTS}}", output_placements="{{OUTPUT_PLACEMENTS}}"}} {
+    %graph = tf_executor.graph {
+      %0:2 = tf_executor.island wraps "tf.SparseSegmentSum"(%arg0, %arg1, %arg2) : (tensor<4x4xf32>, tensor<6xi32>, tensor<6xi32>) -> tensor<?x4xf32>
+      tf_executor.fetch %0#0 : tensor<?x4xf32>
+    }
+    return %graph : tensor<?x4xf32>
+  }
+}

--- a/tao_compiler/mlir/disc/tests/tensorflow_ops/sparse_segment_sum.cc
+++ b/tao_compiler/mlir/disc/tests/tensorflow_ops/sparse_segment_sum.cc
@@ -1,0 +1,57 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir/disc/tests/mlir_feature_test.h"
+#include "mlir/disc/tests/mlir_test.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace mlir_test {
+
+const std::string c_ft_path = "mlir/disc/tests/tensorflow_ops/data/";
+
+TEST(TFSparseSegmentSumOpTest, DynamicShapeF32Dim2Input) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "sparse_segment_sum_d_f32_2d.mlir",
+      /*backend_types*/ {kSupportedCPUBackendList},
+      /*num_inputs*/ 3,
+      /*num_outputs*/ 1,
+      /*input_Xescriptors*/ {"4x4xf32_X", "6xi32_X", "6xi32_X"},
+      /*output_Xescriptors*/ {"f32_X"},
+      /*input_vals*/ {{}, {0, 1, 2, 0, 1, 3}, {0, 0, 0, 2, 2, 2}}));
+}
+
+TEST(TFSparseSegmentSumOpTest, PartialDynamicShapeF64Dim2Input) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "sparse_segment_sum_p_f64_2d.mlir",
+      /*backend_types*/ {kSupportedCPUBackendList},
+      /*num_inputs*/ 3,
+      /*num_outputs*/ 1,
+      /*input_Xescriptors*/ {"4x4xf64_X", "6xi32_X", "6xi32_X"},
+      /*output_Xescriptors*/ {"f64_X"},
+      /*input_vals*/ {{}, {0, 1, 2, 0, 1, 3}, {0, 0, 0, 2, 2, 2}}));
+}
+
+TEST(TFSparseSegmentSumOpTest, StaticShapeF32Dim2Input) {
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "sparse_segment_sum_s_f32_2d.mlir",
+      /*backend_types*/ {kSupportedCPUBackendList},
+      /*num_inputs*/ 3,
+      /*num_outputs*/ 1,
+      /*input_Xescriptors*/ {"4x4xf32_X", "6xi32_X", "6xi32_X"},
+      /*output_Xescriptors*/ {"f32_X"},
+      /*input_vals*/ {{}, {0, 1, 2, 0, 1, 3}, {0, 0, 0, 2, 2, 2}}));
+}
+
+}  // namespace mlir_test

--- a/tao_compiler/mlir/disc/transforms/disc_hlo_legalize_to_lhlo.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_hlo_legalize_to_lhlo.cc
@@ -278,7 +278,7 @@ void populateDiscHLOToLHLOConversionPattern(
       HloToLhloOpConverter<mhlo_disc::QuantizedDynamicConvOp>,
       HloToLhloOpConverter<mhlo_disc::SparseReshapeOp>,
       HloToLhloOpConverter<mhlo_disc::SparseFillEmptyRowsOp>,
-      HloToLhloOpConverter<mhlo_disc::SparseSegmentMeanOp>,
+      HloToLhloOpConverter<mhlo_disc::SparseSegmentReductionOp>,
       HloToLhloOpConverter<mhlo_disc::WhereOp>,
       HloToLhloCustomCallOpConverter,
       HloToLhloCustomCallOpV2Converter,

--- a/tao_compiler/mlir/disc/transforms/disc_map_hlo_to_lhlo_op.h
+++ b/tao_compiler/mlir/disc/transforms/disc_map_hlo_to_lhlo_op.h
@@ -43,7 +43,7 @@ MAP_HLO_TO_LHLO(QuantizedDotGeneralOp);
 MAP_HLO_TO_LHLO(QuantizedDynamicConvOp);
 MAP_HLO_TO_LHLO(SparseReshapeOp);
 MAP_HLO_TO_LHLO(SparseFillEmptyRowsOp);
-MAP_HLO_TO_LHLO(SparseSegmentMeanOp);
+MAP_HLO_TO_LHLO(SparseSegmentReductionOp);
 MAP_HLO_TO_LHLO(WhereOp);
 
 #undef MAP_HLO_TO_LHLO

--- a/tao_compiler/mlir/disc/transforms/fusion_utils_sparse_op_cpu.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils_sparse_op_cpu.cc
@@ -33,7 +33,7 @@ bool iskSparseReductionOutputFusible(Operation* op) {
 }
 
 bool isFusibleSparseReductionOp(Operation* op) {
-  return isa<lmhlo_disc::SparseSegmentMeanOp>(op);
+  return isa<lmhlo_disc::SparseSegmentReductionOp>(op);
 }
 
 ////////////////////// CPU SparseOp FusionStrategy Implemenation ////////////

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -4681,7 +4681,8 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
   b.create<scf::YieldOp>(loc, ValueRange({}));
   b.setInsertionPointAfter(for_op);
 
-  if (sparse_segment_reduction_op.getReductionMode() == lmhlo_disc::ReductionModeEnum::Sum) {
+  if (sparse_segment_reduction_op.getReductionMode() ==
+      lmhlo_disc::ReductionModeEnum::Sum) {
     // data/output's dim 1~(rank-1) are the same
     // for (i = 0; i < indices.shape(0), ++i) {
     //   row_idx = indices[i]
@@ -4727,7 +4728,8 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
             b.create<memref::LoadOp>(loc, data, data_index)),
         output, output_index);
     b.setInsertionPointAfter(parallel_op);
-  } else if (sparse_segment_reduction_op.getReductionMode() == lmhlo_disc::ReductionModeEnum::Mean) {
+  } else if (sparse_segment_reduction_op.getReductionMode() ==
+             lmhlo_disc::ReductionModeEnum::Mean) {
     // segment_count is only needed for mean
     Value segment_count_memref;
     // segment_count[max_segment_ids]
@@ -4841,7 +4843,8 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
     b.create<scf::YieldOp>(loc, ValueRange({}));
     b.setInsertionPointAfter(parallel_op);
   } else {
-    return dominant_op->emitError() << "Reduction mode is not supported for lmhlo_disc.sparse_segment_reduction"; 
+    return dominant_op->emitError() << "Reduction mode is not supported for "
+                                       "lmhlo_disc.sparse_segment_reduction";
   }
   b.setInsertionPoint(operation);
 

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -4623,33 +4623,36 @@ LogicalResult lowerWithScheduleSparseFillEmptyRowsOpCPU(
   return success();
 }
 
-LogicalResult lowerWithScheduleSparseSegmentMeanOpCPU(
+LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
     ArrayRef<Operation*> root_ops, Operation* dominant_op,
     Block* parent = nullptr, bool non_fusion = false,
     const ShapeAnalysis* shape_analysis = nullptr) {
   if (!(root_ops.size() == 1 &&
-        isa<lmhlo_disc::SparseSegmentMeanOp>(root_ops[0]))) {
+        isa<lmhlo_disc::SparseSegmentReductionOp>(root_ops[0]))) {
     return dominant_op->emitError()
-           << "root_ops[0] is not a lmhlo_disc::SparseSegmentMeanOp";
+           << "root_ops[0] is not a lmhlo_disc::SparseSegmentReductionOp";
   }
-  auto sparse_segment_mean =
-      dyn_cast<lmhlo_disc::SparseSegmentMeanOp>(root_ops[0]);
-  if (!sparse_segment_mean) {
-    return dominant_op->emitError()
-           << "can not cast root_ops[0] to lmhlo_disc::SparseSegmentMeanOp";
+  auto sparse_segment_reduction_op =
+      dyn_cast<lmhlo_disc::SparseSegmentReductionOp>(root_ops[0]);
+  if (!sparse_segment_reduction_op) {
+    return dominant_op->emitError() << "can not cast root_ops[0] to "
+                                       "lmhlo_disc::SparseSegmentReductionOp";
   }
 
-  auto loc = sparse_segment_mean.getLoc();
+  auto loc = sparse_segment_reduction_op.getLoc();
+
   OpBuilder b(root_ops.back());
 
-  b.setInsertionPoint(sparse_segment_mean.getOperation());
+  auto operation = sparse_segment_reduction_op.getOperation();
+  auto context = sparse_segment_reduction_op.getContext();
 
   // input
-  Value input = sparse_segment_mean.getData();
-  Value indices = sparse_segment_mean.getIndices();
-  Value segment_ids = sparse_segment_mean.getSegmentIds();
+  Value data = sparse_segment_reduction_op.getData();
+  Value indices = sparse_segment_reduction_op.getIndices();
+  Value segment_ids = sparse_segment_reduction_op.getSegmentIds();
   // output
-  Value output = sparse_segment_mean.getOutput();
+  Value output = sparse_segment_reduction_op.getOutput();
+
   MemRefType output_type = output.getType().template cast<MemRefType>();
   int64_t output_rank = output_type.getRank();
 
@@ -4663,202 +4666,182 @@ LogicalResult lowerWithScheduleSparseSegmentMeanOpCPU(
 
   Value num_results = b.create<memref::DimOp>(loc, output, 0);
 
-  Value segment_count_memref;
-  // segment_count[max_segment_ids]
-  // for (i = 0; i < segment_ids.shape(0); ++i) {
-  //   segment_idx = segment_ids[i]
-  //   segment_count[segment_idx]++
-  // }
-  {
-    auto alloc = b.create<memref::AllocOp>(
-        loc,
-        MemRefType::get({-1}, output_type.getElementType(),
-                        MemRefLayoutAttrInterface(),
-                        StringAttr::get(sparse_segment_mean->getContext(),
-                                        placement_utils::kCpu)),
-        num_results);
-    segment_count_memref = alloc.getResult();
+  // memset output to 0
+  auto num_elements = emitNumElementsComputation(b, loc, output);
+  auto output_shape = getShapeValues(&b, output);
+  auto for_op = b.create<scf::ForOp>(loc, /* lowerBound */ zero,
+                                     /* upperBound */ num_elements,
+                                     /* step */ one);
+  for_op.getBody()->clear();
+  b.setInsertionPointToStart(for_op.getBody());
 
-    {
-      auto for_op =
-          b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                               /* upperBound */ num_results, /* step */ one);
-      for_op.getBody()->clear();
-      b.setInsertionPointToStart(for_op.getBody());
-      Value i = for_op.getInductionVar();
-      b.create<memref::StoreOp>(loc, zero_floating, segment_count_memref, i);
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointAfter(for_op);
-    }
-    {
-      Value num_segment_ids = b.create<memref::DimOp>(loc, segment_ids, 0);
-      auto for_op = b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                                         /* upperBound */ num_segment_ids,
-                                         /* step */ one);
-      for_op.getBody()->clear();
-      b.setInsertionPointToStart(for_op.getBody());
-      Value i = for_op.getInductionVar();
-      Value segment_idx = b.create<arith::IndexCastOp>(
-          loc, b.getIndexType(), b.create<memref::LoadOp>(loc, segment_ids, i));
-      b.create<memref::StoreOp>(
-          loc,
-          b.create<arith::AddFOp>(
-              loc,
-              b.create<memref::LoadOp>(loc, segment_count_memref, segment_idx),
-              one_floating),
-          segment_count_memref, segment_idx);
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointAfter(for_op);
-    }
-  }
+  Value i = for_op.getInductionVar();
+  auto index = calcMultiDimIndex(&b, loc, i, output_shape);
+  b.create<memref::StoreOp>(loc, zero_floating, output, index);
+  b.create<scf::YieldOp>(loc, ValueRange({}));
+  b.setInsertionPointAfter(for_op);
 
-  // memset multidim output to 0
-  {
-    llvm::SmallVector<scf::ForOp, 4> for_ops_output_init;
-    llvm::SmallVector<Value, 4> multidim_index_output_init;
-    for (int i = 0; i < output_rank; i++) {
-      Value dim_i = b.create<memref::DimOp>(loc, output, i);
-      auto for_op =
-          b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                               /* upperBound */ dim_i, /* step */ one);
-      for_op.getBody()->clear();
-      b.setInsertionPointToStart(for_op.getBody());
-      for_ops_output_init.push_back(for_op);
-      multidim_index_output_init.push_back(for_op.getInductionVar());
-    }
-    b.create<memref::StoreOp>(loc, zero_floating, output,
-                              multidim_index_output_init);
-    for (int i = output_rank - 1; i > 0; i--) {
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointToEnd(for_ops_output_init[i - 1].getBody());
-    }
-    b.create<scf::YieldOp>(loc, ValueRange({}));
-    b.setInsertionPointAfter(for_ops_output_init[0]);
-  }
-
-  // for (i = 0; i < indices.shape(0), ++i) {
-  //   row_idx = indices[i]
-  //   segment_idx = segment_ids[i]
-  //   for (j = 0; j < output.shape(1); ++j) {
-  //     for (k = 0; j < output.shape(2); ++k) {
-  //       ...
-  //         for (m = 0; j < output.shape(rank-1); ++m) {
-  //           output[segment_idx][j]...[m] += data[row_idx][j]...[m]
-  //         }
-  //       ...
-  //     }
-  //   }
-  // }
-  {
-    llvm::SmallVector<scf::ForOp, 4> for_ops_output_sum;
-    llvm::SmallVector<Value, 4> multidim_index_output_sum;
-    llvm::SmallVector<Value, 4> multidim_index_input;
-    Value num_indices = b.create<memref::DimOp>(loc, indices, 0);
-    auto for_i =
-        b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                             /* upperBound */ num_indices, /* step */ one);
-    for_i.getBody()->clear();
-    b.setInsertionPointToStart(for_i.getBody());
-    for_ops_output_sum.push_back(for_i);
-    Value i = for_i.getInductionVar();
-    Value row_idx = b.create<arith::IndexCastOp>(
-        loc, b.getIndexType(), b.create<memref::LoadOp>(loc, indices, i));
-    multidim_index_input.push_back(row_idx);
-    Value segment_idx = b.create<arith::IndexCastOp>(
-        loc, b.getIndexType(), b.create<memref::LoadOp>(loc, segment_ids, i));
-    multidim_index_output_sum.push_back(segment_idx);
-
-    // input_rank equals output_rank
+  if (!sparse_segment_reduction_op.getIsMean()) {
+    // data/output's dim 1~(rank-1) are the same
+    // for (i = 0; i < indices.shape(0), ++i) {
+    //   row_idx = indices[i]
+    //   segment_idx = segment_ids[i]
+    //   for (j = 0; j < data.shape(1); ++j) {
+    //     for (k = 0; j < data.shape(2); ++k) {
+    //       ...
+    //         for (m = 0; j < data.shape(rank-1); ++m) {
+    //           output[segment_idx][j]...[m] += data[row_idx][j]...[m]
+    //         }
+    //       ...
+    //     }
+    //   }
+    // }
+    llvm::SmallVector<Value, 2> lower(output_rank, zero), upper,
+        step(output_rank, one);
+    upper.push_back(b.create<memref::DimOp>(loc, indices, 0));
     for (int i = 1; i < output_rank; i++) {
-      Value dim_i = b.create<memref::DimOp>(loc, input, i);
-      auto for_ops =
-          b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                               /* upperBound */ dim_i, /* step */ one);
-      for_ops.getBody()->clear();
-      b.setInsertionPointToStart(for_ops.getBody());
-      for_ops_output_sum.push_back(for_ops);
-      Value loop_index = for_ops.getInductionVar();
-      multidim_index_output_sum.push_back(loop_index);
-      multidim_index_input.push_back(loop_index);
+      upper.push_back(b.create<memref::DimOp>(loc, data, i));
     }
-    Value input_data =
-        b.create<memref::LoadOp>(loc, input, multidim_index_input);
+    auto parallel_op =
+        b.create<scf::ParallelOp>(loc, /* lowerBound */ lower,
+                                  /* upperBound */ upper, /* step */ step);
+    b.setInsertionPointToStart(parallel_op.getBody());
+    auto index_i = parallel_op.getInductionVars()[0];
+    llvm::SmallVector<Value, 4> data_index, output_index;
+    data_index.push_back(b.create<arith::IndexCastOp>(
+        loc, b.getIndexType(),
+        b.create<memref::LoadOp>(loc, indices, index_i)));
+    output_index.push_back(b.create<arith::IndexCastOp>(
+        loc, b.getIndexType(),
+        b.create<memref::LoadOp>(loc, segment_ids, index_i)));
+    for (int i = 1; i < output_rank; ++i) {
+      auto index = b.create<arith::IndexCastOp>(
+          loc, b.getIndexType(), parallel_op.getInductionVars()[i]);
+      data_index.push_back(index);
+      output_index.push_back(index);
+    }
     b.create<memref::StoreOp>(
         loc,
         b.create<arith::AddFOp>(
-            loc,
-            b.create<memref::LoadOp>(loc, output, multidim_index_output_sum),
-            input_data),
-        output, multidim_index_output_sum);
-    for (int i = output_rank - 1; i > 0; i--) {
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointToEnd(for_ops_output_sum[i - 1].getBody());
-    }
-    b.create<scf::YieldOp>(loc, ValueRange({}));
-    b.setInsertionPointAfter(for_i);
-  }
+            loc, b.create<memref::LoadOp>(loc, output, output_index),
+            b.create<memref::LoadOp>(loc, data, data_index)),
+        output, output_index);
+    b.setInsertionPointAfter(parallel_op);
+  } else {
+    // segment_count is only needed for mean
+    Value segment_count_memref;
+    // segment_count[max_segment_ids]
+    // for (i = 0; i < segment_ids.shape(0); ++i) {
+    //   segment_idx = segment_ids[i]
+    //   segment_count[segment_idx]++
+    // }
+    {
+      auto alloc = b.create<memref::AllocOp>(
+          loc,
+          MemRefType::get({-1}, output_type.getElementType(),
+                          MemRefLayoutAttrInterface(),
+                          StringAttr::get(context, placement_utils::kCpu)),
+          num_results);
+      segment_count_memref = alloc.getResult();
 
-  // for (i = 0; i < output.shape(0), ++i) {
-  //   if (segment_count[i] != 0) {
-  //     for (j = 0; j < output.shape(1); ++j) {
-  //       for (k = 0; j < output.shape(2); ++k) {
-  //         ...
-  //           for (m = 0; j < output.shape(rank-1); ++m) {
-  //             output[i][j]...[m] /= segment_count[i]
-  //           }
-  //         ...
-  //       }
-  //     }
-  //   }
-  // }
-  {
-    llvm::SmallVector<scf::ForOp, 4> for_ops_output_mean;
-    llvm::SmallVector<Value, 4> multidim_index_output_mean;
-    auto for_i =
-        b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                             /* upperBound */ num_results, /* step */ one);
-    for_i.getBody()->clear();
-    b.setInsertionPointToStart(for_i.getBody());
-    Value i = for_i.getInductionVar();
-    multidim_index_output_mean.push_back(i);
-    Value segment_count =
-        b.create<memref::LoadOp>(loc, segment_count_memref, i);
+      {
+        auto for_op =
+            b.create<scf::ForOp>(loc, /* lowerBound */ zero,
+                                 /* upperBound */ num_results, /* step */ one);
+        for_op.getBody()->clear();
+        b.setInsertionPointToStart(for_op.getBody());
+        Value i = for_op.getInductionVar();
+        b.create<memref::StoreOp>(loc, zero_floating, segment_count_memref, i);
+        b.create<scf::YieldOp>(loc, ValueRange({}));
+        b.setInsertionPointAfter(for_op);
+      }
+      {
+        Value num_segment_ids = b.create<memref::DimOp>(loc, segment_ids, 0);
+        auto for_op = b.create<scf::ForOp>(loc, /* lowerBound */ zero,
+                                           /* upperBound */ num_segment_ids,
+                                           /* step */ one);
+        for_op.getBody()->clear();
+        b.setInsertionPointToStart(for_op.getBody());
+        Value i = for_op.getInductionVar();
+        Value segment_idx = b.create<arith::IndexCastOp>(
+            loc, b.getIndexType(),
+            b.create<memref::LoadOp>(loc, segment_ids, i));
+        b.create<memref::StoreOp>(
+            loc,
+            b.create<arith::AddFOp>(loc,
+                                    b.create<memref::LoadOp>(
+                                        loc, segment_count_memref, segment_idx),
+                                    one_floating),
+            segment_count_memref, segment_idx);
+        b.create<scf::YieldOp>(loc, ValueRange({}));
+        b.setInsertionPointAfter(for_op);
+      }
+    }
+
+    // for (i = 0; i < indices.shape(0), ++i) {
+    //   row_idx = indices[i]
+    //   segment_idx = segment_ids[i]
+    //   if (segment_count[segment_idx] != 0) {
+    //     for (j = 0; j < data.shape(1); ++j) {
+    //       for (k = 0; j < data.shape(2); ++k) {
+    //         ...
+    //           for (m = 0; j < data.shape(rank-1); ++m) {
+    //             output[segment_idx][j]...[m] +=
+    //               data[row_idx][j]...[m]/segment_count[segment_idx]
+    //           }
+    //         ...
+    //       }
+    //     }
+    //   }
+    // }
+    llvm::SmallVector<Value, 2> lower(output_rank, zero), upper,
+        step(output_rank, one);
+    upper.push_back(b.create<memref::DimOp>(loc, indices, 0));
+    for (int i = 1; i < output_rank; i++) {
+      upper.push_back(b.create<memref::DimOp>(loc, data, i));
+    }
+    auto parallel_op =
+        b.create<scf::ParallelOp>(loc, /* lowerBound */ lower,
+                                  /* upperBound */ upper, /* step */ step);
+    b.setInsertionPointToStart(parallel_op.getBody());
+
+    llvm::SmallVector<Value, 4> data_index, output_index;
+    auto segment_idx = b.create<memref::LoadOp>(
+        loc, segment_ids, parallel_op.getInductionVars()[0]);
+    llvm::SmallVector<Value, 1> segment_count_index(
+        1, b.create<arith::IndexCastOp>(loc, b.getIndexType(), segment_idx));
+    Value segment_count = b.create<memref::LoadOp>(loc, segment_count_memref,
+                                                   segment_count_index);
     Value pred = b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE,
                                          segment_count, zero_floating);
     auto if_op = b.create<scf::IfOp>(loc, pred, /*hasElseRegion*/ false);
     if_op.getThenRegion().front().clear();
     b.setInsertionPointToStart(&if_op.getThenRegion().front());
-    for (int i = 1; i < output_rank; i++) {
-      Value dim_i = b.create<memref::DimOp>(loc, output, i);
-      auto for_op =
-          b.create<scf::ForOp>(loc, /* lowerBound */ zero,
-                               /* upperBound */ dim_i, /* step */ one);
-      for_op.getBody()->clear();
-      b.setInsertionPointToStart(for_op.getBody());
-      for_ops_output_mean.push_back(for_op);
-      Value loop_index = for_op.getInductionVar();
-      multidim_index_output_mean.push_back(loop_index);
+
+    data_index.push_back(b.create<arith::IndexCastOp>(
+        loc, b.getIndexType(),
+        b.create<memref::LoadOp>(loc, indices,
+                                 parallel_op.getInductionVars()[0])));
+    output_index.push_back(
+        b.create<arith::IndexCastOp>(loc, b.getIndexType(), segment_idx));
+    for (int i = 1; i < output_rank; ++i) {
+      auto index = b.create<arith::IndexCastOp>(
+          loc, b.getIndexType(), parallel_op.getInductionVars()[i]);
+      data_index.push_back(index);
+      output_index.push_back(index);
     }
+    auto data_div = b.create<arith::DivFOp>(
+        loc, b.create<memref::LoadOp>(loc, data, data_index), segment_count);
     b.create<memref::StoreOp>(
         loc,
-        b.create<arith::DivFOp>(
-            loc,
-            b.create<memref::LoadOp>(loc, output, multidim_index_output_mean),
-            segment_count),
-        output, multidim_index_output_mean);
-    for (int i = output_rank - 2; i > 0; i--) {
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointToEnd(for_ops_output_mean[i - 1].getBody());
-    }
-    if (output_rank > 1) {
-      b.create<scf::YieldOp>(loc, ValueRange({}));
-      b.setInsertionPointToEnd(&if_op.getThenRegion().front());
-    }
+        b.create<arith::AddFOp>(
+            loc, b.create<memref::LoadOp>(loc, output, output_index), data_div),
+        output, output_index);
+
     b.create<scf::YieldOp>(loc, ValueRange({}));
-    b.setInsertionPointToEnd(for_i.getBody());
-    b.create<scf::YieldOp>(loc, ValueRange({}));
-    b.setInsertionPoint(sparse_segment_mean.getOperation());
+    b.setInsertionPointAfter(parallel_op);
   }
+  b.setInsertionPoint(operation);
 
   // TODO: Support fusion
   for (Operation* root_op : root_ops) root_op->erase();
@@ -5025,8 +5008,8 @@ LogicalResult lowerWithScheduleLoopCPU(
         root_ops, dominant_op, parent, non_fusion, shape_analysis);
   }
 
-  if (non_fusion && isa<lmhlo_disc::SparseSegmentMeanOp>(dominant_op)) {
-    return lowerWithScheduleSparseSegmentMeanOpCPU(
+  if (non_fusion && isa<lmhlo_disc::SparseSegmentReductionOp>(dominant_op)) {
+    return lowerWithScheduleSparseSegmentReductionOpCPU(
         root_ops, dominant_op, parent, non_fusion, shape_analysis);
   }
 

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -4681,7 +4681,7 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
   b.create<scf::YieldOp>(loc, ValueRange({}));
   b.setInsertionPointAfter(for_op);
 
-  if (!sparse_segment_reduction_op.getIsMean()) {
+  if (sparse_segment_reduction_op.getReductionMode() == lmhlo_disc::ReductionModeEnum::Sum) {
     // data/output's dim 1~(rank-1) are the same
     // for (i = 0; i < indices.shape(0), ++i) {
     //   row_idx = indices[i]
@@ -4727,7 +4727,7 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
             b.create<memref::LoadOp>(loc, data, data_index)),
         output, output_index);
     b.setInsertionPointAfter(parallel_op);
-  } else {
+  } else if (sparse_segment_reduction_op.getReductionMode() == lmhlo_disc::ReductionModeEnum::Mean) {
     // segment_count is only needed for mean
     Value segment_count_memref;
     // segment_count[max_segment_ids]
@@ -4840,6 +4840,8 @@ LogicalResult lowerWithScheduleSparseSegmentReductionOpCPU(
 
     b.create<scf::YieldOp>(loc, ValueRange({}));
     b.setInsertionPointAfter(parallel_op);
+  } else {
+    return dominant_op->emitError() << "Reduction mode is not supported for lmhlo_disc.sparse_segment_reduction"; 
   }
   b.setInsertionPoint(operation);
 

--- a/tao_compiler/mlir/disc/transforms/lower_tf.cc
+++ b/tao_compiler/mlir/disc/transforms/lower_tf.cc
@@ -1394,8 +1394,7 @@ class ConvertSparseSegmentMeanOp
                                 PatternRewriter& rewriter) const override {
     auto loc = op.getLoc();
     auto reduction_mode_attr = mlir::mhlo_disc::ReductionModeEnumAttr::get(
-        rewriter.getContext(),
-        mlir::mhlo_disc::ReductionModeEnum::Mean);
+        rewriter.getContext(), mlir::mhlo_disc::ReductionModeEnum::Mean);
     auto hlo_sparse_segment_mean =
         rewriter.create<mhlo_disc::SparseSegmentReductionOp>(
             loc, op.output().getType(), op.data(), op.indices(),
@@ -1414,8 +1413,7 @@ class ConvertSparseSegmentSumOp
                                 PatternRewriter& rewriter) const override {
     auto loc = op.getLoc();
     auto reduction_mode_attr = mlir::mhlo_disc::ReductionModeEnumAttr::get(
-        rewriter.getContext(),
-        mlir::mhlo_disc::ReductionModeEnum::Sum);
+        rewriter.getContext(), mlir::mhlo_disc::ReductionModeEnum::Sum);
     auto hlo_sparse_segment_sum =
         rewriter.create<mhlo_disc::SparseSegmentReductionOp>(
             loc, op.output().getType(), op.data(), op.indices(),

--- a/tao_compiler/mlir/disc/transforms/lower_tf.cc
+++ b/tao_compiler/mlir/disc/transforms/lower_tf.cc
@@ -1393,10 +1393,13 @@ class ConvertSparseSegmentMeanOp
   LogicalResult matchAndRewrite(TF::SparseSegmentMeanOp op,
                                 PatternRewriter& rewriter) const override {
     auto loc = op.getLoc();
+    auto reduction_mode_attr = mlir::mhlo_disc::ReductionModeEnumAttr::get(
+        rewriter.getContext(),
+        mlir::mhlo_disc::ReductionModeEnum::Mean);
     auto hlo_sparse_segment_mean =
         rewriter.create<mhlo_disc::SparseSegmentReductionOp>(
             loc, op.output().getType(), op.data(), op.indices(),
-            op.segment_ids(), rewriter.getBoolAttr(true));
+            op.segment_ids(), reduction_mode_attr);
     rewriter.replaceOp(op, hlo_sparse_segment_mean.getResult());
     return success();
   }
@@ -1410,10 +1413,13 @@ class ConvertSparseSegmentSumOp
   LogicalResult matchAndRewrite(TF::SparseSegmentSumOp op,
                                 PatternRewriter& rewriter) const override {
     auto loc = op.getLoc();
+    auto reduction_mode_attr = mlir::mhlo_disc::ReductionModeEnumAttr::get(
+        rewriter.getContext(),
+        mlir::mhlo_disc::ReductionModeEnum::Sum);
     auto hlo_sparse_segment_sum =
         rewriter.create<mhlo_disc::SparseSegmentReductionOp>(
             loc, op.output().getType(), op.data(), op.indices(),
-            op.segment_ids(), rewriter.getBoolAttr(false));
+            op.segment_ids(), reduction_mode_attr);
     rewriter.replaceOp(op, hlo_sparse_segment_sum.getResult());
     return success();
   }

--- a/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-mean-lhlo-legalize-roots-to-loops.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-mean-lhlo-legalize-roots-to-loops.mlir
@@ -11,18 +11,52 @@ func.func @sparse_segment_mean(
     memref<?x?xf32, "cpu">
   ) {
   // CHECK-NOT lmhlo
-  // CHECK: scf.for %[[ARG4:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
-  // CHECK:   %[[V9:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xf32, "cpu">
-  // CHECK:   %[[V10:.*]] = arith.cmpf one, %[[V9]], %{{.*}} : f32
-  // CHECK:   scf.if %[[V10]] {
-  // CHECK:     scf.for %[[ARG5:.*]] = %{{.*}} to %{{.*}} step %{{.*}} {
-  // CHECK:       %[[V11:.*]] = memref.load %{{.*}}[%[[ARG4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
-  // CHECK:       %[[V12:.*]] = arith.divf %[[V11]], %[[V9]] : f32
-  // CHECK:       memref.store %[[V12]], %{{.*}}[%[[ARG4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
-  // CHECK:     }
+  // CHECK: scf.parallel (%[[ARG4:.*]], %[[ARG5:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
+  // CHECK:   %[[V1:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xi32, "cpu">
+  // CHECK:   %[[V2:.*]] = arith.index_cast %[[V1]] : i32 to index
+  // CHECK:   %[[V3:.*]] = memref.load %{{.*}}[%[[V2]]] : memref<?xf32, "cpu">
+  // CHECK:   %[[V4:.*]] = arith.cmpf one, %[[V3]], %{{.*}} : f32
+  // CHECK:   scf.if %[[V4]] {
+  // CHECK:     %[[V5:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xi32, "cpu">
+  // CHECK:     %[[V6:.*]] = arith.index_cast %[[V5]] : i32 to index
+  // CHECK:     %[[V7:.*]] = arith.index_cast %[[V1]] : i32 to index
+  // CHECK:     %[[V8:.*]] = memref.load %{{.*}}[%[[V6]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK:     %[[V9:.*]] = arith.divf %[[V8]], %[[V3]] : f32
+  // CHECK:     %[[V10:.*]] = memref.load %{{.*}}[%[[V7]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK:     %[[V11:.*]] = arith.addf %[[V10]], %[[V9]] : f32
+  // CHECK:     memref.store %[[V11]], %{{.*}}[%[[V7]], %[[ARG5]]] : memref<?x?xf32, "cpu">
   // CHECK:   }
   // CHECK: }
-  "lmhlo_disc.sparse_segment_mean"(%input1, %input2, %input3, %out1) : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
+  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", is_mean = true} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
+  // CHECK: return %[[OUT1]] : memref<?x?xf32, "cpu">
+  return %out1 : memref<?x?xf32, "cpu">
+}
+
+// -----
+
+// CHECK-LABEL: @sparse_segment_sum
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?x?xf32, "cpu">, %[[INPUT2:.*]]: memref<?xi32, "cpu">, %[[INPUT3:.*]]: memref<?xi32, "cpu">, %[[OUT1:.*]]: memref<?x?xf32, "cpu">) -> memref<?x?xf32, "cpu">
+func.func @sparse_segment_sum(
+    %input1: memref<?x?xf32, "cpu">,
+    %input2: memref<?xi32, "cpu">,
+    %input3: memref<?xi32, "cpu">,
+    %out1: memref<?x?xf32, "cpu">
+    ) -> (
+    memref<?x?xf32, "cpu">
+  ) {
+  // CHECK-NOT lmhlo
+  // CHECK: scf.parallel (%[[ARG4:.*]], %[[ARG5:.*]]) = (%{{.*}}, %{{.*}}) to (%{{.*}}, %{{.*}}) step (%{{.*}}, %{{.*}}) {
+  // CHECK:   %[[V1:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xi32, "cpu">
+  // CHECK:   %[[V2:.*]] = arith.index_cast %[[V1]] : i32 to index
+  // CHECK:   %[[V3:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xi32, "cpu">
+  // CHECK:   %[[V4:.*]] = arith.index_cast %[[V3]] : i32 to index
+  // CHECK:   %[[V5:.*]] = memref.load %{{.*}}[%[[V2]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK:   %[[V6:.*]] = memref.load %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK:   %[[V7:.*]] = arith.addf %[[V6]], %[[V5]] : f32
+  // CHECK:   memref.store %[[V7]], %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK:   scf.yield
+  // CHECK: }
+  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", is_mean = false} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
   // CHECK: return %[[OUT1]] : memref<?x?xf32, "cpu">
   return %out1 : memref<?x?xf32, "cpu">
 }

--- a/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-reduction-lhlo-legalize-roots-to-loops.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-reduction-lhlo-legalize-roots-to-loops.mlir
@@ -50,8 +50,8 @@ func.func @sparse_segment_sum(
   // CHECK:   %[[V2:.*]] = arith.index_cast %[[V1]] : i32 to index
   // CHECK:   %[[V3:.*]] = memref.load %{{.*}}[%[[ARG4]]] : memref<?xi32, "cpu">
   // CHECK:   %[[V4:.*]] = arith.index_cast %[[V3]] : i32 to index
-  // CHECK:   %[[V5:.*]] = memref.load %{{.*}}[%[[V2]], %[[ARG5]]] : memref<?x?xf32, "cpu">
-  // CHECK:   %[[V6:.*]] = memref.load %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK-DAG:   %[[V5:.*]] = memref.load %{{.*}}[%[[V2]], %[[ARG5]]] : memref<?x?xf32, "cpu">
+  // CHECK-DAG:   %[[V6:.*]] = memref.load %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
   // CHECK:   %[[V7:.*]] = arith.addf %[[V6]], %[[V5]] : f32
   // CHECK:   memref.store %[[V7]], %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
   // CHECK:   scf.yield

--- a/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-reduction-lhlo-legalize-roots-to-loops.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-segment-reduction-lhlo-legalize-roots-to-loops.mlir
@@ -27,7 +27,7 @@ func.func @sparse_segment_mean(
   // CHECK:     memref.store %[[V11]], %{{.*}}[%[[V7]], %[[ARG5]]] : memref<?x?xf32, "cpu">
   // CHECK:   }
   // CHECK: }
-  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", is_mean = true} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
+  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", reduction_mode = 0} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
   // CHECK: return %[[OUT1]] : memref<?x?xf32, "cpu">
   return %out1 : memref<?x?xf32, "cpu">
 }
@@ -56,7 +56,7 @@ func.func @sparse_segment_sum(
   // CHECK:   memref.store %[[V7]], %{{.*}}[%[[V4]], %[[ARG5]]] : memref<?x?xf32, "cpu">
   // CHECK:   scf.yield
   // CHECK: }
-  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", is_mean = false} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
+  "lmhlo_disc.sparse_segment_reduction"(%input1, %input2, %input3, %out1) {disc.device = "cpu", reduction_mode = 1} : (memref<?x?xf32, "cpu">, memref<?xi32, "cpu">, memref<?xi32, "cpu">, memref<?x?xf32, "cpu">) -> ()
   // CHECK: return %[[OUT1]] : memref<?x?xf32, "cpu">
   return %out1 : memref<?x?xf32, "cpu">
 }


### PR DESCRIPTION
1. refactor mhlo_disc/lmhlo_disc's `SparseSegmentMean` to `SparseSegmentReduction` with `is_mean` attr to support both tf.sparse_segment_mean and tf.sparse_segment_sum
2. refactor codegen logic, replace impl with `scf.for` to `scf.parallel` for possible fusion
3. support clustering for tf.sparse_segment_sum in tao bridge
4. refine UTs to adapt to code changes