### PR TITLE
bugfix: fix se conv kernel performance regression

### DIFF
--- a/tao_compiler/mlir/xla/ral/context/stream_executor_based_impl.cc
+++ b/tao_compiler/mlir/xla/ral/context/stream_executor_based_impl.cc
@@ -1300,12 +1300,17 @@ Status RunCudnnConvolution(CudnnConvParams& params,
   AlgorithmConfig algorithm{AlgorithmDesc(
       params.algo_id, params.tensor_ops_enabled, params.workspace_size)};
 #else
+#if (TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION > 4) || TF_MAJOR_VERSION > 2
   absl::optional<uint64_t> workspace_size;
   if (!profile_result) {
     workspace_size = params.workspace_size;
   }
   AlgorithmConfig algorithm{
       AlgorithmDesc(params.algo_id, params.tensor_ops_enabled, workspace_size)};
+#else
+  AlgorithmConfig algorithm{
+      AlgorithmDesc(params.algo_id, params.tensor_ops_enabled)};
+#endif
 #endif
 
 #if TENSORFLOW_USE_ROCM
@@ -1533,7 +1538,8 @@ bool PickBestAlgorithm(CudnnConvParams& params,
     params.algo_id = best_result.algorithm().algo_id();
     params.tensor_ops_enabled = best_result.algorithm().tensor_ops_enabled();
     params.best_result_bytes_used = best_result_bytes_used;
-#ifndef TENSORFLOW_USE_ROCM
+#ifndef TENSORFLOW_USE_ROCM and \
+    ((TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION > 4) || TF_MAJOR_VERSION > 2)
     params.workspace_size = best_result_bytes_used;
 #endif
   }


### PR DESCRIPTION
Without this PR, stream executor (se) will call
`cudnnGetConvolutionForwardWorkspaceSize` everytime. This cudnn api itself is very time-consuming on cuda platform, leading to e2e performance regression for cnn networks (e.g. resnet). In this PR, we choose to cache such config to reduce the overhead.

some performance number of testing resnet50 with batch size 32 on A100:
```
|    | Backend     |   batch | precision   |   Median(FPS) |   Mean(FPS) |   Median(ms) |   Mean(ms) |     99th_p |     std_dev |
|---:|:------------|--------:|:------------|--------------:|------------:|-------------:|-----------:|-----------:|------------:|
|  0 | eager       |      32 | fp32        |       2652.74 |     2634.96 |   0.012063   | 0.0121528  | 0.0134366  | 0.000334012 |
|  1 | script      |      32 | fp32        |       2587.84 |     2586.92 |   0.0123655  | 0.01237    | 0.0124442  | 2.00152e-05 |
|  2 | script_disc |      32 | fp32        |       3624.53 |     3601.47 |   0.00882872 | 0.00889192 | 0.00990967 | 0.000255992 |
|  3 | eager       |      32 | amp         |       4157.68 |     4062.57 |   0.00769661 | 0.00789956 | 0.00887882 | 0.000443815 |
|  4 | script      |      32 | amp         |       3947.07 |     3946.81 |   0.00810728 | 0.00810783 | 0.00812229 | 6.86182e-06 |
|  5 | script_disc |      32 | amp         |       8841.56 |     8483.9  |   0.00361927 | 0.0037899  | 0.00421225 | 0.000269538 |
```