### PR TITLE
feat: use pdll to rewrite sparse_segment_reduction

### DIFF
--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -1954,6 +1954,7 @@ cc_library(
     srcs = ["transforms/disc_pdl_utils.cc"],
     hdrs = ["transforms/disc_pdl_utils.h"],
     deps = [
+        ":disc_util",
         ":mhlo_disc",
         "@org_tensorflow//tensorflow/tsl/platform:logging",
         "@llvm-project//llvm:Support",

--- a/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
+++ b/tao_compiler/mlir/disc/IR/hlo_disc_ops.td
@@ -356,6 +356,27 @@ def HLO_SparseSegmentReductionOp: HLODISC_ShapedInterfaceOp<"sparse_segment_redu
   );
 }
 
+def HLO_SparseSegmentReductionWithEmptyRowsOp : HLODISC_ShapedInterfaceOp<"sparse_segment_reduction_with_empty_rows", [Pure]> {
+  let summary = "This is combination of sparse_fill_empty_rows + sparse_segment_mean/sum";
+  let description = [{
+    This is specialized op only used for inference case.
+    In traning scenario, these 2 ops should not be fused, since `reverse_index_map`
+    is needed for backward computation.
+  }];
+  let arguments = (ins
+    HLO_FpTensor:$data,
+    HLO_I32OrI64Tensor:$indices,
+    HLO_I32OrI64Tensor:$unfilled_segment_ids,
+    TensorOf<[I64]>:$dense_shape, // needed for output shape computation
+    DefaultValuedAttr<HLO_ReductionModeEnum, "ReductionModeEnum::Mean">:$reduction_mode
+  );
+
+  let results = (outs
+    HLO_FpTensor:$output,
+    TensorOf<[I1]>:$empty_row_indicator
+  );
+}
+
 def HLO_WhereOp : HLODISC_ShapedInterfaceOp<"where", [Pure]> {
   let summary = "One-to-one mapping of TF_WhereOp";
   let description = [{

--- a/tao_compiler/mlir/disc/disc_util.h
+++ b/tao_compiler/mlir/disc/disc_util.h
@@ -67,6 +67,15 @@ inline std::vector<int64_t> ConvertDenseIntAttr(
   return ConvertDenseIntAttr(*attr);
 }
 
+inline std::vector<int64_t> ConvertArrayAttrToInt(mlir::ArrayAttr array_attr) {
+  SmallVector<float, 4> values;
+  values.reserve(array_attr.getValue().size());
+  for (Attribute val : array_attr.getValue()) {
+    values.push_back(static_cast<int64_t>(val.cast<IntegerAttr>().getInt()));
+  }
+  return {values.begin(), values.end()};
+}
+
 inline mlir::DenseElementsAttr GetScalarOfType(Type ty, int64_t raw_value) {
   RankedTensorType scalar_ty = RankedTensorType::get({}, ty);
 

--- a/tao_compiler/mlir/disc/transforms/disc_sparse_op_rewriter.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_sparse_op_rewriter.cc
@@ -126,6 +126,117 @@ std::string getSparseReshapePDLPattern() {
   return preDefinedPatterns;
 }
 
+// rewrite sparse_fill_empty_rows + sparse_segment_reduction
+// to sparse_segment_reduction_with_empty_rows
+std::string getSparseSegmentReductionPDLPattern() {
+  std::string preDefinedPatterns;
+  preDefinedPatterns += R"pdll(
+    Pattern SparseSegmentReductionRewritePattern {
+      /// match phase: define the pattern
+      let c0 = op<arith.constant> {value = attr<"0 : index">} -> (type<"index">);
+      let c2 = op<arith.constant> {value = attr<"2 : index">} -> (type<"index">);
+      let sparse_fill_empty_rows = op<mhlo_disc.sparse_fill_empty_rows>(
+          indices: Value,
+          values: Value,
+          output_shape: Value,
+          default_value: Value
+      );
+      let extracted = op<tensor.extract>(
+          sparse_fill_empty_rows.4,
+          c0
+      );
+      let casted = op<arith.index_cast>(
+          extracted.0
+      );
+      let from_elements = op<tensor.from_elements>(
+          casted.0,
+          c2
+      );
+      let slice = op<mhlo.real_dynamic_slice>(
+          sparse_fill_empty_rows.0,
+          cst_1: Value,
+          from_elements.0,
+          cst_2: Value
+      );
+      let from_elements_1 = op<tensor.from_elements>(
+          casted.0
+      );
+      let slice_1 = op<mhlo.real_dynamic_slice>(
+          sparse_fill_empty_rows.1,
+          cst_3: Value,
+          from_elements_1.0,
+          cst_4: Value
+      );
+      // ids[:, 0] lowering to {some arith ops + real_dynamic_slice}
+      let slice_op_attr : Attr;
+      let slice_id = op<mhlo.real_dynamic_slice>(
+          slice.0,
+          cst: Value,
+          from_elements_2: Value,
+          cst_0: Value
+      ) {
+        kDiscSliceOpStaticKnownInfo = slice_op_attr
+      };
+      let reshape = op<mhlo.dynamic_reshape>(
+          slice_id.0,
+          from_elements_3: Value
+      );
+      let reduction_attr : Attr;
+      let sparse_segment_reduction = op<mhlo_disc.sparse_segment_reduction>(
+          data: Value,
+          slice_1.0,
+          reshape.0
+      ) {
+        reduction_mode = reduction_attr
+      };
+      let bcast_attr : Attr;
+      let broadcast = op<mhlo.dynamic_broadcast_in_dim>(
+          sparse_fill_empty_rows.2,
+          broadcast_shape: Value
+      ) {
+        broadcast_dimensions = bcast_attr
+      };
+      /// check constant tensor values
+      CheckConstantTensorValueIs(default_value, attr<"0">);
+      // (TODO): maybe check tensor rank?
+      CheckConstantTensorValueIs(cst, attr<"0">);
+      CheckConstantTensorValueIs(cst_0, attr<"1">);
+      CheckConstantTensorValueIs(cst_1, attr<"0">);
+      CheckConstantTensorValueIs(cst_2, attr<"1">);
+      CheckConstantTensorValueIs(cst_3, attr<"0">);
+      CheckConstantTensorValueIs(cst_4, attr<"1">);
+      // check slice op attr
+      CheckSliceOpAttribute(slice_op_attr, attr<"[-2, 1]">, attr<"[0, 0]">, attr<"[1, 1]">);
+
+      // rewrite phase
+      rewrite broadcast with {
+        let inputs = PackValue_4(
+            attr<"\"in\"">,
+            data,
+            indices,
+            values,
+            output_shape
+        );
+        let outputs = PackValue_2(
+            attr<"\"out\"">,
+            sparse_segment_reduction.0,
+            sparse_fill_empty_rows.2
+        );
+        let sparse_seg_reduction = CreateSparseSegmentReduction(
+            attr<"\"op\"">,
+            inputs,
+            outputs,
+            reduction_attr);
+        let rs = UnpackValue_2(sparse_seg_reduction.new_outputs);
+
+        replace sparse_segment_reduction with rs.0;
+        SetOperand(broadcast, attr<"0">, rs.1);
+      };
+    }
+  )pdll";
+  return preDefinedPatterns;
+}
+
 struct DiscSparseOpRewriterPass
     : public DiscSparseOpRewriterPassBase<DiscSparseOpRewriterPass> {
   void runOnOperation() override;
@@ -135,8 +246,11 @@ void DiscSparseOpRewriterPass::runOnOperation() {
   // Setup rewriter patterns.
   MLIRContext& ctx = getContext();
   RewritePatternSet patterns(&ctx);
-  // sparse reshape pattern
+  // rewrite sparse reshape
   populateDiscPdlPatternsFromString(&patterns, getSparseReshapePDLPattern());
+  // rewrite sparse segment reduction
+  populateDiscPdlPatternsFromString(&patterns,
+                                    getSparseSegmentReductionPDLPattern());
 
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {

--- a/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-op-rewriter.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/cpu-only-sparse-op-rewriter.mlir
@@ -38,3 +38,59 @@ func.func @sparse_reshape_elimination(
   %output_indices_783, %output_values_784, %empty_row_indicator_785, %reverse_index_map_786, %output_elements_787 = "mhlo_disc.sparse_fill_empty_rows"(%1285, %1274, %output_shape_782, %4) : (tensor<?x2xi64>, tensor<?xi64>, tensor<2xi64>, tensor<i64>) -> (tensor<?x2xi64>, tensor<?xi64>, tensor<?xi1>, tensor<?xi64>, tensor<1xi64>)
   return %output_indices_783, %output_values_784 : tensor<?x2xi64>, tensor<?xi64>
 }
+
+// -----
+
+// CHECK-LABEL: @sparse_segment_reduction_rewrite
+func.func @sparse_segment_reduction_rewrite(%arg0: tensor<?x2xi64>, %arg1: tensor<?xi64>, %arg2: tensor<2xi64>, %arg3: tensor<?x?xf32>, %arg4: tensor<?x?xf32>, %arg5: index, %arg6: tensor<?x?xf32>, %arg7: tensor<2xindex>, %arg8: tensor<3xindex>, %arg9: tensor<4xindex>) -> (tensor<?x?xf32>, tensor<?x1x?xf32>) {
+  // CHECK: mhlo_disc.sparse_segment_reduction_with_empty_rows
+  // CHECK-NOT: mhlo_disc.sparse_fill_empty_rows
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %1 = mhlo.constant dense<0> : tensor<i64>
+  %cst = arith.constant dense<0> : tensor<2xi32>
+  %cst_0 = arith.constant dense<1> : tensor<2xi32>
+  %cst_1 = arith.constant dense<0> : tensor<2xindex>
+  %cst_2 = arith.constant dense<1> : tensor<2xindex>
+  %cst_3 = arith.constant dense<0> : tensor<1xindex>
+  %cst_4 = arith.constant dense<1> : tensor<1xindex>
+  %false = arith.constant false
+  %dim = tensor.dim %arg4, %c1 : tensor<?x?xf32>
+  %output_indices, %output_values, %empty_row_indicator, %reverse_index_map, %output_elements = "mhlo_disc.sparse_fill_empty_rows"(%arg0, %arg1, %arg2, %1) : (tensor<?x2xi64>, tensor<?xi64>, tensor<2xi64>, tensor<i64>) -> (tensor<?x2xi64>, tensor<?xi64>, tensor<?xi1>, tensor<?xi64>, tensor<1xi64>)
+  %extracted = tensor.extract %output_elements[%c0] : tensor<1xi64>
+  %2 = arith.index_cast %extracted : i64 to index
+  %from_elements = tensor.from_elements %2, %c2 : tensor<2xindex>
+  %3 = mhlo.real_dynamic_slice %output_indices, %cst_1, %from_elements, %cst_2 {kDiscSliceOpStaticKnownInfo = {limit_indices = dense<[-2, -1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}} : (tensor<?x2xi64>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x2xi64>
+  %from_elements_5 = tensor.from_elements %2 : tensor<1xindex>
+  %4 = mhlo.real_dynamic_slice %output_values, %cst_3, %from_elements_5, %cst_4 {kDiscSliceOpStaticKnownInfo = {limit_indices = dense<-2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>}} : (tensor<?xi64>, tensor<1xindex>, tensor<1xindex>, tensor<1xindex>) -> tensor<?xi64>
+  %5 = arith.index_cast %2 : index to i32
+  %6 = arith.cmpi slt, %5, %c0_i32 : i32
+  %7 = arith.cmpi eq, %6, %false : i1
+  %8 = arith.cmpi ne, %5, %c0_i32 : i32
+  %9 = arith.andi %8, %7 : i1
+  %10 = arith.select %9, %5, %c0_i32 : i32
+  %11 = arith.select %6, %c0_i32, %5 : i32
+  %12 = arith.cmpi slt, %11, %5 : i32
+  %13 = arith.select %12, %11, %5 : i32
+  %from_elements_6 = tensor.from_elements %13, %c1_i32 : tensor<2xi32>
+  %14 = mhlo.real_dynamic_slice %3, %cst, %from_elements_6, %cst_0 {kDiscSliceOpStaticKnownInfo = {limit_indices = dense<[-2, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}} : (tensor<?x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x1xi64>
+  %from_elements_7 = tensor.from_elements %10 : tensor<1xi32>
+  %15 = mhlo.dynamic_reshape %14, %from_elements_7 : (tensor<?x1xi64>, tensor<1xi32>) -> tensor<?xi64>
+  %16 = "mhlo_disc.sparse_segment_reduction"(%arg4, %4, %15) {reduction_mode = 1 : i64} : (tensor<?x?xf32>, tensor<?xi64>, tensor<?xi64>) -> tensor<?x?xf32>
+  %from_elements_8 = tensor.from_elements %arg5, %dim : tensor<2xindex>
+  %from_elements_9 = tensor.from_elements %c1, %arg5, %dim, %c1 : tensor<4xindex>
+  %17 = "mhlo.dynamic_broadcast_in_dim"(%empty_row_indicator, %from_elements_9) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<?xi1>, tensor<4xindex>) -> tensor<1x?x?x1xi1>
+  %18 = mhlo.dynamic_reshape %17, %from_elements_8 : (tensor<1x?x?x1xi1>, tensor<2xindex>) -> tensor<?x?xi1>
+  %19 = "mhlo.dynamic_broadcast_in_dim"(%0, %from_elements_8) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<f32>, tensor<2xindex>) -> tensor<?x?xf32>
+  %20 = mhlo.select %18, %19, %16 : tensor<?x?xi1>, tensor<?x?xf32>
+  %21 = "mhlo_disc.sparse_segment_reduction"(%arg3, %4, %15) {reduction_mode = 0 : i64} : (tensor<?x?xf32>, tensor<?xi64>, tensor<?xi64>) -> tensor<?x?xf32>
+  %22 = "mhlo.dynamic_broadcast_in_dim"(%empty_row_indicator, %arg9) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<?xi1>, tensor<4xindex>) -> tensor<1x?x?x1xi1>
+  %23 = mhlo.dynamic_reshape %22, %arg7 : (tensor<1x?x?x1xi1>, tensor<2xindex>) -> tensor<?x?xi1>
+  %24 = mhlo.select %23, %arg6, %21 : tensor<?x?xi1>, tensor<?x?xf32>
+  %25 = mhlo.dynamic_reshape %24, %arg8 : (tensor<?x?xf32>, tensor<3xindex>) -> tensor<?x1x?xf32>
+  return %20, %25 : tensor<?x?xf32>, tensor<?x1x?xf32>
+}


### PR DESCRIPTION
1. add hlo definition of `mhlo_disc.sparse_segment_reduction_with_empty_rows`
2. use pdll to rewrite  `mhlo_disc.sparse_segment_reduction` + `mhlo_disc.sparse_fill_empty_rows` to `mhlo_disc.sparse_segment_reduction_with_empty_rows`
3. add some extra pdll utils