### PR TITLE
[transform] some optimization for split-k gemm epilogue fusion

### DIFF
--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -2133,6 +2133,28 @@ cc_library(
 )
 
 cc_library(
+    name = "disc_duplicate_computation_after_fusion",
+    srcs = ["transforms/disc_duplicate_computation_after_fusion.cc"],
+    deps = [
+        ":disc_shape_optimization_utils",
+        ":disc_util",
+        ":fusion_utils",
+        ":pass_details",
+        ":placement_utils",
+        "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:lhlo",
+        "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "all_passes",
     hdrs = [
         "transforms/register_passes.h",
@@ -2156,6 +2178,7 @@ cc_library(
         ":disc_convert_fake_quant_op",
         ":disc_custom_call_rewriter",
         ":disc_cpu_map_parallel_loop",
+        ":disc_duplicate_computation_after_fusion",
         ":disc_duplicate_computation_for_fusion",
         ":disc_dynamic_slice_converter",
         ":disc_sparse_op_rewriter",
@@ -2171,7 +2194,7 @@ cc_library(
         ":disc_lower_tf",
         ":disc_lower_quantize_and_dequantize",
         ":disc_lower_to_library_call",
-	":disc_mhlo_cse",
+        ":disc_mhlo_cse",
         ":disc_math_approximation",
         ":disc_memref_canonicalizer",
         ":disc_outline_cpu_kernel",

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -487,6 +487,8 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
             gpu_options.sm_count, gpu_options.max_threads_per_sm));
   } else {
     pm.addNestedPass<FuncOp>(
+        disc_ral::createDiscDuplicateComputationAfterFusionPass());
+    pm.addNestedPass<FuncOp>(
         disc_ral::createDiscSpecializeFusionWithSpeculationPass());
   }
 

--- a/tao_compiler/mlir/disc/disc_util.cc
+++ b/tao_compiler/mlir/disc/disc_util.cc
@@ -229,6 +229,17 @@ bool useTransformSchedule() {
   return enabled;
 }
 
+// Returns true if `DISC_ENABLE_TRANSFORM_GEMM_EPILOGUE_FUSION` is true.
+bool useTransformGEMMEpilogueFusionSchedule() {
+  static bool enabled = []() {
+    bool enabled = true;
+    tensorflow::ReadBoolFromEnvVar("DISC_ENABLE_TRANSFORM_GEMM_EPILOGUE_FUSION",
+                                   enabled, &enabled);
+    return enabled;
+  }();
+  return enabled;
+}
+
 bool lowerFakeQuantToQuantAndDequant() {
   static bool enabled = []() {
     bool enabled = false;

--- a/tao_compiler/mlir/disc/disc_util.h
+++ b/tao_compiler/mlir/disc/disc_util.h
@@ -126,6 +126,9 @@ bool useHorizontalFusion();
 // Returns true if `DISC_ENABLE_TRANSFORM_SCHEDULE` is true.
 bool useTransformSchedule();
 
+// Returns true if `DISC_ENABLE_TRANSFORM_GEMM_EPILOGUE_FUSION` is true.
+bool useTransformGEMMEpilogueFusionSchedule();
+
 // Returns true if `DISC_FAKE_QUANT_TO_QUANT_AND_DEQUANT` is true
 bool lowerFakeQuantToQuantAndDequant();
 

--- a/tao_compiler/mlir/disc/tests/disc-transform/matmul_epilogue.cc
+++ b/tao_compiler/mlir/disc/tests/disc-transform/matmul_epilogue.cc
@@ -45,6 +45,26 @@ TEST(PackedMatmul, F32_biasadd_768x3072) {
       /*profiling*/ true));
 }
 
+TEST(PackedMatmul, F32_biasadd_768x3072_2) {
+  EnvSetting setting = {
+      {"DISC_ENABLE_TRANSFORM_SCHEDULE", {"1", false}},
+      {"DISC_ENABLE_SHAPE_CONSTRAINT_IR", {"1", false}},
+      {"DISC_ENABLE_TRANSFORM_GEMM_EPILOGUE_FUSION", {"0", false}},
+      {"DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL", {"0", false}}};
+  EnvSettingContext ctx(setting);
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path +
+          "matmul_epilogue_biasadd_p_768x3072_f32.mlir",
+      /*backend_types*/ {BackendType::kAArch64},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"512x768xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {},
+      /*expected_output_vals*/ {},
+      /*profiling*/ true));
+}
+
 TEST(PackedMatmul, F32_biasadd_relu_768x3072) {
   EnvSetting setting = {{"DISC_ENABLE_TRANSFORM_SCHEDULE", {"1", false}},
                         {"DISC_ENABLE_SHAPE_CONSTRAINT_IR", {"1", false}},
@@ -67,6 +87,25 @@ TEST(PackedMatmul, F32_complex_test0) {
   EnvSetting setting = {{"DISC_ENABLE_TRANSFORM_SCHEDULE", {"1", false}},
                         {"DISC_ENABLE_SHAPE_CONSTRAINT_IR", {"1", false}},
                         {"DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL", {"0", false}}};
+  EnvSettingContext ctx(setting);
+  EXPECT_TRUE(feature_test_main(
+      /*mlir_file_path*/ c_ft_path + "matmul_epilogue_complex_test0.mlir",
+      /*backend_types*/ {BackendType::kAArch64},
+      /*num_inputs*/ 1,
+      /*num_outputs*/ 1,
+      /*input_descriptors*/ {"512x768xf32_X"},
+      /*output_descriptors*/ {"f32_X"},
+      /*input_vals*/ {},
+      /*expected_output_vals*/ {},
+      /*profiling*/ true));
+}
+
+TEST(PackedMatmul, F32_complex_test0_2) {
+  EnvSetting setting = {
+      {"DISC_ENABLE_TRANSFORM_SCHEDULE", {"1", false}},
+      {"DISC_ENABLE_SHAPE_CONSTRAINT_IR", {"1", false}},
+      {"DISC_ENABLE_TRANSFORM_GEMM_EPILOGUE_FUSION", {"0", false}},
+      {"DISC_MEM_INTENSIVE_OPT_EXPERIMENTAL", {"0", false}}};
   EnvSettingContext ctx(setting);
   EXPECT_TRUE(feature_test_main(
       /*mlir_file_path*/ c_ft_path + "matmul_epilogue_complex_test0.mlir",

--- a/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
+++ b/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
@@ -70,6 +70,8 @@ int main(int argc, char** argv) {
       transform_ext::StructuredTransformOpsExtension>();
   mlir::disc_ral::disc_linalg_ext::registerTilingInterfaceExternalModels(
       registry);
+  mlir::disc_ral::disc_linalg_ext::
+      registerBufferizableOpInterfaceExternalModels(registry);
 
   return failed(mlir::MlirOptMain(argc, argv, "MLIR HLO pass driver\n",
                                   registry,

--- a/tao_compiler/mlir/disc/tools/disc-transform/LinalgExt/LinalgExtOps.h
+++ b/tao_compiler/mlir/disc/tools/disc-transform/LinalgExt/LinalgExtOps.h
@@ -59,6 +59,7 @@ SmallVector<T> interchange(ArrayRef<T> elements,
 }
 
 void registerTilingInterfaceExternalModels(DialectRegistry& registry);
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry& registry);
 
 }  // namespace disc_linalg_ext
 }  // namespace disc_ral

--- a/tao_compiler/mlir/disc/tools/disc-transform/TransformOps/TransformOpsExt.td
+++ b/tao_compiler/mlir/disc/tools/disc-transform/TransformOps/TransformOpsExt.td
@@ -779,4 +779,88 @@ def VectorizeConditionalGenericOp : Op<Transform_Dialect, "disc.vectorize_condit
   }];
 }
 
+def SplitVectorTransferIntoFullAndPartialOp : Op<Transform_Dialect, "disc.split_vector_transfer_into_full_and_partial",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
+  let description = [{
+    Split a vector.transfer operation into an in-bounds (i.e., no out-of-bounds masking) fastpath and a slowpath.
+
+    Returns the xfer op if no needs to split, otherwise returns the warpper if op for full version and partial version.
+
+    /// Example (a 2-D vector.transfer_read):
+    /// ```
+    ///    %1 = vector.transfer_read %0[...], %pad : memref<A...>, vector<...>
+    /// ```
+    /// is transformed into:
+    /// ```
+    ///    %1:3 = scf.if (%inBounds) {
+    ///      // fastpath, direct cast
+    ///      memref.cast %A: memref<A...> to compatibleMemRefType
+    ///      scf.yield %view : compatibleMemRefType, index, index
+    ///    } else {
+    ///      // slowpath, not in-bounds vector.transfer or linalg.copy.
+    ///      memref.cast %alloc: memref<B...> to compatibleMemRefType
+    ///      scf.yield %4 : compatibleMemRefType, index, index
+    //     }
+    ///    %0 = vector.transfer_read %1#0[%1#1, %1#2] {in_bounds = [true ... true]}
+    /// ```
+    /// where `alloc` is a top of the function alloca'ed buffer of one vector.
+
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$result);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "::mlir::disc_ral::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def LowerConditionalGenericOp : Op<Transform_Dialect, "disc.lower_conditional_generic",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
+  let description = [{
+    Lower the conditional_generic op to a scf.if + linalg.generic op.
+
+    Note the this transform primitive supposes the conditional_generic has been bufferized.
+
+    Returns the generated linalg.generic op.
+
+    /// Example:
+    /// ```
+    ///    %1 = disc_linalg_ext.conditional_generic ins(%pred, ...), outs(...)
+    /// ```
+    /// is transformed into:
+    /// ```
+    ///    scf.if (%pred) {
+    ///      linalg.generic ins(...) outs(...)
+    ///      scf.yield %view
+    ///    }
+    /// ```
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$result);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "::mlir::disc_ral::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // DISC_TRANSFORM_OPS_EXT

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/decompose-vectors.mlir
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/decompose-vectors.mlir
@@ -128,3 +128,38 @@ transform.structured.canonicalized_sequence failures(propagate) {
 ^bb0(%arg0: !pdl.operation):
   transform.disc.decompose_vectors %arg0 {vector_size = 4}
 }
+
+// -----
+
+// CHECK-LABEL: @test_if
+// CHECK-SAME: (%[[ARG0:.*]]: i1, %[[ARG1:.*]]: vector<8xf32>, %[[ARG2:.*]]: vector<8xf32>)
+func.func @test_if(%arg0: i1, %arg1: vector<8xf32>, %arg2: vector<8xf32>) -> vector<8xf32> {
+  // CHECK: scf.if %[[ARG0]] -> (vector<4xf32>, vector<4xf32>)
+  %out = scf.if %arg0 -> vector<8xf32> {
+    // CHECK: %[[T0:.*]] = vector.extract_strided_slice %[[ARG1]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T1:.*]] = vector.extract_strided_slice %[[ARG2]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T2:.*]] = arith.addf %[[T0]], %[[T1]] : vector<4xf32>
+    // CHECK: %[[T3:.*]] = vector.extract_strided_slice %[[ARG1]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T4:.*]] = vector.extract_strided_slice %[[ARG2]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T5:.*]] = arith.addf %[[T3]], %[[T4]] : vector<4xf32>
+    // CHECK: scf.yield %[[T2]], %[[T5]] : vector<4xf32>, vector<4xf32>
+    %0 = arith.addf %arg1, %arg2 : vector<8xf32>
+    scf.yield %0 : vector<8xf32>
+  } else {
+    // CHECK: %[[T10:.*]] = vector.extract_strided_slice %[[ARG1]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T11:.*]] = vector.extract_strided_slice %[[ARG2]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T12:.*]] = arith.subf %[[T10]], %[[T11]] : vector<4xf32>
+    // CHECK: %[[T13:.*]] = vector.extract_strided_slice %[[ARG1]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T14:.*]] = vector.extract_strided_slice %[[ARG2]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+    // CHECK: %[[T15:.*]] = arith.subf %[[T13]], %[[T14]] : vector<4xf32>
+    // CHECK: scf.yield %[[T12]], %[[T15]] : vector<4xf32>, vector<4xf32>
+    %1 = arith.subf %arg1, %arg2 : vector<8xf32>
+    scf.yield %1 : vector<8xf32>
+  }
+  return %out: vector<8xf32>
+}
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  transform.disc.decompose_vectors %arg0 {vector_size = 4}
+}

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/lower-conditional-generic.mlir
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/tests/lower-conditional-generic.mlir
@@ -1,0 +1,29 @@
+// RUN: disc-opt --disc-transform-dialect-interpreter -split-input-file %s | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> ()>
+#map1 = affine_map<(d0, d1) -> (d1)>
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: @lower_conditional_generic
+// CHECK-SAME: (%[[ARG0:.*]]: i1, %[[ARG1:.*]]: memref<f32>, %[[ARG2:.*]]: memref<12xf32>, %[[ARG3:.*]]: memref<8x12xf32>)
+func.func @lower_conditional_generic(
+    %pred : i1, %arg0: memref<f32>, %arg1 : memref<12xf32>, %arg2 : memref<8x12xf32>) -> memref<8x12xf32> {
+  // CHECK: scf.if %[[ARG0]] {
+  // CHECK-NEXT: linalg.generic
+  // CHECK-SAME: ins(%[[ARG1]], %[[ARG2]] : memref<f32>, memref<12xf32>)
+  // CHECK-SAME: outs(%[[ARG3]] : memref<8x12xf32>)
+  disc_linalg_ext.conditional_generic {indexing_maps = [#map0, #map0, #map1, #map2], iterator_types = ["parallel", "parallel"]}
+      ins(%pred, %arg0, %arg1 : i1, memref<f32>, memref<12xf32>) outs(%arg2 : memref<8x12xf32>) {
+  ^bb0(%in: i1, %in_1: f32, %in_2: f32, %out: f32):
+    %t0 = arith.addf %out, %in_2 : f32
+    %t1 = arith.maxf %in_1, %t0 : f32
+    disc_linalg_ext.yield %t1 : f32
+  }
+  return %arg2 : memref<8x12xf32>
+}
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  %0 = transform.structured.match ops{["disc_linalg_ext.conditional_generic"]} in %arg0
+  transform.disc.lower_conditional_generic %0
+}

--- a/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_dialect_interpreter.cc
+++ b/tao_compiler/mlir/disc/tools/disc-transform/transforms/transform_dialect_interpreter.cc
@@ -92,6 +92,7 @@ void addTransformDialectDependentDialects(DialectRegistry& registry) {
   scf::registerTransformDialectExtension(registry);
   registerTransformDialectCommonExtension(registry);
   disc_linalg_ext::registerTilingInterfaceExternalModels(registry);
+  disc_linalg_ext::registerBufferizableOpInterfaceExternalModels(registry);
 }
 
 namespace {

--- a/tao_compiler/mlir/disc/transforms/disc_duplicate_computation_after_fusion.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_duplicate_computation_after_fusion.cc
@@ -1,0 +1,115 @@
+/* Copyright 2023 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/disc/disc_util.h"
+#include "mlir/disc/transforms/PassDetail.h"
+#include "mlir/disc/transforms/fusion_utils.h"
+
+// This file implements the logic to duplicate some lmhlo operations in order
+// to enable more opportunities for fusion and reduce memory footprint.
+
+namespace mlir {
+namespace disc_ral {
+
+namespace {
+
+using func::FuncOp;
+using namespace lmhlo;
+
+lmhlo::ConstantOp getConstProducer(Value value) {
+  for (Operation* user : value.getUsers()) {
+    auto constOp = dyn_cast<lmhlo::ConstantOp>(user);
+    if (constOp) return constOp;
+  }
+  return nullptr;
+}
+
+struct DiscDuplicateComputationAfterFusionPass
+    : public DiscDuplicateComputationAfterFusionPassBase<
+          DiscDuplicateComputationAfterFusionPass> {
+  using DiscDuplicateComputationAfterFusionPassBase<
+      DiscDuplicateComputationAfterFusionPass>::
+      DiscDuplicateComputationAfterFusionPassBase;
+
+  void runOnOperation() override {
+    FuncOp func = getOperation();
+    // skip shape constraint graph
+    if (func.getName() == SymbolicDimMgr::getShapeConstraintGraphFunctionName())
+      return;
+    if (useTransformSchedule()) {
+      if (failed(duplicateForTransformBaseFusion(func))) {
+        return signalPassFailure();
+      }
+    }
+  }
+
+  LogicalResult duplicateForTransformBaseFusion(FuncOp func);
+};
+
+LogicalResult
+DiscDuplicateComputationAfterFusionPass::duplicateForTransformBaseFusion(
+    FuncOp func) {
+  SmallVector<lmhlo::FusionOp> fusionOps;
+  func->walk([&](lmhlo::FusionOp fusionOp) { fusionOps.push_back(fusionOp); });
+
+  std::unique_ptr<ShapeAnalysis> shapeAnalysisPtr;
+  if (useShapeConstraintIR()) {
+    shapeAnalysisPtr.reset(new ShapeConstraintIRAnalysis(func));
+  } else {
+    shapeAnalysisPtr.reset(new ShapeAnalysisDeprecated{func});
+    if (failed(static_cast<ShapeAnalysisDeprecated*>(shapeAnalysisPtr.get())
+                   ->run())) {
+      return failure();
+    }
+  }
+  for (FusionOp fusionOp : fusionOps) {
+    FusionPattern fusionPattern(fusionOp, shapeAnalysisPtr.get());
+    if (!fusionPattern.isTransformBasedFusion()) continue;
+    for (Value operand : fusionPattern.getOperands()) {
+      auto constOp = getConstProducer(operand);
+      if (!constOp ||
+          constOp.getValue().cast<ElementsAttr>().getNumElements() != 1)
+        continue;
+      OpBuilder b(fusionOp);
+      auto newBuffer = b.create<memref::AllocOp>(
+          constOp->getLoc(),
+          constOp->getOperand(0).getType().cast<MemRefType>());
+      b.setInsertionPointToStart(fusionOp.getBody());
+      auto newConstOp = b.clone(*constOp);
+      newConstOp->setOperand(0, newBuffer);
+      for (Operation* op : fusionPattern.getOpList()) {
+        auto operands = op->getOperands();
+        if (llvm::find(operands, constOp->getOperand(0)) == operands.end())
+          continue;
+        op->replaceUsesOfWith(constOp->getOperand(0), newBuffer);
+      }
+    }
+  }
+
+  return success();
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscDuplicateComputationAfterFusionPass() {
+  return std::make_unique<DiscDuplicateComputationAfterFusionPass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/transforms/disc_passes.td
+++ b/tao_compiler/mlir/disc/transforms/disc_passes.td
@@ -601,3 +601,8 @@ def DiscSparseOpRewriterPass : Pass<"disc-sparse-op-rewriter", "mlir::func::Func
   let summary = "Rewrite sparse op for possible fusion";
   let constructor = "createDiscSparseOpRewriterPass()";
 }
+
+def DiscDuplicateComputationAfterFusionPass : Pass<"disc-duplicate-computation-after-fusion", "mlir::func::FuncOp"> {
+  let summary = "Duplicate and fuse some computations into the consumer fusion op in order to remove memory footprint.";
+  let constructor = "createDiscDuplicateComputationAfterFusionPass()";
+}

--- a/tao_compiler/mlir/disc/transforms/fusion_utils_transform_based.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils_transform_based.cc
@@ -76,6 +76,9 @@ bool isSupportedBcast(Operation* op, ShapeAnalysis& shapeAnalysisBase) {
 }
 
 bool TransformBasedCpuFusionStrategy::isFusible(Operation* op) {
+  if (!useTransformGEMMEpilogueFusionSchedule()) {
+    return isSupportedDot(op) || isa<lmhlo::ConstantOp>(op);
+  }
   return isSupportedDot(op) || isElementWise(op) || isBcastOp(op) ||
          isa<lmhlo::ConstantOp>(op);
 }

--- a/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
@@ -737,10 +737,6 @@ struct DiscFusionPass : public DiscFusionPassBase<DiscFusionPass> {
         pipeline.emplace_back(
             makeNewPlacementAwareFusionStrategy(gpu_enabled_, "stitch"));
       } else {
-        if (useTransformSchedule()) {
-          pipeline.emplace_back(makeNewPlacementAwareFusionStrategy(
-              gpu_enabled_, "transform_based"));
-        }
         pipeline.emplace_back(
             makeNewPlacementAwareFusionStrategy(gpu_enabled_, "sparse_base"));
         // Do some basic fusion first.
@@ -750,6 +746,10 @@ struct DiscFusionPass : public DiscFusionPassBase<DiscFusionPass> {
             makeNewPlacementAwareFusionStrategy(gpu_enabled_, "stitch"));
         pipeline.emplace_back(
             makeNewPlacementAwareFusionStrategy(gpu_enabled_, "base"));
+        if (useTransformSchedule()) {
+          pipeline.emplace_back(makeNewPlacementAwareFusionStrategy(
+              gpu_enabled_, "transform_based"));
+        }
       }
     }
     return pipeline;

--- a/tao_compiler/mlir/disc/transforms/passes.h
+++ b/tao_compiler/mlir/disc/transforms/passes.h
@@ -309,6 +309,11 @@ createDiscTransformLegalizeToLoopPass(bool gpuEnabled = false,
                                       const std::string& filename = "",
                                       bool expensiveCheck = false);
 
+// Duplicate and fuse some computation into their fusion consumer to reduce
+// memory footprint.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscDuplicateComputationAfterFusionPass();
+
 }  // namespace disc_ral
 }  // namespace mlir
 

--- a/tao_compiler/mlir/disc/transforms/tests/disc-duplicate-computation-after-fusion.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-duplicate-computation-after-fusion.mlir
@@ -1,0 +1,19 @@
+// RUN: DISC_ENABLE_TRANSFORM_SCHEDULE=1 disc-opt -split-input-file --disc-duplicate-computation-after-fusion %s -o - | FileCheck %s --check-prefix=TRANSFORM
+
+// TRANSFORM-LABEL: @duplicate_scalar_weight_for_ktransform
+func.func @duplicate_scalar_weight_for_ktransform(
+    %arg0 : memref<128x128xf32, "cpu">, %arg1 : memref<128x128xf32, "cpu">,
+    %arg2 : memref<128x128xf32, "cpu">, %arg3: memref<f32, "cpu">, %arg4: memref<2xindex, "cpu">,
+    %arg5 : memref<128x128xf32, "cpu">, %arg6 : memref<128x128xf32, "cpu">) -> (memref<128x128xf32, "cpu">) {
+  "lmhlo.constant"(%arg3) {disc.device = "cpu", value = dense<2.000000e-01> : tensor<f32>} : (memref<f32, "cpu">) -> ()
+  // TRANSFORM: "lmhlo.fusion"
+  // TRANSFORM-NEXT: "lmhlo.constant"(%[[T:.*]]) {disc.device = "cpu", value = dense<2.000000e-01> : tensor<f32>} : (memref<f32, "cpu">) -> ()
+  "lmhlo.fusion"() ({
+    "lmhlo.constant"(%arg0) {disc.device = "cpu", value = dense<0.1> : tensor<128x128xf32>} : (memref<128x128xf32, "cpu">) -> ()
+    "lmhlo.dot_general"(%arg1, %arg0, %arg2) {dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>} : (memref<128x128xf32, "cpu">, memref<128x128xf32, "cpu">, memref<128x128xf32, "cpu">) -> ()
+    "lmhlo.dynamic_broadcast_in_dim"(%arg3, %arg4, %arg5) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (memref<f32, "cpu">, memref<2xindex, "cpu">, memref<128x128xf32, "cpu">) -> ()
+    "lmhlo.add"(%arg2, %arg5, %arg6) : (memref<128x128xf32, "cpu">, memref<128x128xf32, "cpu">, memref<128x128xf32, "cpu">) -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) {disc.device = "cpu", disc.fusion.name = "xxx0", disc.fusion_type = "kTransform"} : () -> ()
+  return %arg6 :  memref<128x128xf32, "cpu">
+}


### PR DESCRIPTION
to #787 

1, decompose scf.if with result having large vector size

2, work around inefficent lower code of arith.select with vector type

3, work around split vector xfer op into full and partial inside a if op.

4, vector.extract_strided_slice/extrac and
vector.insert/vector.insert_strided_slice pair elimination

5, add a pass to duplicate and fuse some computations into the consumer fusion op in order to remove memory footprint

6, use tile buffer to stitch gemm computation and the following epilogue computation by default instead of using vector register. We found that when the epilogue computaion has many operands (except from the gemm), the l1/l2 cache will be polluted by these operands, which significantly hurts the performance of the gemm.