### PR TITLE
[torch-quant] update weight observer qscheme before converting to ref

### DIFF
--- a/tools/torch_quant/tests/test_quantizer.py
+++ b/tools/torch_quant/tests/test_quantizer.py
@@ -19,10 +19,16 @@ from torch_quant.observer import toggle_observer
 from torch_quant.quantizer import Backend, Quantizer
 
 
+def parameterized_backend(backend):
+    # skip if fbgemm not available
+    if torch.backends.quantized.engine != 'fbgemm':
+        backend.remove((Backend.FBGEMM, ))
+    return parameterized.expand(backend)
+
 class QuantizerTest(unittest.TestCase):
-    @parameterized.expand([
+    @parameterized_backend([
         (Backend.REFERENCE, ),
-        (Backend.FBGEMM, ),  # TODO(litan.ls): select test according to ci env
+        (Backend.FBGEMM, ),
         (Backend.DISC, ),
     ])
     def test_calib_and_quantize(self, backend: Backend) -> None:

--- a/tools/torch_quant/tests/test_quantizer.py
+++ b/tools/torch_quant/tests/test_quantizer.py
@@ -22,7 +22,7 @@ from torch_quant.quantizer import Backend, Quantizer
 class QuantizerTest(unittest.TestCase):
     @parameterized.expand([
         (Backend.REFERENCE, ),
-        # (Backend.FBGEMM, ), TODO(litan.ls): select test according to ci env
+        (Backend.FBGEMM, ),  # TODO(litan.ls): select test according to ci env
         (Backend.DISC, ),
     ])
     def test_calib_and_quantize(self, backend: Backend) -> None:

--- a/tools/torch_quant/torch_quant/graph.py
+++ b/tools/torch_quant/torch_quant/graph.py
@@ -247,7 +247,16 @@ def quantizable_module_to_ref(ctx: GraphModContext) -> None:
                 f'module type {type(src)} is not supported for static quantization.')
         w_ob = src.qconfig.weight()
         w_ob(src.weight)
-        dst = dst_type.from_float(src, w_ob.qparams._asdict())
+        # update qscheme, since we don't have symmetric quant qscheme in quantized Tensor
+        # https://github.com/pytorch/pytorch/blob/v1.13.1/torch/ao/quantization/utils.py#L138
+        wq_dict = w_ob.qparams._asdict()
+        sym_to_aff_map = {
+            torch.per_tensor_symmetric: torch.per_tensor_affine,
+            torch.per_channel_symmetric: torch.per_channel_affine,
+        }
+        wq_dict['qscheme'] = sym_to_aff_map.get(wq_dict['qscheme'], wq_dict['qscheme'])
+        wq_dict['axis'] = wq_dict.pop('ch_axis')
+        dst = dst_type.from_float(src, wq_dict)
         # TODO(litan.ls): copy forward hooks
         ctx.replace_module(node.target, dst)
         LOGGER.debug(f'to_ref: {node.target}({type(src)}->{dst_type})')

--- a/tools/torch_quant/torch_quant/quantizer.py
+++ b/tools/torch_quant/torch_quant/quantizer.py
@@ -91,6 +91,8 @@ class Quantizer:
         self.module_filter = module_filter
         self.backend = backend
         self.tracer = tracer
+        if backend == Backend.FBGEMM and torch.backends.quantized.engine != 'fbgemm':
+            raise ValueError('fbgemm is not available, it only for x86_64')
 
     def calib_gm(self, gm: GraphModule, root: nn.Module, ob_types: ObserverTypes) -> None:
         ctx = GraphModContext(gm, root, ob_types.act_ob_ctr, ob_types.w_ob_ctr, ob_types.bias_ob_ctr)

--- a/tools/torch_quant/torch_quant/quantizer.py
+++ b/tools/torch_quant/torch_quant/quantizer.py
@@ -50,9 +50,6 @@ DEFAULT_ACT_OB_CTR: Dict[Backend, Callable[..., Observer]] = {
 }
 
 DEFAULT_W_OB_CTR = {
-    # According to the url below, PyTorch's reference module does not support
-    # symmetric quantization, which is confusing...
-    # https://github.com/pytorch/pytorch/blob/28e69954a1fb25c20153c0e3636b9052e6962ffa/torch/ao/nn/quantized/reference/modules/utils.py#L19
     Backend.REFERENCE: partial(MinMaxObserver, dtype=torch.quint8, qscheme=torch.per_tensor_affine),
     Backend.DISC: partial(PerChannelMinMaxObserver, dtype=torch.qint8, qscheme=torch.per_channel_symmetric),
     Backend.FBGEMM: partial(PerChannelMinMaxObserver, dtype=torch.qint8, qscheme=torch.per_channel_symmetric),


### PR DESCRIPTION
[torch-quant] update weight observer qscheme before converting to ref, change symmetric to affine