### PR TITLE
add flag to control multi-cc compilation

### DIFF
--- a/pytorch_blade/tests/test_config.py
+++ b/pytorch_blade/tests/test_config.py
@@ -25,14 +25,20 @@ class TestConfig(TestCase):
         new_cfg.fp16_fallback_op_ratio = 0.5
         new_cfg.enable_mlir_amp = True
         new_cfg.disc_cpu_fast_math_level = 0
+        new_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity = False
         with new_cfg:
             self.assertEqual(len(Config.get_contexts()), 1)
             now_cfg = Config.get_current_context_or_new()
             self.assertEqual(now_cfg.disc_cpu_fast_math_level, 0)
+            self.assertEqual(now_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity, False)
         now_cfg = Config.get_current_context_or_new()
         self.assertEqual(default_cfg.fp16_fallback_op_ratio, now_cfg.fp16_fallback_op_ratio)
         self.assertEqual(default_cfg.enable_mlir_amp, now_cfg.enable_mlir_amp)
         self.assertEqual(default_cfg.disc_cpu_fast_math_level, now_cfg.disc_cpu_fast_math_level)
+        self.assertEqual(
+            default_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity,
+            now_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity
+        )
 
     def test_config_work(self):
         new_cfg = Config()

--- a/pytorch_blade/tests/test_config.py
+++ b/pytorch_blade/tests/test_config.py
@@ -25,19 +25,19 @@ class TestConfig(TestCase):
         new_cfg.fp16_fallback_op_ratio = 0.5
         new_cfg.enable_mlir_amp = True
         new_cfg.disc_cpu_fast_math_level = 0
-        new_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity = False
+        new_cfg.disc_compile_for_multi_cuda_targets = False
         with new_cfg:
             self.assertEqual(len(Config.get_contexts()), 1)
             now_cfg = Config.get_current_context_or_new()
             self.assertEqual(now_cfg.disc_cpu_fast_math_level, 0)
-            self.assertEqual(now_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity, False)
+            self.assertEqual(now_cfg.disc_compile_for_multi_cuda_targets, False)
         now_cfg = Config.get_current_context_or_new()
         self.assertEqual(default_cfg.fp16_fallback_op_ratio, now_cfg.fp16_fallback_op_ratio)
         self.assertEqual(default_cfg.enable_mlir_amp, now_cfg.enable_mlir_amp)
         self.assertEqual(default_cfg.disc_cpu_fast_math_level, now_cfg.disc_cpu_fast_math_level)
         self.assertEqual(
-            default_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity,
-            now_cfg.disc_cuda_compile_for_multi_cuda_compute_capacity
+            default_cfg.disc_compile_for_multi_cuda_targets,
+            now_cfg.disc_compile_for_multi_cuda_targets
         )
 
     def test_config_work(self):

--- a/pytorch_blade/torch_blade/clustering/support_group_conversion.py
+++ b/pytorch_blade/torch_blade/clustering/support_group_conversion.py
@@ -188,6 +188,11 @@ def group_node_to_engine(
     logger.debug(f"Group converting complete: {group_name}")
 
 
+def group_node_to_engine_with_cfg(config, *args, **kwargs):
+    local_config = config or Config.get_current_context_or_new()
+    with local_config:
+        group_node_to_engine(*args, **kwargs)
+
 def group_nodes(block):
     grp_nodes = []
     for node in block.node_list():
@@ -258,7 +263,8 @@ def group_to_engine_conversion(
                 logger.debug(f"Submit to convert fusion group {idx} ...")
                 group_id = idx + start_id
                 grp_calib_data = all_calib_data[idx] if all_calib_data is not None else None
-                f = executor.submit(group_node_to_engine,
+                f = executor.submit(group_node_to_engine_with_cfg,
+                                    Config.get_current_context_or_new(),
                                     module,
                                     node,
                                     try_cvt_to_engine_func,

--- a/pytorch_blade/torch_blade/config.py
+++ b/pytorch_blade/torch_blade/config.py
@@ -166,10 +166,13 @@ class Config(ConfigContext):
         #   Level 3: Level 2 + NoNaNs + NoSignedZeros
         #   Level 4: Level 3 + fully llvm fast math
         self._disc_cpu_fast_math_level = 4
-        # Note that default cluster max_iter_count number has risk of early stopping before 
-        # cluster final convergence. If this phenomenon happens and it drastically influence 
+        # Note that default cluster max_iter_count number has risk of early stopping before
+        # cluster final convergence. If this phenomenon happens and it drastically influence
         # the latency, user can try to enlarge this number.
         self._disc_cluster_max_iter_count = 10
+        # Ahead of time compile for multi cuda compute_capacity..
+        # Note that it will take longer time to optimize when the flag is on.
+        self._disc_cuda_compile_for_multi_cuda_compute_capacity = True
         # min/max/opt settings for tuning trt engines with dynamic input shapes
         # looks like:
         # {
@@ -237,7 +240,7 @@ class Config(ConfigContext):
 
     @property
     def enable_onnx_shape_white_list(self):
-        """The flag is used to force convert shape aten operations to TensorRT. Currently the list contains, 
+        """The flag is used to force convert shape aten operations to TensorRT. Currently the list contains,
         'aten::view', 'aten::size', 'aten::reshape', 'aten::floor_divide', 'aten::Int', 'prim::NumToTensor'.
 
         :type: bool
@@ -357,6 +360,23 @@ class Config(ConfigContext):
     def disc_cpu_fast_math_level(self, val):
         assert isinstance(val, int), "disc_cpu_fast_math_level should be int, got {}".format(type(val))
         self._disc_cpu_fast_math_level = val
+
+    @property
+    def disc_cuda_compile_for_multi_cuda_compute_capacity(self):
+        """The flag to enable multi_cc commpilation.
+
+        # Ahead of time compile for multi cuda compute_capacity..
+        # Note that it will take longer time to optimize when the flag is on.
+
+        :type: bool
+        :default: True
+        """
+        return self._disc_cuda_compile_for_multi_cuda_compute_capacity
+
+    @disc_cuda_compile_for_multi_cuda_compute_capacity.setter
+    def disc_cuda_compile_for_multi_cuda_compute_capacity(self, val):
+        assert isinstance(val, bool), "disc_cuda_compile_for_multi_cuda_compute_capacity should be bool, got {}".format(type(val))
+        self._disc_cuda_compile_for_multi_cuda_compute_capacity = val
 
     @property
     def disc_cluster_max_iter_count(self):

--- a/pytorch_blade/torch_blade/config.py
+++ b/pytorch_blade/torch_blade/config.py
@@ -172,7 +172,7 @@ class Config(ConfigContext):
         self._disc_cluster_max_iter_count = 10
         # Ahead of time compile for multi cuda compute_capacity..
         # Note that it will take longer time to optimize when the flag is on.
-        self._disc_cuda_compile_for_multi_cuda_compute_capacity = True
+        self._disc_compile_for_multi_cuda_targets = True
         # min/max/opt settings for tuning trt engines with dynamic input shapes
         # looks like:
         # {
@@ -362,7 +362,7 @@ class Config(ConfigContext):
         self._disc_cpu_fast_math_level = val
 
     @property
-    def disc_cuda_compile_for_multi_cuda_compute_capacity(self):
+    def disc_compile_for_multi_cuda_targets(self):
         """The flag to enable multi_cc commpilation.
 
         # Ahead of time compile for multi cuda compute_capacity..
@@ -371,12 +371,12 @@ class Config(ConfigContext):
         :type: bool
         :default: True
         """
-        return self._disc_cuda_compile_for_multi_cuda_compute_capacity
+        return self._disc_compile_for_multi_cuda_targets
 
-    @disc_cuda_compile_for_multi_cuda_compute_capacity.setter
-    def disc_cuda_compile_for_multi_cuda_compute_capacity(self, val):
-        assert isinstance(val, bool), "disc_cuda_compile_for_multi_cuda_compute_capacity should be bool, got {}".format(type(val))
-        self._disc_cuda_compile_for_multi_cuda_compute_capacity = val
+    @disc_compile_for_multi_cuda_targets.setter
+    def disc_compile_for_multi_cuda_targets(self, val):
+        assert isinstance(val, bool), "disc_compile_for_multi_cuda_targets should be bool, got {}".format(type(val))
+        self._disc_compile_for_multi_cuda_targets = val
 
     @property
     def disc_cluster_max_iter_count(self):

--- a/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
+++ b/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
@@ -81,8 +81,11 @@ def _compile_torchscript(graph):
             env['DISC_CPU_FAST_MATH_LEVEL'] = str(cfg.disc_cpu_fast_math_level)
             # RUN: disc_compiler_main input_mlir_file.mlir output_file.so
             # redirect stdout to devnull
+            extra_flags = []
+            if cfg.disc_cuda_compile_for_multi_cuda_compute_capacity:
+                extra_flags += ["--multi-cc-support"]
             subprocess.check_call(
-                [mhlo_compile_cmd, inp_mlir_file.name, out_file_name, "--multi-cc-support", "--mlir-elide-elementsattrs-if-larger=8"],
+                [mhlo_compile_cmd, inp_mlir_file.name, out_file_name, "--mlir-elide-elementsattrs-if-larger=8"] + extra_flags,
                 stdout=devnull,
                 stderr=devnull,
                 env=env,

--- a/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
+++ b/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
@@ -82,7 +82,7 @@ def _compile_torchscript(graph):
             # RUN: disc_compiler_main input_mlir_file.mlir output_file.so
             # redirect stdout to devnull
             extra_flags = []
-            if cfg.disc_cuda_compile_for_multi_cuda_compute_capacity:
+            if cfg.disc_compile_for_multi_cuda_targets:
                 extra_flags += ["--multi-cc-support"]
             subprocess.check_call(
                 [mhlo_compile_cmd, inp_mlir_file.name, out_file_name, "--mlir-elide-elementsattrs-if-larger=8"] + extra_flags,


### PR DESCRIPTION
multi-cc compilation will take longer time. Add flag to control it.

Disable it will reduce the compilation time for `GpuKernelToBlobPass` from ~200s to ~80s.