### PR TITLE
avoid mix reduction type in one fusion block

### DIFF
--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -1162,6 +1162,16 @@ bool FusionStrategy::tryFuse(ShapeAnalysis& shapeAnalysis, FusionPattern& lhs,
   auto& operands = target.getOperands();
   auto& results = target.getResults();
 
+  // TODO(Yancey): support fusion with different reduction type
+  bool has_row_reduction = llvm::any_of(
+      op_list, [](Operation* op) { return isRank2RowReduction(op); });
+  bool has_col_reduciton = llvm::any_of(
+      op_list, [](Operation* op) { return isRank2ColReduction(op); });
+
+  if (has_row_reduction && has_col_reduciton) {
+    return false;
+  }
+
   if (results.size() + operands.size() >
       options_.max_num_arguments_per_kernel) {
     // some backend devices (e.g. GPU) do not support a kernel with

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -791,7 +791,8 @@ class BaseGpuFusionStrategy : public BaseFusionStrategy {
                       FusionPattern& target) {
     return lhs.isKInputFusion() && rhs.isKInputFusion();
   }
-
+  virtual bool tryFuse(ShapeAnalysis& shapeAnalysis, FusionPattern& lhs,
+                       FusionPattern& rhs, FusionPattern& target) override;
   Value getEffectiveShape(FusionPattern& target, Value v) override;
   virtual StringRef getName() override { return "BaseGpuFusionStrategy"; }
 };
@@ -801,7 +802,8 @@ class StitchGpuFusionStrategy : public FusionStrategy {
   StitchGpuFusionStrategy(const FusionOptions& options)
       : FusionStrategy(options) {}
   virtual bool isFusible(Operation* op) override;
-
+  virtual bool tryFuse(ShapeAnalysis& shapeAnalysis, FusionPattern& lhs,
+                       FusionPattern& rhs, FusionPattern& target) override;
   virtual bool initFusionPattern(ShapeAnalysis& shapeAnalysis,
                                  FusionPattern& fusion_pattern) override;
   virtual StringRef getName() override { return "StitchGpuFusionStrategy"; }

--- a/tao_compiler/tao
+++ b/tao_compiler/tao
@@ -1,0 +1,1 @@
+/workspace/BladeDISC/tao


### PR DESCRIPTION
mixing col reduction in row reduction fusion block caused a bug on indexing, this PR avoid mixing row/col into one fusion block.
