### PR TITLE
add torch_blade compilation cache

### DIFF
--- a/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
@@ -17,6 +17,7 @@
 
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/lazy/core/hash.h>
 
 #include "common_utils/utils.h"
 #include "compiler/jit/torch/const_loop_unroll.h"
@@ -167,6 +168,12 @@ Getting record cluster IO(Inputs/Outputs) flag configured in current thread.
             method_name, graph);
         self.type()->addMethod(fn);
       });
+  tools.def("hash_combine", [](size_t a, size_t b) {
+    return torch::lazy::StdHashCombine(a, b);
+  });
+  tools.def("data_hash", [](const std::string& val) {
+    return torch::lazy::StdDataHash(val.c_str(), val.size());
+  });
 }
 
 } // namespace blade

--- a/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/pybind_functions.cpp
@@ -17,7 +17,6 @@
 
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
-#include <torch/csrc/lazy/core/hash.h>
 
 #include "common_utils/utils.h"
 #include "compiler/jit/torch/const_loop_unroll.h"
@@ -168,12 +167,6 @@ Getting record cluster IO(Inputs/Outputs) flag configured in current thread.
             method_name, graph);
         self.type()->addMethod(fn);
       });
-  tools.def("hash_combine", [](size_t a, size_t b) {
-    return torch::lazy::StdHashCombine(a, b);
-  });
-  tools.def("data_hash", [](const std::string& val) {
-    return torch::lazy::StdDataHash(val.c_str(), val.size());
-  });
 }
 
 } // namespace blade

--- a/pytorch_blade/tests/disc/test_cache.py
+++ b/pytorch_blade/tests/disc/test_cache.py
@@ -1,0 +1,46 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from torch_blade.mlir.cache import DiscCompilationCache, get_graph_hash, CompilationResult
+#from torch_blade.testing.common_utils import TestCase
+import unittest
+
+class TestCache(unittest.TestCase):
+    def test_disc_cache(self):
+        gstr = """graph(%x.1 : Float(*, *),
+                %y.1 : Float(*, *)):
+            %4 : Tensor = aten::mul(%x.1, %y.1)
+            return (%4)"""
+        graph = torch._C.parse_ir(gstr)
+
+        so_bytes = "so_bytes"
+        pb_bytes = "pb_bytes"
+        input_dev_str = "cpu"
+        output_dev_str = "cpu"
+
+        cache = DiscCompilationCache()
+
+        result = CompilationResult(so_bytes, pb_bytes, input_dev_str, output_dev_str)
+        hash_value = get_graph_hash(graph)
+        cache.set(hash_value, result)
+
+        expect_result = cache.get(hash_value)
+        self.assertEqual(expect_result._so_bytes, bytes(so_bytes, "utf-8"))
+        self.assertEqual(expect_result._pb_bytes, bytes(pb_bytes, "utf-8"))
+        self.assertEqual(expect_result._inputs_device, bytes(input_dev_str, "utf-8"))
+        self.assertEqual(expect_result._outputs_device, bytes(output_dev_str, "utf-8"))
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pytorch_blade/tests/disc/test_cache.py
+++ b/pytorch_blade/tests/disc/test_cache.py
@@ -11,11 +11,12 @@
 
 
 import torch
-from torch_blade.mlir.cache import DiscCompilationCache, get_graph_hash, CompilationResult
-#from torch_blade.testing.common_utils import TestCase
+from torch_blade.mlir.cache import DiscCompilationCache, CompilationResult
+from torch_blade.mlir.hash import get_graph_hash
+from tests.disc.testing_base import DiscTestCase
 import unittest
 
-class TestCache(unittest.TestCase):
+class TestCache(DiscTestCase):
     def test_disc_cache(self):
         gstr = """graph(%x.1 : Float(*, *),
                 %y.1 : Float(*, *)):

--- a/pytorch_blade/torch_blade/logging.py
+++ b/pytorch_blade/torch_blade/logging.py
@@ -25,7 +25,7 @@ def logger_level_context(level):
     # create console handler and set level to debug
     ch = logging.StreamHandler()
     # create formatter
-    formatter = logging.Formatter('%(asctime)s - [%(levelname)-05s] %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(filename)s:%(lineno)d - [%(levelname)-05s] %(message)s')
     # add formatter to ch
     ch.setFormatter(formatter)
     # add ch to logger

--- a/pytorch_blade/torch_blade/mlir/cache.py
+++ b/pytorch_blade/torch_blade/mlir/cache.py
@@ -14,12 +14,16 @@ import os
 import shutil
 import logging
 from enum import Enum
-from torch_blade.tools import hash_combine, data_hash
+from torch_blade.tools import hash_combine, data_hash, read_bool_from_env
 from torch_blade._torch_blade import _backends
 from torch_blade.logging import logger
 
 HASH_SEED = 1
 DEFAULT_DISC_CACHE_DIR = os.path.join(os.path.expanduser('~'), ".cache/disc")
+
+def enable_compilation_cache():
+    return read_bool_from_env('TORCH_BLADE_ENABLE_COMPILATION_CACHE', False)
+
 
 class ResultEnum(str, Enum):
     SO_BYTES = "so_bytes"
@@ -106,7 +110,6 @@ def get_graph_hash(graph):
         hash_value = hash_combine(hash_value, data_hash(val_info.dtype))
         hash_value = hash_combine(hash_value, data_hash(val_info.device))
         hash_value = hash_combine(hash_value, data_hash(str(rank)))
-        logger.debug("input tensor info: {}, {}, {}, {}, hash_value: {}".format(val_info.dtype, val_info.device, val_info.name, rank, hash_value))
     # hash node info
     for n in nodes:
         hash_value = hash_combine(hash_value, data_hash(n.kind()))

--- a/pytorch_blade/torch_blade/mlir/cache.py
+++ b/pytorch_blade/torch_blade/mlir/cache.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import logging
 from enum import Enum
-from torch_blade.tools import hash_combine, data_hash, read_bool_from_env
+from torch_blade.tools import read_bool_from_env
 from torch_blade._torch_blade import _backends
 from torch_blade.logging import logger
 
@@ -23,12 +23,6 @@ DEFAULT_DISC_CACHE_DIR = os.path.join(os.path.expanduser('~'), ".cache/disc")
 
 def enable_compilation_cache():
     return read_bool_from_env('TORCH_BLADE_ENABLE_COMPILATION_CACHE', False)
-
-def data_hash(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-def hash_combine(seed: int, value: int) -> int:
-    return seed ^ value + 0x9e3779b9 + (seed << 6) + (seed >> 2)
 
 class ResultEnum(str, Enum):
     SO_BYTES = "so_bytes"

--- a/pytorch_blade/torch_blade/mlir/cache.py
+++ b/pytorch_blade/torch_blade/mlir/cache.py
@@ -1,0 +1,113 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import shutil
+import logging
+from enum import Enum
+from torch_blade.tools import hash_combine, data_hash
+from torch_blade._torch_blade import _backends
+from torch_blade.logging import logger
+
+HASH_SEED = 1
+DEFAULT_DISC_CACHE_DIR = os.path.join(os.path.expanduser('~'), ".cache/disc")
+
+class ResultEnum(str, Enum):
+    SO_BYTES = "so_bytes"
+    PB_BYTES = "pb_bytes"
+    INPUTS_DEVICE = "inputs_device"
+    OUTPUTS_DEVICE = "outputs_device"
+
+class CompilationResult:
+    def __init__(self, so_bytes, pb_bytes, inputs_device, outputs_device):
+        self._so_bytes = so_bytes
+        self._pb_bytes = pb_bytes
+        self._inputs_device = inputs_device
+        self._outputs_device = outputs_device
+
+    def _dump_data_to_file(self, path, data):
+        if os.path.exists(path):
+            raise RuntimeError("path {} does already exist.".format(path))
+        if isinstance(data, str):
+            data = bytes(data, "utf-8")
+        with open(path, "wb") as f:
+            f.write(data)
+
+    def unpack(self):
+        return self._so_bytes, self._pb_bytes, self._inputs_device, self._outputs_device
+
+    @staticmethod
+    def read_from_file(path):
+        with open(path, "rb") as f:
+            return f.read()
+
+    def dump(self, path):
+        self._dump_data_to_file(os.path.join(path, ResultEnum.SO_BYTES), self._so_bytes)
+        self._dump_data_to_file(os.path.join(path, ResultEnum.PB_BYTES), self._pb_bytes)
+        self._dump_data_to_file(os.path.join(path, ResultEnum.INPUTS_DEVICE), self._inputs_device)
+        self._dump_data_to_file(os.path.join(path, ResultEnum.OUTPUTS_DEVICE), self._outputs_device)
+        return True
+
+    @staticmethod
+    def load_from_path(path):
+        so_bytes = CompilationResult.read_from_file(os.path.join(path, ResultEnum.SO_BYTES))
+        pb_bytes = CompilationResult.read_from_file(os.path.join(path, ResultEnum.PB_BYTES))
+        inputs_device = CompilationResult.read_from_file(os.path.join(path, ResultEnum.INPUTS_DEVICE))
+        outputs_device = CompilationResult.read_from_file(os.path.join(path, ResultEnum.OUTPUTS_DEVICE))
+        return CompilationResult(so_bytes, pb_bytes, inputs_device, outputs_device)
+
+class DiscCompilationCache:
+    def __init__(self, cache_dir=DEFAULT_DISC_CACHE_DIR):
+        logger.info("DiscCompilationCache init with cache_dir: {}".format(cache_dir))
+        self._cache_dir = cache_dir
+        if not os.path.exists(self._cache_dir):
+            os.makedirs(self._cache_dir)
+        
+
+    def get(self, key) -> CompilationResult:
+        path = os.path.join(self._cache_dir, str(key))
+        if not os.path.exists(path):
+            return None
+        return CompilationResult.load_from_path(path)
+
+    def has(self, key) -> bool:
+        path = os.path.join(self._cache_dir, str(key))
+        return os.path.exists(path)
+    
+    def set(self, hash_value : str, result : CompilationResult) -> bool:
+        path = os.path.join(self._cache_dir, str(hash_value))
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+        if not os.path.exists(path):
+            os.makedirs(path)
+        return result.dump(path)
+
+
+def get_graph_hash(graph):
+    nodes = []
+    for node in graph.nodes():
+        if node.kind() != 'prim::Constant':
+            nodes.append(node)
+    hash_value = HASH_SEED
+    # hash input tensor info
+    for input in graph.inputs():
+        val_info = _backends.TensorInfo(input)
+        rank = len(val_info.sizes)
+        hash_value = hash_combine(hash_value, data_hash(val_info.dtype))
+        hash_value = hash_combine(hash_value, data_hash(val_info.device))
+        hash_value = hash_combine(hash_value, data_hash(str(rank)))
+        logger.debug("input tensor info: {}, {}, {}, {}, hash_value: {}".format(val_info.dtype, val_info.device, val_info.name, rank, hash_value))
+    # hash node info
+    for n in nodes:
+        hash_value = hash_combine(hash_value, data_hash(n.kind()))
+    return hash_value

--- a/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
+++ b/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
@@ -23,7 +23,7 @@ from torch_blade._torch_blade import _backends
 from torch_blade.clustering import support_fusion_group, support_group_conversion
 from torch_blade.config import Config
 from torch_blade.logging import logger
-from torch_blade.mlir.cache import get_graph_hash, DiscCompilationCache, CompilationResult, DEFAULT_DISC_CACHE_DIR
+from torch_blade.mlir.cache import get_graph_hash, DiscCompilationCache, CompilationResult, enable_compilation_cache
 from collections import defaultdict
 
 def _dump_to_tempfile(tmp_dir, dump_bytes):
@@ -32,13 +32,9 @@ def _dump_to_tempfile(tmp_dir, dump_bytes):
     inp_file.close()
     return inp_file
 
-def enable_compilation_cache():
-    return tools.read_bool_from_env('TORCH_BLADE_ENABLE_COMPILATION_CACHE', True)
-
 disc_cache = None
 if enable_compilation_cache():
-    cache_dir = os.getenv('TORCH_BLADE_COMPILATION_CACHE_DIR', DEFAULT_DISC_CACHE_DIR)
-    disc_cache = DiscCompilationCache(cache_dir)
+    disc_cache = DiscCompilationCache()
 
 def _compile_torchscript(graph):
     # NB: Some MLIR debug information would be dump to mlir_dump_dir,

--- a/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
+++ b/pytorch_blade/torch_blade/mlir/disc_engine_conversion.py
@@ -23,7 +23,8 @@ from torch_blade._torch_blade import _backends
 from torch_blade.clustering import support_fusion_group, support_group_conversion
 from torch_blade.config import Config
 from torch_blade.logging import logger
-from torch_blade.mlir.cache import get_graph_hash, DiscCompilationCache, CompilationResult, enable_compilation_cache
+from torch_blade.mlir.cache import DiscCompilationCache, CompilationResult, enable_compilation_cache
+from torch_blade.mlir.hash import get_graph_hash
 from collections import defaultdict
 
 def _dump_to_tempfile(tmp_dir, dump_bytes):

--- a/pytorch_blade/torch_blade/mlir/hash.py
+++ b/pytorch_blade/torch_blade/mlir/hash.py
@@ -1,0 +1,40 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import hashlib
+from torch_blade._torch_blade import _backends
+HASH_SEED = 1
+
+def data_hash(value: str) -> int:
+    return int(hashlib.sha256(value.encode("utf-8")).hexdigest(), 16)
+
+def hash_combine(a: int, b: int) -> int:
+    return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2))
+
+def get_graph_hash(graph):
+    nodes = []
+    for node in graph.nodes():
+        if node.kind() != 'prim::Constant':
+            nodes.append(node)
+    hash_value = HASH_SEED
+    # hash input tensor info
+    for input in graph.inputs():
+        val_info = _backends.TensorInfo(input)
+        rank = len(val_info.sizes)
+        hash_value = hash_combine(hash_value, data_hash(val_info.dtype))
+        hash_value = hash_combine(hash_value, data_hash(val_info.device))
+        hash_value = hash_combine(hash_value, data_hash(str(rank)))
+    # hash node info
+    for n in nodes:
+        hash_value = hash_combine(hash_value, data_hash(n.kind()))
+    return hash_value


### PR DESCRIPTION
This PR allowed pytorch_blade to cache the compilation result on JIT or AOT compilation progress.
Uses can enable this feature using env `TORCH_BLADE_ENABLE_COMPLATION_CACHE=true`.
