### PR TITLE
add DISC attentionF custom operator schema

### DIFF
--- a/pytorch_blade/pytorch_blade/BUILD
+++ b/pytorch_blade/pytorch_blade/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//pytorch_blade/compiler/jit:torch_blade_jit",
         "//pytorch_blade/compiler/mlir:torch_blade_mlir",
         "@local_org_torch//:libtorch",
+        "//pytorch_blade/disc_ops:attention_op",
     ] + if_tensorrt_enabled([
         "//pytorch_blade/compiler/tensorrt:tensorrt_runtime_impl",
     ]) + if_cuda_is_configured([

--- a/pytorch_blade/pytorch_blade/compiler/jit/torch/shape_analysis.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/jit/torch/shape_analysis.cpp
@@ -1090,7 +1090,18 @@ class ShapePropagator : public PropertyPropBase {
           }
           return type_vec_t{};
         }};
-
+    static const register_formula_for disc_op{
+        {
+            "disc::attentionF(Tensor query, Tensor key, Tensor value, Tensor attn_mask, str i_layout, str o_layout, bool is_causal, bool compute_logsumexp) -> (Tensor, Tensor)",
+        },
+        [](Node* node) -> type_vec_t {
+          if (auto input_type = node->input(0)->type()->cast<TensorType>()) {
+            return type_vec_t{
+                input_type->dimensionedOnly(),
+                input_type->withDim(input_type->dim().value() - 1)};
+          }
+          return type_vec_t{};
+        }};
     static const register_formula_for permute_op{
         {
             "aten::permute(Tensor self, int[] dims) -> Tensor",

--- a/pytorch_blade/pytorch_blade/disc_ops/BUILD
+++ b/pytorch_blade/pytorch_blade/disc_ops/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "attention_op",
+    srcs = [
+        "attention_op.cpp",
+    ],
+    deps = [
+        "@local_org_torch//:libtorch",
+        "//pytorch_blade/common_utils:torch_blade_common"
+    ],
+    alwayslink = True,
+)

--- a/pytorch_blade/pytorch_blade/disc_ops/attention_op.cpp
+++ b/pytorch_blade/pytorch_blade/disc_ops/attention_op.cpp
@@ -1,0 +1,40 @@
+// Copyright 2023 The BladeDISC Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/script.h>
+#include <cstdint>
+
+namespace torch {
+namespace blade {
+std::tuple<at::Tensor, at::Tensor> torch_blade_attentionF(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& attn_mask,
+    const std::string& i_layout,
+    const std::string& o_layout,
+    bool is_causal,
+    bool compute_logsumexp) {
+  TORCH_CHECK(
+      false,
+      "nerver call this disc attentionF operator on eager mode, we need to lower this op to DISC custom call, please contact BladeDISC dev team!");
+  Tensor out, logsumexp;
+  return std::make_tuple(out, logsumexp);
+}
+
+TORCH_LIBRARY(disc, m) {
+  m.def(
+      "attentionF(Tensor query, Tensor key, Tensor value, Tensor attn_mask, str i_layout=\"BMHK\", str o_layout=\"BMHK\", bool is_causal=False, bool compute_logsumexp=False) -> (Tensor, Tensor)");
+  m.impl("attentionF", &torch_blade_attentionF);
+}
+
+} //  namespace blade
+} //  namespace torch

--- a/pytorch_blade/tests/torch-disc-ops/test_attention_op.py
+++ b/pytorch_blade/tests/torch-disc-ops/test_attention_op.py
@@ -1,0 +1,33 @@
+# Copyright 2023 The BladeDISC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch_blade
+import unittest
+from torch.testing import FileCheck
+
+class TestDiscAttentionOp(unittest.TestCase):
+    def test_attentionF_graph(self):
+        @torch.jit.script
+        def func_attF(query, key, value, attn_mask):
+            return torch.ops.disc.attentionF(query, key, value, attn_mask, "NHWC", "NHWC", False, False)
+        expected_gstr = """
+graph(%query.1 : Tensor,
+      %key.1 : Tensor,
+      %value.1 : Tensor):
+  # CHECK: disc::attentionF
+  %8 : Tensor, %9 : Tensor = disc::attentionF(%query.1, %key.1, %value.1, %6, %7)
+  return (%10)
+"""
+        FileCheck().run(expected_gstr, str(func_attF.graph))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR added a PyTorch custom operator `disc::attentionF` op schema, that we can use pdll to lower this op to disc BladNN custom call .
