### PR TITLE
Add environment to enable using i64 for GPU index computation.

### DIFF
--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -631,12 +631,15 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
     kernelPm.addNestedPass<FuncOp>(createCSEPass());
     kernelPm.addNestedPass<FuncOp>(createCanonicalizerPass());
     kernelPm.addPass(createStripDebugInfoPass());
+    int64_t codegen_bitwidth = 32;
+    tensorflow::ReadInt64FromEnvVar("DISC_CODEGEN_INDEX_BITWIDTH",
+                                    codegen_bitwidth, &codegen_bitwidth);
 #if TENSORFLOW_USE_ROCM
     kernelPm.addPass(disc_ral::createDiscLowerGpuOpsToROCDLOpsPass(
-        /*kDeriveIndexBitwidthFromDataLayout*/ 32));
+        /*kDeriveIndexBitwidthFromDataLayout*/ codegen_bitwidth));
 #elif GOOGLE_CUDA
     kernelPm.addPass(disc_ral::createDiscLowerGpuOpsToNVVMOpsPass(
-        /*kDeriveIndexBitwidthFromDataLayout*/ 32));
+        /*kDeriveIndexBitwidthFromDataLayout*/ codegen_bitwidth));
 #endif
     if (isMemIntensiveOptExperimentalEnabled()) {
       // To eliminate dead argument of GPU LLVM functions. First, it has to


### PR DESCRIPTION
We encounter some models whose generated kernels suffer from index overflow due to the i32 data type. With this commit, by using the environment `DISC_CODEGEN_INDEX_BITWIDTH=64`, the codegen will use i64 for index computation. We may also need to update the index type selection logic on the CPU side someday.