### PR TITLE
enable pdl pattern match in more place

### DIFF
--- a/pytorch_blade/pytorch_blade/torch-mlir/lib/Conversion/MhloPasses.cpp
+++ b/pytorch_blade/pytorch_blade/torch-mlir/lib/Conversion/MhloPasses.cpp
@@ -65,6 +65,9 @@ void mlir::torch::createDiscTorchBackendToMhloBackendPipeline(
   pm.addNestedPass<func::FuncOp>(
       Torch::createDecomposeComplexOpsPass(/*legalOps*/ {}));
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<func::FuncOp>(createApplyDiscPdlPatternsPass(
+      disc_torch_pdl_files, disc_torch_pdll_include_dirs));
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   // TorchMLIR DecomposeComplexOpsPass might generate new operators
   // that need to be decomposed further before DISC passes
   pm.addNestedPass<func::FuncOp>(createDiscDecomposeComplexOpsPass());


### PR DESCRIPTION
After `createDecomposeComplexOpsPass`, the `torch.aten.linear` will be decomposed to `matmul` with the weight transformed from `nxk` to` kxn`, which is more friendly for weight-only quantization pattern match. 