### PR TITLE
Support setting scratch memory limit by env

### DIFF
--- a/tao_compiler/mlir/ral/context/stream_executor_based_impl.cc
+++ b/tao_compiler/mlir/ral/context/stream_executor_based_impl.cc
@@ -1269,7 +1269,13 @@ class ScratchAllocator : public se::ScratchAllocator {
   // TODO: For now we just set a small threshold to ease this problem.
   // Revisit this for the performance degrade in more models.
   int64 GetMemoryLimitInBytesImpl() {
-    return 1LL << 28;  // 256M.
+    static int64 value;
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+      TF_CHECK_OK(ReadInt64FromEnvVar("TAO_SCRATCH_ALLOC_LIMIT_BYTES",
+                                      1LL << 28, &value));
+    });
+    return value;
   }
 
  private:


### PR DESCRIPTION
Instead of hard-coding 256M for the scratch memory limit, introduce environment TAO_SCRATCH_ALLOC_LIMIT_BYTES to set it.