### PR TITLE
run through inplace KV cache compilation pass pipeline in torch_blade

### DIFF
--- a/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
@@ -173,16 +173,11 @@ const std::unordered_set<std::string> &GetTorchMlirWhiteList() {
 
   std::call_once(white, [&]() {
     auto list = StrSplit(env::ReadStringFromEnvVar("TORCH_MHLO_OP_WHITE_LIST", ""), ';');
-    for (auto s : list) {
-      std::cout << "white insert: " << s << std::endl;
-      white_list.insert(s);
-    }
+    for (auto s : list) white_list.insert(s);
   });
   std::call_once(black, [&]() {
     auto list = StrSplit(env::ReadStringFromEnvVar("TORCH_MHLO_OP_BLACK_LIST", ""), ';');
-    for (auto s : list) {
-      white_list.erase(s);
-    }
+    for (auto s : list) white_list.erase(s);
   });
 
   std::ostringstream ostr;

--- a/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/mlir/converters/torch_mlir_op_filter.cpp
@@ -174,6 +174,7 @@ const std::unordered_set<std::string> &GetTorchMlirWhiteList() {
   std::call_once(white, [&]() {
     auto list = StrSplit(env::ReadStringFromEnvVar("TORCH_MHLO_OP_WHITE_LIST", ""), ';');
     for (auto s : list) {
+      std::cout << "white insert: " << s << std::endl;
       white_list.insert(s);
     }
   });

--- a/pytorch_blade/pytorch_blade/compiler/mlir/runtime/ral_context.cpp
+++ b/pytorch_blade/pytorch_blade/compiler/mlir/runtime/ral_context.cpp
@@ -161,8 +161,7 @@ at::List<at::Tensor> RalContext::PreProcessInputs(
   at::List<at::Tensor> contiguous_inputs;
   for (at::Tensor inp_tensor : inputs) {
     // make sure the input is in contiguous layout
-    auto contiguous_tensor = inp_tensor.contiguous();
-    contiguous_inputs.push_back(contiguous_tensor);
+    contiguous_inputs.push_back(inp_tensor.contiguous());
   }
   return contiguous_inputs;
 }

--- a/pytorch_blade/tests/disc/ops/test_input_mutation.py
+++ b/pytorch_blade/tests/disc/ops/test_input_mutation.py
@@ -38,8 +38,8 @@ class TestInputMutation(DiscTestCase):
         del os.environ["TORCH_BLADE_EXPERIMENTAL_MERGE_HORIZONTAL_GROUPS"]
 
     def test_inplace_kv(self):
-        k_cache = torch.zeros(8, 32, 4096, 128, device=self.device)
-        k = torch.ones(8, 32, 1, 128, device=self.device)
+        k_cache = torch.zeros(2, 32, 8, device=self.device)
+        k = torch.ones(2, 1, 8, device=self.device)
         
         m = KVCacheModule()
         m.train(False)
@@ -48,6 +48,8 @@ class TestInputMutation(DiscTestCase):
         expect = m(k_cache.clone(), k.clone(), step)
         actual = opt_func(k_cache.clone(), k.clone(), step)
         for exp, act in zip(expect, actual):
+            print(exp)
+            print(act)
             self.assertTrue(torch.allclose(exp.cpu(), act.cpu()))
 
 if __name__ == "__main__":

--- a/pytorch_blade/tests/disc/ops/test_input_mutation.py
+++ b/pytorch_blade/tests/disc/ops/test_input_mutation.py
@@ -34,6 +34,7 @@ class TestInputMutation(DiscTestCase):
         del os.environ["TORCH_MHLO_OP_WHITE_LIST"]
         del os.environ["TORCH_BLADE_EXPERIMENTAL_MERGE_HORIZONTAL_GROUPS"]
 
+    @skipTorchLE("1.10.0")
     def test_inplace_kv(self):
         k_cache = torch.zeros(2, 32, 8, device=self.device)
         k = torch.ones(2, 1, 8, device=self.device)
@@ -45,6 +46,7 @@ class TestInputMutation(DiscTestCase):
         expect = m(k_cache.clone(), k.clone(), step)
         actual = opt_func(k_cache.clone(), k.clone(), step)
         self.assertTrue(torch.allclose(expect.cpu(), actual.cpu()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pytorch_blade/tests/disc/ops/test_input_mutation.py
+++ b/pytorch_blade/tests/disc/ops/test_input_mutation.py
@@ -23,8 +23,6 @@ class KVCacheModule(nn.Module):
     def forward(self, k_cache: Tensor, k: Tensor, step : Tensor):
         k_cache[..., step - k.shape[-2]: step , :].add_(k)
         value = k_cache[..., : step, :]
-        # attention
-        value = torch.matmul(k, value.transpose(-2, -1))
         return k_cache, value
 
 class TestInputMutation(DiscTestCase):
@@ -40,7 +38,7 @@ class TestInputMutation(DiscTestCase):
     def test_inplace_kv(self):
         k_cache = torch.zeros(2, 32, 8, device=self.device)
         k = torch.ones(2, 1, 8, device=self.device)
-        
+
         m = KVCacheModule()
         m.train(False)
         step = torch.tensor(1)
@@ -48,8 +46,8 @@ class TestInputMutation(DiscTestCase):
         expect = m(k_cache.clone(), k.clone(), step)
         actual = opt_func(k_cache.clone(), k.clone(), step)
         for exp, act in zip(expect, actual):
-            print(exp)
-            print(act)
+            print(exp.cpu())
+            print(act.cpu())
             self.assertTrue(torch.allclose(exp.cpu(), act.cpu()))
 
 if __name__ == "__main__":

--- a/pytorch_blade/tests/disc/ops/test_input_mutation.py
+++ b/pytorch_blade/tests/disc/ops/test_input_mutation.py
@@ -22,8 +22,7 @@ from tests.disc.testing_base import skipTorchLE, DiscTestCase
 class KVCacheModule(nn.Module):
     def forward(self, k_cache: Tensor, k: Tensor, step : Tensor):
         k_cache[..., step - k.shape[-2]: step , :].add_(k)
-        value = k_cache[..., : step, :]
-        return k_cache, value
+        return k_cache
 
 class TestInputMutation(DiscTestCase):
     def setUp(self):
@@ -45,10 +44,7 @@ class TestInputMutation(DiscTestCase):
         opt_func = torch_blade.optimize(m, allow_tracing=True, model_inputs=(k_cache.clone(), k.clone(), step))
         expect = m(k_cache.clone(), k.clone(), step)
         actual = opt_func(k_cache.clone(), k.clone(), step)
-        for exp, act in zip(expect, actual):
-            print(exp.cpu())
-            print(act.cpu())
-            self.assertTrue(torch.allclose(exp.cpu(), act.cpu()))
+        self.assertTrue(torch.allclose(expect.cpu(), actual.cpu()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pytorch_blade/torch_blade/pass_manager.py
+++ b/pytorch_blade/torch_blade/pass_manager.py
@@ -498,7 +498,6 @@ def _jit_pass_reinplace(graph):
         inp2_v = new_op.output()
         prev_node = slice_0
         for op_idx, op in enumerate(slice_ops):
-            print("iter", op_idx, op, flush=True)
             slice_scatter = graph.create("aten::slice_scatter")
             input_list = [v for v in op.inputs()]
             if op_idx == 0:
@@ -524,6 +523,9 @@ def _jit_pass_reinplace(graph):
         copy_op.addInput(cst_false.output())
         copy_op.output().setType(list(slice_scatter.inputs())[0].type())
         graph.appendNode(copy_op)
+        if list(graph.return_node().inputs())[0].node().kind() == "prim::TupleConstruct":
+            copy_op.moveBefore(list(graph.return_node().inputs())[0].node())
+        
         list(copy_op.inputs())[0].replaceAllUsesAfterNodeWith(copy_op, slice_scatter.output())
         node.destroy()
     print("after inplace mutation: \n", graph)

--- a/pytorch_blade/torch_blade/pass_manager.py
+++ b/pytorch_blade/torch_blade/pass_manager.py
@@ -444,7 +444,6 @@ def _jit_pass_reinplace(graph):
     %slice_scatter.2 = slice_scatter(%slice_scatter.1, %output, %start.1, %end.1, %step)
     %copy = copy_(%arg0, %slice_scatter.2, %false)
     """
-    print("before inplace mutation", graph)
     def _collect_all_inplace_nodes(block):
         all_nodes = []
         for node in block.nodes():

--- a/pytorch_blade/torch_blade/pass_manager.py
+++ b/pytorch_blade/torch_blade/pass_manager.py
@@ -363,7 +363,6 @@ def _optimize_common(c_module):
         torch._C._jit_pass_remove_dropout(c_module)
         _fixup_for_dynamic_shape(cfg, c_module)
         graph = c_module.forward.graph
-        print("after fixup for dynamic shape", graph)
         _jit_pass_remove_nograd(graph)
         _jit_pass_freeze_requires_grad(graph)
         if hasattr(torch._C, "_jit_pass_fold_frozen_conv_bn"):
@@ -525,10 +524,8 @@ def _jit_pass_reinplace(graph):
         graph.appendNode(copy_op)
         if list(graph.return_node().inputs())[0].node().kind() == "prim::TupleConstruct":
             copy_op.moveBefore(list(graph.return_node().inputs())[0].node())
-        
         list(copy_op.inputs())[0].replaceAllUsesAfterNodeWith(copy_op, slice_scatter.output())
         node.destroy()
-    print("after inplace mutation: \n", graph)
 
 def _jit_pass_hack_cpu_device(graph):
     cfg = Config.get_current_context_or_new()

--- a/tao_compiler/mlir/disc/transforms/codegen_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/codegen_utils.cc
@@ -104,6 +104,9 @@ Value emitNumElementsComputation(OpBuilder& b, Location loc, Operation* op) {
   // only const rank is supported for now
   assert(op->getDialect()->getNamespace() == "lmhlo");
   int num_operands = op->getNumOperands();
+  if (isa<lmhlo::DynamicUpdateSliceOp>(op)) {
+    return emitNumElementsComputation(b, loc, op->getOperand(1));
+  }
   Value result_memref = op->getOperand(num_operands - 1);
   return emitNumElementsComputation(b, loc, result_memref);
 }

--- a/tao_compiler/mlir/disc/transforms/codegen_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/codegen_utils.cc
@@ -104,7 +104,8 @@ Value emitNumElementsComputation(OpBuilder& b, Location loc, Operation* op) {
   // only const rank is supported for now
   assert(op->getDialect()->getNamespace() == "lmhlo");
   int num_operands = op->getNumOperands();
-  if (isa<lmhlo::DynamicUpdateSliceOp>(op) && isInplaceOperator(op)) {
+  if (isa<lmhlo::DynamicUpdateSliceOp>(op) &&
+      op->getOperand(0) == op->getOperand(num_operands - 1)) {
     return emitNumElementsComputation(b, loc, op->getOperand(1));
   }
   Value result_memref = op->getOperand(num_operands - 1);

--- a/tao_compiler/mlir/disc/transforms/codegen_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/codegen_utils.cc
@@ -104,7 +104,7 @@ Value emitNumElementsComputation(OpBuilder& b, Location loc, Operation* op) {
   // only const rank is supported for now
   assert(op->getDialect()->getNamespace() == "lmhlo");
   int num_operands = op->getNumOperands();
-  if (isa<lmhlo::DynamicUpdateSliceOp>(op)) {
+  if (isa<lmhlo::DynamicUpdateSliceOp>(op) && isInplaceOperator(op)) {
     return emitNumElementsComputation(b, loc, op->getOperand(1));
   }
   Value result_memref = op->getOperand(num_operands - 1);

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "mlir/disc/transforms/disc_shape_optimization_utils.h"
 #include "mlir/disc/transforms/lhlo_elemental_utils.h"
 #include "mlir/disc/transforms/placement_utils.h"
+#include "tensorflow/tsl/platform/str_util.h"
 #include "utils/placement_utils.h"
 
 // This file implements some helper functions and classes used to do fusion
@@ -261,13 +262,7 @@ FusionType getFusionType(Operation* op) {
 StringRef getFusionName(lmhlo::FusionOp op) {
   auto attr = op->getAttrOfType<StringAttr>(kFusionOpNameAttr);
   if (!attr) return "";
-  return attr.getValue();
-}
-
-StringRef formatFusionName(StringRef name) {
-  std::string formattedName = name.str();
-  std::replace(formattedName.begin(), formattedName.end(), '-', '_');
-  return formattedName;
+  return tsl::str_util::StringReplace(attr.getValue().str(), "-", "_", true);
 }
 
 // Sets the name of the fusion op
@@ -3257,7 +3252,7 @@ bool StitchCPUAnalysis::emitAllSubRootsAndRootsCalculation(OpBuilder& b,
     auto subFusionName =
         (llvm::Twine(fusionName) + "_" + llvm::Twine(subRootId)).str();
     ++subRootId;
-    setFusionName(b, subFusionOp, formatFusionName(subFusionName));
+    setFusionName(b, subFusionOp, subFusionName);
     subFusionOp->setAttr(
         kDiscFusionTypeAttrName,
         b.getStringAttr(fusionTypeToString(FusionType::kLoop)));

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -1488,7 +1488,13 @@ Value BaseGpuFusionStrategy::getEffectiveShape(FusionPattern& target, Value v) {
   Operation* result_op = target.findLastWriter(v);
   assert(result_op);
   // effective shape of reduce op is its operand's shape.
-  return isa<lmhlo::ReduceOp>(result_op) ? result_op->getOperand(0) : v;
+  if (isa<lmhlo::ReduceOp>(result_op)) {
+    return result_op->getOperand(0);
+  } else if (isa<lmhlo::DynamicUpdateSliceOp>(result_op) &&
+             isInplaceOperator(result_op)) {
+    return result_op->getOperand(1);
+  }
+  return v;
 }
 
 bool BaseGpuFusionStrategy::tryFuse(ShapeAnalysis& shapeAnalysis,

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -264,6 +264,12 @@ StringRef getFusionName(lmhlo::FusionOp op) {
   return attr.getValue();
 }
 
+StringRef formatFusionName(StringRef name) {
+  std::string formattedName = name.str();
+  std::replace(formattedName.begin(), formattedName.end(), '-', '_');
+  return formattedName;
+}
+
 // Sets the name of the fusion op
 void setFusionName(OpBuilder& b, lmhlo::FusionOp op, StringRef name) {
   op->setAttr(kFusionOpNameAttr, b.getStringAttr(name));
@@ -554,7 +560,8 @@ bool isFusible(Operation* op) {
     lmhlo::ReverseOp,
     lmhlo::SelectOp,
     lmhlo::SliceOp,
-    lmhlo::TransposeOp
+    lmhlo::TransposeOp,
+    lmhlo::DynamicUpdateSliceOp
   >(op);
   // clang-format on
 }
@@ -3244,7 +3251,7 @@ bool StitchCPUAnalysis::emitAllSubRootsAndRootsCalculation(OpBuilder& b,
     auto subFusionName =
         (llvm::Twine(fusionName) + "_" + llvm::Twine(subRootId)).str();
     ++subRootId;
-    setFusionName(b, subFusionOp, subFusionName);
+    setFusionName(b, subFusionOp, formatFusionName(subFusionName));
     subFusionOp->setAttr(
         kDiscFusionTypeAttrName,
         b.getStringAttr(fusionTypeToString(FusionType::kLoop)));

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.cc
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.cc
@@ -262,7 +262,7 @@ FusionType getFusionType(Operation* op) {
 StringRef getFusionName(lmhlo::FusionOp op) {
   auto attr = op->getAttrOfType<StringAttr>(kFusionOpNameAttr);
   if (!attr) return "";
-  return tsl::str_util::StringReplace(attr.getValue().str(), "-", "_", true);
+  return attr.getValue();
 }
 
 // Sets the name of the fusion op

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -432,9 +432,6 @@ StringRef getFusionName(lmhlo::FusionOp op);
 // Sets the name of the fusion op
 void setFusionName(OpBuilder& b, lmhlo::FusionOp op, StringRef name);
 
-// format the fusion name to be valid in MLIR world.
-StringRef formatFusionName(StringRef name);
-
 // Attaches a new tag to the fusion op.
 // Here different tags is mapping to different variants of the fusion op.
 void addFusionTag(OpBuilder& b, lmhlo::FusionOp op, StringRef tag);

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -76,6 +76,8 @@ DenseSet<Operation*> getValueUsersInFusionLike(Value memref, Operation* op);
 
 bool isOnGpu(Operation* op);
 
+bool isInplaceOperator(Operation* op);
+
 // Attributes used to annotate the fusion type, fusion name and tags.
 constexpr const char* kDiscFusionTypeAttrName = "disc.fusion_type";
 constexpr StringRef kFusionOpNameAttr = "disc.fusion.name";

--- a/tao_compiler/mlir/disc/transforms/fusion_utils.h
+++ b/tao_compiler/mlir/disc/transforms/fusion_utils.h
@@ -430,6 +430,9 @@ StringRef getFusionName(lmhlo::FusionOp op);
 // Sets the name of the fusion op
 void setFusionName(OpBuilder& b, lmhlo::FusionOp op, StringRef name);
 
+// format the fusion name to be valid in MLIR world.
+StringRef formatFusionName(StringRef name);
+
 // Attaches a new tag to the fusion op.
 // Here different tags is mapping to different variants of the fusion op.
 void addFusionTag(OpBuilder& b, lmhlo::FusionOp op, StringRef tag);

--- a/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.cc
+++ b/tao_compiler/mlir/disc/transforms/input_inline_fusion_pattern.cc
@@ -288,8 +288,8 @@ LogicalResult InputInlineFusionPattern::inlineFuseLhloOp(
                                 lower_config) ||
       miscFuseHelper<SliceOp>(b, user, producer, load_op, load_ops,
                               lower_config) ||
-      // miscFuseHelper<DynamicUpdateSliceOp>(b, user, producer, load_op,
-      // load_ops, lower_config) ||
+      miscFuseHelper<DynamicUpdateSliceOp>(b, user, producer, load_op, load_ops,
+                                           lower_config) ||
       miscFuseHelper<TransposeOp>(b, user, producer, load_op, load_ops,
                                   lower_config)) {
     return success();

--- a/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
@@ -844,7 +844,7 @@ struct DiscFusionPass : public DiscFusionPassBase<DiscFusionPass> {
         int counter = nameCounter[signature]++;
         name = (func.getName() + "_" + signature + "_" + Twine(counter)).str();
       } while (nameSet.count(name));
-      setFusionName(b, op, formatFusionName(name));
+      setFusionName(b, op, name);
     });
   }
 

--- a/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_fusion.cc
@@ -844,7 +844,7 @@ struct DiscFusionPass : public DiscFusionPassBase<DiscFusionPass> {
         int counter = nameCounter[signature]++;
         name = (func.getName() + "_" + signature + "_" + Twine(counter)).str();
       } while (nameSet.count(name));
-      setFusionName(b, op, name);
+      setFusionName(b, op, formatFusionName(name));
     });
   }
 

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -165,10 +165,7 @@ LogicalResult miscLowerHelper(OpBuilder& b, Location loc, Operation* opaque_op,
 
   SmallVector<SmallVector<Value>> multidim_index_vector(vector_size);
   // for inplace dynamic-update-slice op, output_index according to operand(2)
-  if (isa<lmhlo::DynamicUpdateSliceOp>(op) &&
-      isInplaceOperator(
-          op)) {  // result_memref ==
-                  // cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(0)) {
+  if (isa<lmhlo::DynamicUpdateSliceOp>(op) && isInplaceOperator(op)) {
     memref = cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(1);
   }
   for (int64_t i = 0; i < vector_size; i++) {
@@ -183,8 +180,7 @@ LogicalResult miscLowerHelper(OpBuilder& b, Location loc, Operation* opaque_op,
                                       /*check_cache=*/true, lower_config);
   }
   if (vector_size == 1) {
-    if (result_memref !=
-        cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(0)) {
+    if (!isa<lmhlo::DynamicUpdateSliceOp>(op) && !isInplaceOperator(op)) {
       for (int i = 0; i < vector_size; i++) {
         b.create<memref::StoreOp>(loc, operand_datas[0], result_memref,
                                   multidim_index_vector[0]);

--- a/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tao_compiler/mlir/disc/transforms/lhlo_legalize_roots_to_loops.cc
@@ -164,6 +164,13 @@ LogicalResult miscLowerHelper(OpBuilder& b, Location loc, Operation* opaque_op,
   }
 
   SmallVector<SmallVector<Value>> multidim_index_vector(vector_size);
+  // for inplace dynamic-update-slice op, output_index according to operand(2)
+  if (isa<lmhlo::DynamicUpdateSliceOp>(op) &&
+      isInplaceOperator(
+          op)) {  // result_memref ==
+                  // cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(0)) {
+    memref = cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(1);
+  }
   for (int64_t i = 0; i < vector_size; i++) {
     Value linear_index = linear_indices[i];
     auto multidim_index = calcMultiDimIndex(&b, loc, linear_index, memref);
@@ -176,9 +183,12 @@ LogicalResult miscLowerHelper(OpBuilder& b, Location loc, Operation* opaque_op,
                                       /*check_cache=*/true, lower_config);
   }
   if (vector_size == 1) {
-    for (int i = 0; i < vector_size; i++) {
-      b.create<memref::StoreOp>(loc, operand_datas[i], result_memref,
-                                multidim_index_vector[i]);
+    if (result_memref !=
+        cast<lmhlo::LmhloOp>(&*op).getOperation()->getOperand(0)) {
+      for (int i = 0; i < vector_size; i++) {
+        b.create<memref::StoreOp>(loc, operand_datas[0], result_memref,
+                                  multidim_index_vector[0]);
+      }
     }
     return success();
   }
@@ -4108,11 +4118,8 @@ LogicalResult HandleGpuFusionOp(OpBuilder& b, Operation* fusion,
   if (print_params_enabled) {
     createPrintFusionParams(fusion_op, fusion_pattern);
   }
-
   auto root_ops = fusion_pattern.getRootOps();
   auto fused_block = &(fusion_op.getRegion().front());
-  SmallVector<Operation*, 4> op_list;
-  for (Operation& op : *fused_block) op_list.push_back(&op);
 
   // No need to do codegen, return directly.
   if (root_ops.empty()) {
@@ -5729,8 +5736,6 @@ struct DiscLhloLegalizeRootsToParallelLoops
       // should be sufficient for performance.
       // TODO(disc): Revisit this when the backend is cpu and the calculation is
       // for data.
-      llvm::dbgs() << "cpu-no-fusion-op: \n";
-      op->dump();
       if (failed(lowerWithScheduleLoopCPU({op}, op, nullptr,
                                           /*non_fusion=*/true,
 #ifdef TAO_CPU_ONLY


### PR DESCRIPTION
related tf pr: https://github.com/pai-disc/tensorflow/pull/33

this PR run throught inplace KV cache compilation pipeline in torch_blade inference API, which includes 3 parts:
1. add re-inplace pass on PyTorch IR to re-inplace on mutation node, such as slice->add_ will be transformed into slice->add->slice_scatter.
2. implement `mhlo.dynamic_update_slice` operator code generator with some performance improvement