### PR TITLE
add reduce-buffer-live-range pass to reduce memory peak

### DIFF
--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -2090,6 +2090,25 @@ cc_library(
 )
 
 cc_library(
+    name = "disc_reduce_buffer_live_range",
+    srcs = ["transforms/disc_reduce_buffer_live_range.cc"],
+    deps = [
+        ":lmhlo_disc",
+        ":disc_util",
+        ":pass_details",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:BufferizationTransforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "disc_bf16_expansion",
     srcs = ["transforms/disc_bf16_expansion.cc"],
     deps = [
@@ -2305,6 +2324,7 @@ cc_library(
         ":disc_assign_memory_space",
         ":disc_bf16_expansion",
         ":disc_buffer_deallocation",
+        ":disc_reduce_buffer_live_range",
         ":disc_canonicalizer",
         ":disc_comp_intens_fusion_to_cuda_source",
         ":disc_comp_intens_fusion_to_func",

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -526,9 +526,9 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(createCSEPass());
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
+  pm.addNestedPass<FuncOp>(disc_ral::createDiscReduceBufferLiveRangePass());
   pm.addNestedPass<FuncOp>(bufferization::createBufferDeallocationPass());
   pm.addNestedPass<FuncOp>(disc_ral::createDiscBufferDeallocationPass());
-  pm.addNestedPass<FuncOp>(disc_ral::createDiscReduceBufferLiveRangePass());
 
   pm.addPass(disc_ral::createRalInjectExecutionContextPass());
   pm.addNestedPass<FuncOp>(

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -528,6 +528,7 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   pm.addNestedPass<FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(bufferization::createBufferDeallocationPass());
   pm.addNestedPass<FuncOp>(disc_ral::createDiscBufferDeallocationPass());
+  pm.addNestedPass<FuncOp>(disc_ral::createDiscReduceBufferLiveRangePass());
 
   pm.addPass(disc_ral::createRalInjectExecutionContextPass());
   pm.addNestedPass<FuncOp>(

--- a/tao_compiler/mlir/disc/transforms/disc_passes.td
+++ b/tao_compiler/mlir/disc/transforms/disc_passes.td
@@ -663,3 +663,8 @@ def DiscInputOutputAliasPass : Pass<"disc-input-output-alias", "ModuleOp"> {
   let summary = "Input and output alias information for buffer reuse";
   let constructor = "createDiscInputOutputAliasPass()";
 }
+
+def DiscReduceBufferLiveRangePass : Pass<"disc-reduce-buffer-live-range", "mlir::func::FuncOp"> {
+  let summary = "reduce buffer live range";
+  let constructor = "createDiscReduceBufferLiveRangePass()";
+}

--- a/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
@@ -1,0 +1,79 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "lhlo/IR/lhlo_ops.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Bufferization/Transforms/BufferUtils.h"
+#include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/disc/disc_util.h"
+#include "mlir/disc/transforms/PassDetail.h"
+
+namespace mlir {
+namespace disc_ral {
+
+using lmhlo::FusionOp;
+using memref::AllocOp;
+
+namespace {
+
+Operation* findNearestConsumer(AllocOp allocOp) {
+  auto value = allocOp->getResult(0);
+  for (auto user : value.getUsers()) {
+    if (isa<memref::DeallocOp>(user)) continue;
+    auto resultBuffer = user->getOperands()[user->getOperands().size() - 1];
+    if (resultBuffer == value) {
+      // if parent op is fusion op, return this fusion op
+      if (auto fusion_op = dyn_cast<FusionOp>(user->getParentOp())) {
+        return fusion_op;
+      }
+      return user;
+    }
+  }
+  return nullptr;
+}
+
+struct DiscReduceBufferLiveRangePass
+    : public DiscReduceBufferLiveRangePassBase<DiscReduceBufferLiveRangePass> {
+  void runOnOperation() override {
+    SmallVector<AllocOp, 4> candidateBuffers;
+    func::FuncOp func = getOperation();
+
+    func.walk([&](AllocOp op) { candidateBuffers.push_back(op); });
+
+    for (int i = 0; i < candidateBuffers.size(); ++i) {
+      AllocOp alloc_op = candidateBuffers[i];
+      if (auto consumer = findNearestConsumer(alloc_op)) {
+        alloc_op->moveBefore(consumer);
+      }
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDiscReduceBufferLiveRangePass() {
+  return std::make_unique<DiscReduceBufferLiveRangePass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
@@ -39,10 +39,8 @@ namespace {
 LogicalResult moveBufferAllocator(AllocOp allocOp) {
   Value alloc = allocOp.getResult();
   BufferViewFlowAnalysis aliasAnalysis(allocOp);
-  Liveness livenessAnalysis(allocOp);
   PostDominanceInfo postDominators(allocOp);
   auto aliasesSet = aliasAnalysis.resolve(alloc);
-  assert(!aliasesSet.empty() && "must contain at least one alias");
   // Determine the actual block to place the alloc and get liveness
   // information.
   Block* placementBlock =

--- a/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
@@ -54,7 +54,8 @@ LogicalResult moveBufferAllocator(AllocOp allocOp) {
     if (isa<func::ReturnOp>(user)) continue;
     // Skip if the user is in the same block as the alloc.
     while (isa<scf::IfOp>(user->getParentOp()) ||
-           isa<lmhlo::FusionOp>(user->getParentOp())) {
+           isa<lmhlo::FusionOp>(user->getParentOp()) ||
+           isa<scf::ForOp>(user->getParentOp())) {
       user = user->getParentOp();
     }
     if (toMoveBefore == nullptr || user->isBeforeInBlock(toMoveBefore)) {

--- a/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
@@ -55,7 +55,8 @@ LogicalResult moveBufferAllocator(AllocOp allocOp) {
     // Skip if the user is in the same block as the alloc.
     while (isa<scf::IfOp>(user->getParentOp()) ||
            isa<lmhlo::FusionOp>(user->getParentOp()) ||
-           isa<scf::ForOp>(user->getParentOp())) {
+           isa<scf::ForOp>(user->getParentOp()) ||
+           isa<scf::ParallelOp>(user->getParentOp())) {
       user = user->getParentOp();
     }
     if (toMoveBefore == nullptr || user->isBeforeInBlock(toMoveBefore)) {

--- a/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_reduce_buffer_live_range.cc
@@ -52,11 +52,9 @@ LogicalResult moveBufferAllocator(AllocOp allocOp) {
   Operation* toMoveBefore = nullptr;
   for (auto user : alloc.getUsers()) {
     if (isa<func::ReturnOp>(user)) continue;
-    // Skip if the user is in the same block as the alloc.
-    while (isa<scf::IfOp>(user->getParentOp()) ||
-           isa<lmhlo::FusionOp>(user->getParentOp()) ||
-           isa<scf::ForOp>(user->getParentOp()) ||
-           isa<scf::ParallelOp>(user->getParentOp())) {
+    // user maybe in the sub-block of the placementBlock,
+    // find the closest parent op inside of placementBlock
+    while (user->getBlock() != placementBlock) {
       user = user->getParentOp();
     }
     if (toMoveBefore == nullptr || user->isBeforeInBlock(toMoveBefore)) {

--- a/tao_compiler/mlir/disc/transforms/passes.h
+++ b/tao_compiler/mlir/disc/transforms/passes.h
@@ -328,6 +328,7 @@ createDiscEraseBufferDeallocationPass();
 
 // Insert ArgsMutationOp for buffer reuse
 std::unique_ptr<OperationPass<ModuleOp>> createDiscInputOutputAliasPass();
+std::unique_ptr<OperationPass<ModuleOp>> createDiscReduceBufferLiveRangePass();
 }  // namespace disc_ral
 }  // namespace mlir
 


### PR DESCRIPTION
the reduce-buffer-live-range pass moves the `AllocOp` to the nearest location to the consumer to avoid early allocation to reduce memory peak.
