### PR TITLE
add shape propagate pass on mhlo

### DIFF
--- a/tao_compiler/decoupling/mlir_compiler.cc
+++ b/tao_compiler/decoupling/mlir_compiler.cc
@@ -383,7 +383,7 @@ Status CompilerMLIR::ConvertToMlir(const TaoCompilerInput& input,
     VLOG(2) << "\nMLIR Module (after standard pipeline) END }\n";
   }
 
-  // TF_RETURN_IF_ERROR(::tensorflow::ConvertTF2MlirHlo(*module));
+  TF_RETURN_IF_ERROR(::tensorflow::ConvertTF2MlirHlo(*module));
   if (VLOG_IS_ON(2)) {
     VLOG(0) << "MLIR Module (after tf2xla) BEGIN {\n";
     module->dump();

--- a/tao_compiler/decoupling/mlir_compiler.cc
+++ b/tao_compiler/decoupling/mlir_compiler.cc
@@ -383,7 +383,7 @@ Status CompilerMLIR::ConvertToMlir(const TaoCompilerInput& input,
     VLOG(2) << "\nMLIR Module (after standard pipeline) END }\n";
   }
 
-  TF_RETURN_IF_ERROR(::tensorflow::ConvertTF2MlirHlo(*module));
+  // TF_RETURN_IF_ERROR(::tensorflow::ConvertTF2MlirHlo(*module));
   if (VLOG_IS_ON(2)) {
     VLOG(0) << "MLIR Module (after tf2xla) BEGIN {\n";
     module->dump();

--- a/tao_compiler/mlir/disc/BUILD
+++ b/tao_compiler/mlir/disc/BUILD
@@ -1666,6 +1666,29 @@ cc_library(
 )
 
 cc_library(
+    name = "disc_shape_propagate",
+    srcs = ["transforms/disc_shape_propagate.cc"],
+    hdrs = [
+    ],
+    deps = [
+        ":mhlo_disc",
+        ":pass_details",
+        ":shape_utils",
+        "@org_tensorflow//tensorflow/compiler/xla/mlir_hlo:mlir_hlo",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "disc_dot_merge",
     srcs = ["transforms/disc_dot_merge.cc"],
     hdrs = [
@@ -2471,6 +2494,7 @@ cc_library(
         ":disc_remove_shape_constraints",
         ":disc_shape_optimization",
         ":disc_shape_simplifier",
+        "disc_shape_propagate",
         ":disc_shape_to_std",
         ":disc_sparse_op_rewriter",
         ":disc_specialize_fusion_with_speculation",

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -244,6 +244,7 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
 
   pm.addNestedPass<FuncOp>(disc_ral::createDiscAlgebraicSimplifierPass());
   pm.addPass(disc_ral::createDiscInputOutputAliasPass());
+  pm.addPass(disc_ral::createDiscShapePropagatePass());
   pm.addPass(mlir::createInlinerPass());
   // TODO(disc): Lower HLO shape constraints instead of eliding them here.
   pm.addNestedPass<FuncOp>(disc_ral::createDiscCollectiveOpsRewriterPass());

--- a/tao_compiler/mlir/disc/disc_compiler.cc
+++ b/tao_compiler/mlir/disc/disc_compiler.cc
@@ -235,7 +235,8 @@ LogicalResult LowerHLOToLLVM(ModuleOp m, const DISCLoweringOptions& options) {
   auto printingFlags = OpPrintingFlags();
   printingFlags.elideLargeElementsAttrs(16);
   pm.enableIRPrinting(
-      /*shouldPrintBeforePass=*/nullptr,
+      /*shouldPrintBeforePass=*/
+      nullptr,
       /*shouldPrintAfterPass=*/
       [](Pass* pass, Operation*) { return VLOG_IS_ON(1); },
       /*printModuleScope=*/false,
@@ -1016,7 +1017,8 @@ Status ConvertTF2MlirHlo(mlir::ModuleOp module_op) {
   auto printingFlags = mlir::OpPrintingFlags();
   printingFlags.elideLargeElementsAttrs(16);
   pm.enableIRPrinting(
-      /*shouldPrintBeforePass=*/nullptr,
+      /*shouldPrintBeforePass=*/
+      nullptr,
       /*shouldPrintAfterPass=*/
       [](mlir::Pass* pass, mlir::Operation*) { return VLOG_IS_ON(1); },
       /*printModuleScope=*/false,

--- a/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
+++ b/tao_compiler/mlir/disc/tools/disc-opt/disc-opt.cc
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
   mlir::disc_ral::registerTransformDialectCommonExtension(registry);
+  registry.insert<mlir::shape::ShapeDialect>();
   registry.insert<mlir::mhlo::MhloDialect>();
   registry.insert<mlir::mhlo_disc::MhloDiscDialect>();
   registry.insert<mlir::chlo::ChloDialect>();

--- a/tao_compiler/mlir/disc/transforms/disc_passes.td
+++ b/tao_compiler/mlir/disc/transforms/disc_passes.td
@@ -673,3 +673,8 @@ def DiscReduceBufferLiveRangePass : Pass<"disc-reduce-buffer-live-range", "mlir:
   let summary = "reduce buffer live range";
   let constructor = "createDiscReduceBufferLiveRangePass()";
 }
+
+def DiscShapePropagatePass : Pass<"disc-shape-propagate", "ModuleOp"> {
+  let summary = "shape analysis pass";
+  let constructor = "createDiscShapePropagatePass()";
+}

--- a/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
@@ -1,0 +1,248 @@
+/* Copyright 2022 The BladeDISC Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements the logic to do some shape optimizations on tensor
+// level.
+#include <chrono>
+#include <unordered_set>
+#include <utility>
+
+#include "absl/strings/str_split.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+#include "mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"  // TF:llvm-project
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Pass/Pass.h"  // TF:local_config_mlir
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/Passes.h"  // TF:llvm-project
+#include "mlir/disc/IR/disc_shape_ops.h"
+#include "mlir/disc/IR/hlo_disc_ops.h"
+#include "mlir/disc/disc_util.h"
+#include "mlir/disc/transforms/PassDetail.h"
+#include "mlir/disc/transforms/shape_utils.h"
+
+namespace mlir {
+namespace disc_ral {
+
+using ::mlir::func::FuncOp;
+
+namespace {
+struct DiscShapePropagatePass
+    : public DiscShapePropagatePassBase<DiscShapePropagatePass> {
+  DiscShapePropagatePass()
+      : DiscShapePropagatePassBase<
+            DiscShapePropagatePass>::DiscShapePropagatePassBase() {}
+
+  void runOnOperation() override;
+};
+
+std::optional<Value> getConstTensor(OpBuilder& b, Operation* op,
+                                    ArrayRef<int> vec,
+                                    ArrayRef<int64_t> shape) {
+  uint64_t num_total_elements = 1;
+  for (int64_t a : shape) {
+    num_total_elements *= a;
+  }
+
+  if (vec.size() != num_total_elements) {
+    op->emitOpError("getConstTensor(): number of elements mismatch.");
+    return std::nullopt;
+  }
+
+  auto const_type = RankedTensorType::get(shape, b.getI64Type());
+  auto const_attr = DenseElementsAttr::get(const_type, vec);
+
+  auto const_op =
+      b.create<mhlo::ConstantOp>(op->getLoc(), const_type, const_attr);
+  return const_op.getResult();
+}
+
+LogicalResult HandleBinaryOp(OpBuilder& b, Operation* op) {
+  // set result type same as input type
+  auto shape = op->getOperand(0).getType().cast<RankedTensorType>().getShape();
+  auto elemTy =
+      op->getOperand(0).getType().cast<RankedTensorType>().getElementType();
+  auto resultElemTy =
+      op->getResult(0).getType().cast<RankedTensorType>().getElementType();
+  op->getResult(0).setType(RankedTensorType::get(shape, resultElemTy));
+  if (auto const_op =
+          dyn_cast<mhlo::ConstantOp>(op->getOperand(1).getDefiningOp())) {
+    b.setInsertionPoint(op);
+    auto dense_attr = const_op.getValue().dyn_cast<mlir::DenseElementsAttr>();
+
+    int64_t value = (*dense_attr.getValues<APInt>().begin()).getSExtValue();
+    auto scalar_const_op = getConstTensor(b, op, {value}, {});
+    Value inputShape =
+        b.create<shape::ShapeOfOp>(op->getLoc(), op->getOperand(0));
+    auto rank = shape.size();
+    SmallVector<int64_t> boradcast_dim;
+    boradcast_dim.push_back(static_cast<int64_t>(rank));
+
+    auto bcast_op = b.create<mhlo::DynamicBroadcastInDimOp>(
+        op->getLoc(), RankedTensorType::get(shape, elemTy),
+        scalar_const_op.value(), inputShape, b.getI64TensorAttr({}));
+    const_op.getResult().replaceAllUsesWith(bcast_op.getResult());
+    const_op.erase();
+  }
+  return success();
+}
+
+LogicalResult HandleUnaryOp(OpBuilder& b, Operation* op) {
+  int n = op->getOperands().size();
+  // set result type same as input type
+  auto shape = op->getOperand(0).getType().cast<RankedTensorType>().getShape();
+  auto elemTy =
+      op->getOperand(0).getType().cast<RankedTensorType>().getElementType();
+  auto resultElemTy =
+      op->getResult(0).getType().cast<RankedTensorType>().getElementType();
+  op->getResult(0).setType(RankedTensorType::get(shape, resultElemTy));
+  return success();
+}
+LogicalResult HandleDot(OpBuilder& b, Operation* op) {
+  if (!isa<mhlo::DotOp>(op)) return success();
+  auto dot_op = cast<mhlo::DotOp>(op);
+  auto lhs_shape =
+      dot_op.getOperand(0).getType().cast<RankedTensorType>().getShape();
+  auto rhs_shape =
+      dot_op.getOperand(1).getType().cast<RankedTensorType>().getShape();
+  auto result_shape =
+      dot_op.getResult().getType().cast<RankedTensorType>().getShape();
+  SmallVector<int64_t, 4> new_shape;
+  new_shape.push_back(lhs_shape[0]);
+  new_shape.push_back(rhs_shape[1]);
+  dot_op.getResult().setType(RankedTensorType::get(
+      new_shape,
+      dot_op.getResult().getType().cast<RankedTensorType>().getElementType()));
+  return success();
+}
+
+bool isUnaryOp(Operation* op) {
+  return isa<mhlo::AddOp>(*op) || isa<mhlo::CompareOp>(*op) ||
+         isa<mhlo::SelectOp>(*op) || isa<mhlo::ConvertOp>(*op);
+}
+
+bool isBinaryOp(Operation* op) { return isa<mhlo::ConvertOp>(op); }
+
+LogicalResult eraseInputTensorShapesFromAttr(
+    FuncOp& main, StringRef input_dynamic_dims_attr,
+    SmallVector<Type, 4>& new_arg_types) {
+  SmallVector<StringRef, 4> parsed_dynamic_dims;
+  input_dynamic_dims_attr.split(parsed_dynamic_dims, "|");
+  for (auto kv : parsed_dynamic_dims) {
+    SmallVector<StringRef, 4> pair;
+    kv.split(pair, ":");
+    if (pair.size() != 2) {
+      main.emitError("input_dynamic_dims format error");
+      return failure();
+    }
+    int arg_index = std::stoi(pair[0].str());
+    auto arg = main.getArgument(arg_index);
+
+    auto arg_ty = new_arg_types[arg_index].dyn_cast<RankedTensorType>();
+    if (!arg_ty) {
+      main.emitError("input tensor type not found");
+      return failure();
+    }
+    auto shape = arg_ty.getShape();
+    SmallVector<int64_t, 4> new_shape(shape.begin(), shape.end());
+    SmallVector<StringRef, 4> dims;
+    pair[1].split(dims, ",");
+    for (auto dim : dims) {
+      new_shape[std::stoi(dim.str())] = ShapedType::kDynamic;
+    }
+    auto new_ty = RankedTensorType::get(new_shape, arg_ty.getElementType());
+    arg.setType(new_ty);
+    new_arg_types[arg_index] = new_ty;
+    main.getArgument(arg_index).setType(new_ty);
+  }
+  return success();
+}
+void DiscShapePropagatePass::runOnOperation() {
+  ModuleOp m = getOperation();
+  FuncOp main = m.lookupSymbol<FuncOp>("main");
+  MLIRContext* context = &getContext();
+  mlir::OpBuilder rewriter(context);
+  OpBuilder b(main);
+  if (!main) {
+    m.emitError("entry func: main not found");
+    signalPassFailure();
+    return;
+  }
+
+  // stage1: fixup input tensor shapes accroding to attr
+  auto dict_attr = main->getAttrOfType<DictionaryAttr>("tf.entry_function");
+  if (!dict_attr) {
+    signalPassFailure();
+    return;
+  }
+  auto param_str =
+      dict_attr.get("input_dynamic_dims").dyn_cast<mlir::StringAttr>();
+  if (param_str.getValue().empty()) {
+    return;
+  }
+  SmallVector<Type, 4> new_arg_types;
+  for (auto arg : main.getArguments()) {
+    new_arg_types.push_back(arg.getType());
+  }
+  if (failed(eraseInputTensorShapesFromAttr(main, param_str, new_arg_types))) {
+    m.emitError("failed erase input tensor shapes from attr");
+    signalPassFailure();
+    return;
+  }
+
+  // stage2: propagate tensor shapes or rewrite graph with dynamic operator
+  SmallVector<Type, 4> new_return_types;
+  main.walk([&](Operation* op) {
+    if (isUnaryOp(op)) {
+      if (failed(HandleUnaryOp(rewriter, op))) {
+        m.emitError("failed handle unary op: ");
+        signalPassFailure();
+        return;
+      }
+    }
+    if (failed(HandleDot(rewriter, op))) {
+      m.emitError("failed handle dot op: ");
+      signalPassFailure();
+      return;
+    }
+    if (isa<func::ReturnOp>(*op)) {
+      for (auto operand : op->getOperands()) {
+        new_return_types.push_back(operand.getType());
+      }
+    }
+  });
+  // stage3: update function signature
+  main.setType(
+      FunctionType::get(main.getContext(), new_arg_types, new_return_types));
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createDiscShapePropagatePass() {
+  return std::make_unique<DiscShapePropagatePass>();
+}
+
+}  // namespace disc_ral
+}  // namespace mlir

--- a/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
@@ -98,6 +98,7 @@ std::optional<Value> getConstTensor(OpBuilder& b, Operation* op,
 
 std::optional<ShapeContext> HandleBinaryOp(OpBuilder& b, Operation* op,
                                            ShapeContext& inputCtx) {
+  if (!isBinaryOp(op)) return std::nullopt;
   if (op->getOperand(1).isa<BlockArgument>()) {
     return ShapeContext(op->getResult(0), inputCtx.shape);
   }
@@ -125,6 +126,26 @@ std::optional<ShapeContext> HandleBinaryOp(OpBuilder& b, Operation* op,
 }
 
 std::optional<ShapeContext> HandleDot(OpBuilder& b, Operation* op) {
+  auto dot_op = cast<mhlo::DotOp>(op);
+  auto lhs_shape =
+      dot_op.getOperand(0).getType().cast<RankedTensorType>().getShape();
+  auto rhs_shape =
+      dot_op.getOperand(1).getType().cast<RankedTensorType>().getShape();
+  auto result_shape =
+      dot_op.getResult().getType().cast<RankedTensorType>().getShape();
+  SmallVector<int64_t> new_shape;
+  new_shape.push_back(lhs_shape[0]);
+  new_shape.push_back(rhs_shape[1]);
+  return ShapeContext(op->getResult(0), new_shape);
+}
+template <typename OpTy>
+std::optional<ShapeContext> propagateHelper(OpBuilder& b, Operation* op,
+                                            ShapeContext& inputCtx) {
+  return std::nullopt;
+}
+template <>
+std::optional<ShapeContext> propagateHelper<mhlo::DotOp>(
+    OpBuilder& b, Operation* op, ShapeContext& inputCtx) {
   auto dot_op = cast<mhlo::DotOp>(op);
   auto lhs_shape =
       dot_op.getOperand(0).getType().cast<RankedTensorType>().getShape();
@@ -180,11 +201,22 @@ void applyShapeContext(ShapeContext& ctx) {
 
 std::optional<ShapeContext> propagateOpShape(OpBuilder& rewriter, Operation* op,
                                              ShapeContext& inputCtx) {
-  if (isBinaryOp(op)) {
-    return HandleBinaryOp(rewriter, op, inputCtx);
-  }
   if (isUnaryOp(op)) {
     return ShapeContext(op->getResult(0), inputCtx.shape);
+  }
+  if (auto ctx = HandleBinaryOp(rewriter, op, inputCtx)) {
+    return ctx;
+  }
+  using PropagationFunc =
+      std::optional<ShapeContext> (*)(OpBuilder&, Operation*, ShapeContext&);
+  const std::vector<PropagationFunc> propagationFunctions = {
+      propagateHelper<mhlo::DotOp>,
+  };
+  // Iterate over the propagation functions and apply each one
+  for (const auto& propagate : propagationFunctions) {
+    if (auto ctx = propagate(rewriter, op, inputCtx)) {
+      return ctx;
+    }
   }
   return std::nullopt;
 }

--- a/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
+++ b/tao_compiler/mlir/disc/transforms/disc_shape_propagate.cc
@@ -184,13 +184,7 @@ std::optional<ShapeContext> propagateOpShape(OpBuilder& rewriter, Operation* op,
     return HandleBinaryOp(rewriter, op, inputCtx);
   }
   if (isUnaryOp(op)) {
-    auto shape = inputCtx.shape;
-    auto elemTy =
-        op->getOperand(0).getType().cast<RankedTensorType>().getElementType();
-    auto resultElemTy =
-        op->getResult(0).getType().cast<RankedTensorType>().getElementType();
-    mlir::Value result = op->getResult(0);
-    return ShapeContext(op->getResult(0), shape);
+    return ShapeContext(op->getResult(0), inputCtx.shape);
   }
   return std::nullopt;
 }

--- a/tao_compiler/mlir/disc/transforms/passes.h
+++ b/tao_compiler/mlir/disc/transforms/passes.h
@@ -191,6 +191,8 @@ createDiscUnhandledAtomicRMWConverterPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDiscShapeSimplifierPass(
     const std::string& entry_func_name = "main", bool insert_tie_shape = false);
 
+std::unique_ptr<OperationPass<ModuleOp>> createDiscShapePropagatePass();
+
 // Using approximation impl for some special math ops.
 std::unique_ptr<OperationPass<FuncOp>> createDiscMathApproximationPass();
 

--- a/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
@@ -1,0 +1,20 @@
+// RUN: disc-opt -split-input-file %s -disc-shape-propagate | FileCheck %s
+// CHECK-LABEL: main
+func.func @main(%arg0: tensor<4x101xi64>, %arg1: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1|1:1"}}{
+  // CHECK: mhlo.compare  LT, %arg0, %arg1 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
+  %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<4x101xi64>, tensor<4x101xi64>) -> tensor<4x101xi1>
+  // CHECK: return %0 : tensor<4x?xi1>
+  return %0 : tensor<4x101xi1>
+}
+
+// -----
+
+func.func @compare(%arg0: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1"}}{
+  // CHECK: %1 = mhlo.constant dense<0> : tensor<i64>
+  // CHECK: %2 = shape.shape_of %arg0 : tensor<4x?xi64> -> tensor<2xindex>
+  // CHECK: %3 = "mhlo.dynamic_broadcast_in_dim"(%1, %2) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i64>, tensor<2xindex>) -> tensor<4x?xi64>
+  // CHECK: %4 = mhlo.compare  LT, %arg0, %3 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
+  %0 = mhlo.constant dense<0> : tensor<4x101xi64> 
+  %1 = "mhlo.compare"(%arg0, %0) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<4x101xi64>, tensor<4x101xi64>) -> tensor<4x101xi1>
+  return %1 : tensor<4x101xi1>
+}

--- a/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
@@ -11,11 +11,9 @@ func.func @main(%arg0: tensor<4x101xi64>, %arg1: tensor<4x101xi64>) -> tensor<4x
 // -----
 // CHECK-LABEL: main
 func.func @main(%arg0: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1"}}{
-  // CHECK: %0 = mhlo.constant dense<0> : tensor<i64>
   // CHECK: %1 = shape.shape_of %arg0 : tensor<4x?xi64> -> tensor<2xindex>
   // CHECK: %2 = "mhlo.dynamic_broadcast_in_dim"(%0, %1) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i64>, tensor<2xindex>) -> tensor<4x?xi64>
-  // CHECK: %3 = mhlo.compare  LT, %arg0, %2 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
-  %0 = mhlo.constant dense<0> : tensor<4x101xi64> 
+  %0 = mhlo.constant dense<0> : tensor<4x101xi64>
   %1 = "mhlo.compare"(%arg0, %0) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<4x101xi64>, tensor<4x101xi64>) -> tensor<4x101xi1>
   return %1 : tensor<4x101xi1>
 }

--- a/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
+++ b/tao_compiler/mlir/disc/transforms/tests/disc-shape-propagate.mlir
@@ -1,19 +1,20 @@
-// RUN: disc-opt -split-input-file %s -disc-shape-propagate | FileCheck %s
+// RUN: disc-opt -split-input-file --disc-shape-propagate %s | FileCheck %s
+
 // CHECK-LABEL: main
 func.func @main(%arg0: tensor<4x101xi64>, %arg1: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1|1:1"}}{
-  // CHECK: mhlo.compare  LT, %arg0, %arg1 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
+  // CHECK: %0 = mhlo.compare  LT, %arg0, %arg1 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
   %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<4x101xi64>, tensor<4x101xi64>) -> tensor<4x101xi1>
   // CHECK: return %0 : tensor<4x?xi1>
   return %0 : tensor<4x101xi1>
 }
 
 // -----
-
-func.func @compare(%arg0: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1"}}{
-  // CHECK: %1 = mhlo.constant dense<0> : tensor<i64>
-  // CHECK: %2 = shape.shape_of %arg0 : tensor<4x?xi64> -> tensor<2xindex>
-  // CHECK: %3 = "mhlo.dynamic_broadcast_in_dim"(%1, %2) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i64>, tensor<2xindex>) -> tensor<4x?xi64>
-  // CHECK: %4 = mhlo.compare  LT, %arg0, %3 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
+// CHECK-LABEL: main
+func.func @main(%arg0: tensor<4x101xi64>) -> tensor<4x101xi1> attributes{tf.entry_function = {input_dynamic_dims = "0:1"}}{
+  // CHECK: %0 = mhlo.constant dense<0> : tensor<i64>
+  // CHECK: %1 = shape.shape_of %arg0 : tensor<4x?xi64> -> tensor<2xindex>
+  // CHECK: %2 = "mhlo.dynamic_broadcast_in_dim"(%0, %1) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i64>, tensor<2xindex>) -> tensor<4x?xi64>
+  // CHECK: %3 = mhlo.compare  LT, %arg0, %2 : (tensor<4x?xi64>, tensor<4x?xi64>) -> tensor<4x?xi1>
   %0 = mhlo.constant dense<0> : tensor<4x101xi64> 
   %1 = "mhlo.compare"(%arg0, %0) {comparison_direction = #mhlo<comparison_direction LT>} : (tensor<4x101xi64>, tensor<4x101xi64>) -> tensor<4x101xi1>
   return %1 : tensor<4x101xi1>


### PR DESCRIPTION
```python
import torch
import torch.nn as nn
import unittest
import torch_xla.core.xla_model as xm
import torch.nn.functional as F

torch.manual_seed(1001)
xla_device = xm.xla_device()
#xla_device = "cuda"
dtype = torch.float16

class TestMLP(nn.Module):
  def __init__(self):
    super(TestMLP, self).__init__()
    self.fc = nn.Linear(1024, 4096, bias=False)

  def forward(self, x):
    return self.fc(x)

class TestDynamicShape(unittest.TestCase):
  def test_embeded(self):
    device = xla_device

    m = TestMLP().to(device)
    m.train()
    with torch.cuda.amp.autocast(dtype=torch.bfloat16):
      for i in range(10):
        xla_tensor = torch.rand(i+1, 1024, requires_grad=False)
        xla_tensor = xla_tensor.to(device)

        xla_output = m(xla_tensor)
        loss = xla_output.sum()
        loss.backward()
        xm.mark_step()
        print(f"iteration :{i}, loss: {loss.clone().detach()}")
if __name__ == '__main__':
  unittest.main()
```

I got the same loss value with the CUDA device using the above simple MLP module. 
